### PR TITLE
Simplify running Scholia locally

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,6 +5,21 @@
 
 Scholia is a python package and webapp for interaction with scholarly information in Wikidata_.
 
+Installation
+------------
+Scholia can be installed directly from GitHub with:
+
+.. code-block:: shell
+
+    $ python3 -m pip install git+https://github.com/WDscholia/scholia
+
+It can be installed in development mode with:
+
+.. code-block:: shell
+
+    $ git clone https://github.com/WDscholia/scholia
+    $ cd scholia
+    $ pip install --editable .
 
 Webapp
 ------

--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,11 @@ The webapp displays scholarly profiles for individual researchers, research topi
     
 The information displayed on the page is only what is available in Wikidata.
 
+Run locally after installing with ``pip``:
+
+.. code-block:: sh
+
+    $ scholia run
 
 Script
 ------

--- a/scholia/__main__.py
+++ b/scholia/__main__.py
@@ -4,6 +4,7 @@ Usage:
   scholia arxiv-to-quickstatements [options] <arxiv>
   scholia orcid-to-q <orcid>
   scholia string-to-type <string>
+  scholia run
 
 Options:
   -o --output=file  Output filename, default output to stdout
@@ -59,6 +60,15 @@ def main():
     elif arguments['string-to-type']:
         type = string_to_type(arguments['<string>'])
         print(type)
+
+    elif arguments['run']:
+        from .app import create_app
+        app = create_app(
+            text_to_topic_q_text_enabled=False,
+            third_parties_enabled=True,
+        )
+        app.config['APPLICATION_ROOT'] = '/'
+        app.run(debug=True, port=8100)
 
 
 if __name__ == '__main__':

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,3 +11,6 @@ versionfile_build = scholia/_version.py
 tag_prefix = v
 parentdir_prefix = scholia-
 
+[options.entry_points]
+console_scripts =
+    scholia = scholia.__main__:main


### PR DESCRIPTION
This PR does the following to make it easier to develop Scholia locally:

1. Adds documentation in the README on how to install Scholia locally
2. Adds an entrypoint in the setup.py file so you can run `scholia` from the shell instead of `python -m scholia`
3. Adds a `run` command to the CLI that mimics `runserver.py`