### PR TITLE
Fix #1459: venue panel distinct authors

### DIFF
--- a/scholia/app/templates/venue_recently-published-works.sparql
+++ b/scholia/app/templates/venue_recently-published-works.sparql
@@ -1,9 +1,9 @@
-# title: Recent works published in venue
+#title: Recent works published in venue
 SELECT
   (MIN(?publication_date_) AS ?publication_date)
   ?work ?workLabel
-  (GROUP_CONCAT(?author_label; separator=", ") AS ?authors)
-  (CONCAT("../authors/", GROUP_CONCAT(SUBSTR(STR(?author), 32); separator=",")) AS ?authorsUrl)
+  (GROUP_CONCAT(DISTINCT ?author_label; separator=", ") AS ?authors)
+  (CONCAT("../authors/", GROUP_CONCAT(DISTINCT SUBSTR(STR(?author), 32); separator=",")) AS ?authorsUrl)
 WHERE {
   ?work wdt:P1433 wd:{{ q }} .
   OPTIONAL {


### PR DESCRIPTION
When publications had multiple publication dates an author would
appear multiple times in the "recently published works" panel in the
venue aspect. With a distinct an author now only is listed a single time.

This might cause confusion if there are multiple different authors with the
same name. Alternatively the SPARQL should be further refined.