### PR TITLE
Fix #1473: missing distinct in citation

### DIFF
--- a/scholia/app/templates/work_cited-works.sparql
+++ b/scholia/app/templates/work_cited-works.sparql
@@ -2,7 +2,7 @@
 # List of works that is cited by the specified work
 SELECT ?citations ?publication_date ?cited_work ?cited_workLabel 
 WITH {
-  SELECT (MIN(?date) AS ?publication_date) (COUNT(?citing_cited_work) AS ?citations) ?cited_work 
+  SELECT (MIN(?date) AS ?publication_date) (COUNT(DISTINCT ?citing_cited_work) AS ?citations) ?cited_work 
   WHERE {
     wd:{{ q }} wdt:P2860 ?cited_work . 
     OPTIONAL {


### PR DESCRIPTION
Count for cited works in work aspect counted double (or more)
if the work had multiple publication dates