### PR TITLE
Add Bioschemas by proxying Wikidata content (making Google bots happy)

### DIFF
--- a/scholia/app/templates/base.html
+++ b/scholia/app/templates/base.html
@@ -87,6 +87,11 @@ sparqlToShortInchiKey(`# tool: scholia
 
 <script type="text/javascript">
     {% if q %}
+    if ( $( "#bioschemas" ).length ) {
+      var bioschemasurl = "{{ url_for('app.index') }}{{ q }}/bioschemas";
+      $.get(bioschemasurl, function(data) { $( '#bioschemas' ).append( data) } )
+    }
+
     var url = 'https://www.wikidata.org/w/api.php?action=wbgetentities&ids=' +
 	       '{{ q }}' + 
 	       '&format=json&callback=?';
@@ -178,137 +183,6 @@ sparqlToShortInchiKey(`# tool: scholia
 	     $( '#details' ).append( detailsList.join( " | " ) );
 	 }
 	 catch(e) {}
-	 
-	 /* BioSchemas annotation */
-	 if (item.claims.P31 &&
-	     ((item.claims.P31[0].mainsnak.datavalue.value.id == 'Q5'))) {
-	   try { /* Person */
-	       bioschemasAnnotation = {
-	          "@context" : "https://schema.org",
-	          "@type" : "Person" ,
-	          "http://purl.org/dc/terms/conformsTo": { "@type": "CreativeWork", "@id": "https://bioschemas.org/profiles/Person/0.2-DRAFT-2019_07_19/" },
-	          "description" : "A person" ,
-	          "identifier" : "{{ q }}" ,
-	          "mainEntityOfPage" : "http://www.wikidata.org/entity/{{ q }}"
-	       }
-	       if ('en' in item.labels) {
-	         bioschemasAnnotation.name = item.labels.en.value;
-	       }
-	       $( '#bioschemas' ).append( JSON.stringify(bioschemasAnnotation) );
-	    } catch(e) {}
-	 } else if (item.claims.P31 &&
-	     ((item.claims.P31[0].mainsnak.datavalue.value.id == 'Q47461491') ||
-	      (item.claims.P31[0].mainsnak.datavalue.value.id == 'Q967847'))) {
-	   try { /* ChemicalSubstance */
-	       bioschemasAnnotation = {
-	          "@context" : "https://schema.org",
-	          "@type" : "ChemicalSubstance" ,
-	          "http://purl.org/dc/terms/conformsTo": { "@type": "CreativeWork", "@id": "https://bioschemas.org/profiles/ChemicalSubstance/0.4-RELEASE/" },
-	          "identifier" : "{{ q }}" ,
-	          "url" : "http://www.wikidata.org/entity/{{ q }}"
-	       }
-	       if ('en' in item.labels) {
-	         bioschemasAnnotation.name = item.labels.en.value;
-	       }
-	       $( '#bioschemas' ).append( JSON.stringify(bioschemasAnnotation) );
-	    } catch(e) {}
-	 } else if (item.claims.P225) {
-             try { /* Taxon */
-		 var taxonName = item.claims.P225[0].mainsnak.datavalue.value;
-		 bioschemasAnnotation = {
-	             "@context" : "https://schema.org",
-	             "@type" : "Taxon" ,
-	             "http://purl.org/dc/terms/conformsTo": { "@type": "CreativeWork", "@id": "https://bioschemas.org/profiles/Taxon/0.6-RELEASE/" },
-	             "name" : taxonName ,
-	             "url" : "http://www.wikidata.org/entity/{{ q }}"
-		 }
-		 if (item.claims.P105) {
-	             var taxonRank = item.claims.P105[0].mainsnak.datavalue.value.id;
-	             bioschemasAnnotation.taxonRank = "http://www.wikidata.org/entity/" + taxonRank ;
-		 }
-		 if (item.claims.P171) {
-	             var parent = item.claims.P171[0].mainsnak.datavalue.value.id;
-	             bioschemasAnnotation.parentTaxon = "http://www.wikidata.org/entity/" + parent ;
-		 }
-		 $( '#bioschemas' ).append( JSON.stringify(bioschemasAnnotation) );
-		 // console.log(JSON.stringify(bioschemasAnnotation, "", 2))
-	     } catch(e) {}
-	 } else if (item.claims.P235) {
-	     try { /* Chemical Compound */
-		 var inchiKey = item.claims.P235[0].mainsnak.datavalue.value;
-		 bioschemasAnnotation = {
-	             "@context" : "https://schema.org",
-	             "@type" : "MolecularEntity" ,
-	             "http://purl.org/dc/terms/conformsTo": { "@type": "CreativeWork", "@id": "https://bioschemas.org/profiles/MolecularEntity/0.5-RELEASE/" },
-	             "identifier" : "{{ q }}" ,
-	             "inChIKey" : inchiKey ,
-	             "url" : "http://www.wikidata.org/entity/{{ q }}"
-		 }
-		 if ('en' in item.labels) {
-	         bioschemasAnnotation.name = item.labels.en.value;
-         }
-		 if (item.claims.P234 && item.claims.P234[0].mainsnak.datavalue) {
-	             var inchi = item.claims.P234[0].mainsnak.datavalue.value;
-	             bioschemasAnnotation.inChI = inchi ;
-		 }
-		 if (item.claims.P274 && item.claims.P274[0].mainsnak.datavalue) {
-	             var chemformula = item.claims.P274[0].mainsnak.datavalue.value;
-	             bioschemasAnnotation.molecularFormula = chemformula ;
-		 }
-		 if (item.claims.P2017 && item.claims.P2017[0].mainsnak.datavalue) {
-	             var smiles = item.claims.P2017[0].mainsnak.datavalue.value;
-	             bioschemasAnnotation.molecularFormula = smiles.replace("\"", "\'\'") ;
-		 } else if (item.claims.P233 && item.claims.P233[0].mainsnak.datavalue) {
-	             var smiles = item.claims.P233[0].mainsnak.datavalue.value;
-	             bioschemasAnnotation.smiles = smiles.replace("\"", "\'\'") ;
-		 }
-		 $( '#bioschemas' ).append( JSON.stringify(bioschemasAnnotation) );
-	     } catch(e) { console.log("Exception: " + e)
-	     }
-	 } else if (item.claims.P352) { // UniProt ID
-	     try { /* Protein */
-		 var uniprot = item.claims.P352[0].mainsnak.datavalue.value;
-		 bioschemasAnnotation = {
-	             "@context" : "https://schema.org",
-	             "@type" : "Protein" ,
-	             "http://purl.org/dc/terms/conformsTo": { "@type": "CreativeWork", "@id": "https://bioschemas.org/profiles/Protein/0.11-RELEASE/" },
-	             "identifier" : "{{ q }}" ,
-	             "url" : "http://www.wikidata.org/entity/{{ q }}" ,
-	             "sameAs": "https://www.uniprot.org/uniprot/" + uniprot
-		 }
-		 if ('en' in item.labels) {
-	       bioschemasAnnotation.name = item.labels.en.value;
-         }
-		 $( '#bioschemas' ).append( JSON.stringify(bioschemasAnnotation) );
-	     } catch(e) { console.log("Exception: " + e)
-	     }
-	 } else if (item.claims.P351 || item.claims.P594) { // NCBI Gene or Ensembl
-	     try { /* Gene */
-		 bioschemasAnnotation = {
-	             "@context" : "https://schema.org",
-	             "@type" : "Gene" ,
-	             "http://purl.org/dc/terms/conformsTo": { "@type": "CreativeWork", "@id": "https://bioschemas.org/profiles/Gene/0.7-RELEASE/" },
-	             "identifier" : "{{ q }}" ,
-	             "url" : "http://www.wikidata.org/entity/{{ q }}"
-		 }
-		 if ('en' in item.labels) {
-	       bioschemasAnnotation.name = item.labels.en.value;
-         }
-		 counter = 0
-		 bioschemasAnnotation.sameAs = []
-		 if (item.claims.P351 && item.claims.P351[0].mainsnak.datavalue) {
-	             var ncbi = item.claims.P351[0].mainsnak.datavalue.value;
-	             bioschemasAnnotation.sameAs[counter] = "https://www.ncbi.nlm.nih.gov/gene/" + ncbi;
-	             counter++
-		 }
-		 if (item.claims.P594 && item.claims.P594[0].mainsnak.datavalue) {
-	             var ensembl = item.claims.P594[0].mainsnak.datavalue.value;
-	             bioschemasAnnotation.sameAs[counter] = "http://identifiers.org/ensembl/" + ensembl;
-		 }
-		 $( '#bioschemas' ).append( JSON.stringify(bioschemasAnnotation) );
-	     } catch(e) { console.log("Exception: " + e)
-	     }
-	 }
 	 
 	 /* English Wikipedia */
 	 if ('enwiki' in item.sitelinks) {

--- a/scholia/app/templates/base.html
+++ b/scholia/app/templates/base.html
@@ -88,8 +88,10 @@ sparqlToShortInchiKey(`# tool: scholia
 <script type="text/javascript">
     {% if q %}
     if ( $( "#bioschemas" ).length ) {
-      var bioschemasurl = "{{ url_for('app.index') }}{{ q }}/bioschemas";
-      $.get(bioschemasurl, function(data) { $( '#bioschemas' ).append( data) } )
+      var bioschemasurl = "{{ url_for('app.bioschemas_for', q=q) }}";
+      $.get(bioschemasurl, function(data) {
+          $( '#bioschemas' ).text( JSON.stringify(data, undefined, 2))
+      } )
     }
 
     var url = 'https://www.wikidata.org/w/api.php?action=wbgetentities&ids=' +

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -20,7 +20,7 @@ from ..query import (arxiv_to_qs, cas_to_qs, atomic_symbol_to_qs, doi_to_qs,
                      cordis_to_qs, mesh_to_qs, pubmed_to_qs,
                      lipidmaps_to_qs, ror_to_qs, wikipathways_to_qs,
                      pubchem_to_qs, atomic_number_to_qs, ncbi_taxon_to_qs,
-                     ncbi_gene_to_qs, uniprot_to_qs, q_to_label,
+                     ncbi_gene_to_qs, uniprot_to_qs, q_to_label_and_description,
                      properties_for_q)
 from ..utils import sanitize_q
 from ..wikipedia import q_to_bibliography_templates
@@ -215,11 +215,15 @@ def bioschemas_for(q):
     # glue stuff together
     content = {
         "@context": "https://schema.org",
-        "name": q_to_label(q),
         "identifier": q,
         "mainEntityOfPage": f"http://www.wikidata.org/entity/{q}",
         **data,
     }
+    label_and_description = q_to_label_and_description(q)
+    if label_and_description["label"]:
+        content["name"] = label_and_description["label"]
+    if label_and_description["description"]:
+        content["description"] = label_and_description["description"]
     return jsonify(content)
 
 

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -135,22 +135,22 @@ def redirect_q(q):
     return redirect(url_for(method, q=q), code=302)
 
 
-def bioschemas_type(bioschemasType, conformsTo):
+def bioschemas_type(bioschemas_type, conforms_to):
     """Helper function to create the basic content of Bioschemas.
 
     Parameters
     ----------
-    bioschemasType : str
+    bioschemas_type : str
         Bioschemas type of the thing to be represented
-    conformsTo : str
+    conforms_to : str
         Profile specification for the given type
     """
-    bsProfile = "https://bioschemas.org/profiles/"
+    bs_profile = "https://bioschemas.org/profiles/"
     return {
-        "@type": bioschemasType,
+        "@type": bioschemas_type,
         "http://purl.org/dc/terms/conformsTo": {
             "@type": "CreativeWork",
-            "@id": bsProfile + conformsTo,
+            "@id": bs_profile + conforms_to,
         }
     }
 

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -135,6 +135,26 @@ def redirect_q(q):
     return redirect(url_for(method, q=q), code=302)
 
 
+def bioschemas_type(bioschemasType, conformsTo):
+    """Helper function to create the basic content of Bioschemas.
+
+    Parameters
+    ----------
+    bioschemasType : str
+        Bioschemas type of the thing to be represented
+    conformsTo : str
+        Profile specification for the given type
+    """
+    bsProfile = "https://bioschemas.org/profiles/"
+    return {
+        "@type": bioschemasType,
+        "http://purl.org/dc/terms/conformsTo": {
+            "@type": "CreativeWork",
+            "@id": bsProfile + conformsTo,
+        }
+    }
+
+
 @main.route("/" + q_pattern + "/bioschemas")
 def bioschemas_for(q):
     """Detect a Bioschemas API request and return Bioschemas for this item.
@@ -147,68 +167,39 @@ def bioschemas_for(q):
     entity_class = q_to_class(q)
 
     # get the aspect specific bits
-    bsProfile = "https://bioschemas.org/profiles/"
     if entity_class == "author":
-        data = {
-            "@type": "Person",
-            "http://purl.org/dc/terms/conformsTo": {
-                "@type": "CreativeWork",
-                "@id": bsProfile + "Person/0.2-DRAFT-2019_07_19/",
-            },
-            "description": "A person",
-        }
+        data = bioschemas_type("Person", "Person/0.2-DRAFT-2019_07_19/")
     elif entity_class == "substance":
-        data = {
-            "@type": "ChemicalSubstance",
-            "http://purl.org/dc/terms/conformsTo": {
-                "@type": "CreativeWork",
-                "@id": bsProfile + "ChemicalSubstance/0.4-RELEASE/",
-            },
-        }
+        data = bioschemas_type(
+            "ChemicalSubstance", "ChemicalSubstance/0.4-RELEASE/"
+        )
     elif entity_class == "taxon":
-        data = {
-            "@type": "Taxon",
-            "http://purl.org/dc/terms/conformsTo": {
-                "@type": "CreativeWork",
-                "@id": bsProfile + "Taxon/0.6-RELEASE/",
-            },
-        }
+        data = bioschemas_type("Taxon", "Taxon/0.6-RELEASE/")
         data.update(properties_for_q(
-                q, {"P225": "name", "P105": "taxonRank", "P171": "taxonParent"}
+                q,
+                {"P225": "name", "P105": "taxonRank", "P171": "taxonParent"}
         ))
     elif entity_class == "chemical":
-        data = {
-            "@type": "MolecularEntity",
-            "http://purl.org/dc/terms/conformsTo": {
-                "@type": "CreativeWork",
-                "@id": bsProfile + "MolecularEntity/0.5-RELEASE/",
-            },
-        }
+        data = bioschemas_type(
+            "MolecularEntity", "MolecularEntity/0.5-RELEASE/"
+        )
         data.update(
             properties_for_q(q, {
                 "P235": "inChIKey", "P234": "inChI",
-                "P274": "molecularFormula", "P2017": "smiles", "P233": "smiles"
+                "P274": "molecularFormula", "P2017": "smiles",
+                "P233": "smiles"
             })
         )
     elif entity_class == "protein":
-        data = {
-            "@type": "Protein",
-            "http://purl.org/dc/terms/conformsTo": {
-                "@type": "CreativeWork",
-                "@id": bsProfile + "Protein/0.11-RELEASE/",
-            }
-        }
+        data = bioschemas_type(
+            "Protein", "Protein/0.11-RELEASE/"
+        )
         data.update(properties_for_q(
-            q, {"P352": "sameAs"}, {"P352": "https://www.uniprot.org/uniprot/"}
+            q,
+            {"P352": "sameAs"}, {"P352": "https://www.uniprot.org/uniprot/"}
         ))
     elif entity_class == "gene":
-        data = {
-            "@type": "Gene",
-            "http://purl.org/dc/terms/conformsTo": {
-                "@type": "CreativeWork",
-                "@id": bsProfile + "Gene/0.7-RELEASE/",
-            },
-        }
+        data = bioschemas_type("Gene", "Gene/0.7-RELEASE/")
         data.update(
             properties_for_q(
                 q, {"P351": "sameAs", "P594": "sameAs"},

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -2,8 +2,8 @@
 
 import re
 
-from flask import (Blueprint, current_app, jsonify, redirect, render_template, request,
-                   Response, url_for)
+from flask import (Blueprint, current_app, jsonify, redirect, render_template,
+                   request, Response, url_for)
 from jinja2 import TemplateNotFound
 from werkzeug.routing import BaseConverter
 
@@ -147,12 +147,13 @@ def bioschemas_for(q):
     entity_class = q_to_class(q)
 
     # get the aspect specific bits
+    bsProfile = "https://bioschemas.org/profiles/"
     if entity_class == "author":
         data = {
             "@type": "Person",
             "http://purl.org/dc/terms/conformsTo": {
                 "@type": "CreativeWork",
-                "@id": "https://bioschemas.org/profiles/Person/0.2-DRAFT-2019_07_19/",
+                "@id": bsProfile + "Person/0.2-DRAFT-2019_07_19/",
             },
             "description": "A person",
         }
@@ -161,7 +162,7 @@ def bioschemas_for(q):
             "@type": "ChemicalSubstance",
             "http://purl.org/dc/terms/conformsTo": {
                 "@type": "CreativeWork",
-                "@id": "https://bioschemas.org/profiles/ChemicalSubstance/0.4-RELEASE/",
+                "@id": bsProfile + "ChemicalSubstance/0.4-RELEASE/",
             },
         }
     elif entity_class == "taxon":
@@ -169,7 +170,7 @@ def bioschemas_for(q):
             "@type": "Taxon",
             "http://purl.org/dc/terms/conformsTo": {
                 "@type": "CreativeWork",
-                "@id": "https://bioschemas.org/profiles/Taxon/0.6-RELEASE/",
+                "@id": bsProfile + "Taxon/0.6-RELEASE/",
             },
         }
         taxon_name = property_for_q(q, "P225")
@@ -186,10 +187,11 @@ def bioschemas_for(q):
             "@type": "MolecularEntity",
             "http://purl.org/dc/terms/conformsTo": {
                 "@type": "CreativeWork",
-                "@id": "https://bioschemas.org/profiles/MolecularEntity/0.5-RELEASE/",
+                "@id": bsProfile + "MolecularEntity/0.5-RELEASE/",
             },
         }
         inchi_key = property_for_q(q, "P235")
+        inchi = property_for_q(q, "P234")
         if inchi_key:
             data['inChIKey'] = inchi_key
         if inchi:
@@ -209,7 +211,7 @@ def bioschemas_for(q):
             "@type": "Protein",
             "http://purl.org/dc/terms/conformsTo": {
                 "@type": "CreativeWork",
-                "@id": "https://bioschemas.org/profiles/Protein/0.11-RELEASE/",
+                "@id": bsProfile + "Protein/0.11-RELEASE/",
             }
         }
         uniprot = property_for_q(q, "P352")
@@ -219,7 +221,8 @@ def bioschemas_for(q):
         data = {
             "@type": "Gene",
             "http://purl.org/dc/terms/conformsTo": {
-                "@type": "CreativeWork", "@id": "https://bioschemas.org/profiles/Gene/0.7-RELEASE/",
+                "@type": "CreativeWork",
+                "@id": bsProfile + "Gene/0.7-RELEASE/",
             },
         }
         same_genes = []
@@ -1673,7 +1676,6 @@ def show_substance(q):
         Rendered HTML.
 
     """
-    entities = wb_get_entities([q])
     return render_template('chemical.html', q=q)
 
 

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -21,7 +21,7 @@ from ..query import (arxiv_to_qs, cas_to_qs, atomic_symbol_to_qs, doi_to_qs,
                      lipidmaps_to_qs, ror_to_qs, wikipathways_to_qs,
                      pubchem_to_qs, atomic_number_to_qs, ncbi_taxon_to_qs,
                      ncbi_gene_to_qs, uniprot_to_qs, q_to_label,
-                     property_for_q, properties_for_q)
+                     properties_for_q)
 from ..utils import sanitize_q
 from ..wikipedia import q_to_bibliography_templates
 
@@ -173,8 +173,8 @@ def bioschemas_for(q):
                 "@id": bsProfile + "Taxon/0.6-RELEASE/",
             },
         }
-        data.update(properties_for_q(q,
-            {"P225":"name", "P105":"taxonRank", "P171":"taxonParent"}
+        data.update(properties_for_q(
+                q, {"P225": "name", "P105": "taxonRank", "P171": "taxonParent"}
         ))
     elif entity_class == "chemical":
         data = {
@@ -186,8 +186,8 @@ def bioschemas_for(q):
         }
         data.update(
             properties_for_q(q, {
-                "P235":"inChIKey", "P234":"inChI",
-                "P274":"molecularFormula", "P2017":"smiles", "P233":"smiles"
+                "P235": "inChIKey", "P234": "inChI",
+                "P274": "molecularFormula", "P2017": "smiles", "P233": "smiles"
             })
         )
     elif entity_class == "protein":
@@ -198,9 +198,9 @@ def bioschemas_for(q):
                 "@id": bsProfile + "Protein/0.11-RELEASE/",
             }
         }
-        data.update(properties_for_q(q, {"P352":"sameAs"},
-            {"P352":"https://www.uniprot.org/uniprot/"})
-        )
+        data.update(properties_for_q(
+            q, {"P352": "sameAs"}, {"P352": "https://www.uniprot.org/uniprot/"}
+        ))
     elif entity_class == "gene":
         data = {
             "@type": "Gene",
@@ -210,10 +210,11 @@ def bioschemas_for(q):
             },
         }
         data.update(
-            properties_for_q(q, {"P351":"sameAs", "P594":"sameAs"},
+            properties_for_q(
+                q, {"P351": "sameAs", "P594": "sameAs"},
                 # and the prefixes:
-                {"P351":"https://www.ncbi.nlm.nih.gov/gene/",
-                 "P594":"http://identifiers.org/ensembl/"}
+                {"P351": "https://www.ncbi.nlm.nih.gov/gene/",
+                 "P594": "http://identifiers.org/ensembl/"}
             )
         )
     else:

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -1651,6 +1651,38 @@ def show_topics(qs):
         return render_template('topics.html', qs=qs)
 
 
+@main.route('/substance/' + q_pattern)
+def show_substance(q):
+    """Return html render page for specific chemical substance.
+
+    Parameters
+    ----------
+    q : str
+        Wikidata item identifier.
+
+    Returns
+    -------
+    html : str
+        Rendered HTML.
+
+    """
+    entities = wb_get_entities([q])
+    return render_template('chemical.html', q=q)
+
+
+@main.route('/substance/')
+def show_substance_index():
+    """Return rendered HTML index page for chemical substance.
+
+    Returns
+    -------
+    html : str
+        Rendered HTML index page for chemical.
+
+    """
+    return render_template('chemical-index.html')
+
+
 @main.route('/chemical/' + q_pattern)
 def show_chemical(q):
     """Return html render page for specific chemical.

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -20,7 +20,8 @@ from ..query import (arxiv_to_qs, cas_to_qs, atomic_symbol_to_qs, doi_to_qs,
                      cordis_to_qs, mesh_to_qs, pubmed_to_qs,
                      lipidmaps_to_qs, ror_to_qs, wikipathways_to_qs,
                      pubchem_to_qs, atomic_number_to_qs, ncbi_taxon_to_qs,
-                     ncbi_gene_to_qs, uniprot_to_qs)
+                     ncbi_gene_to_qs, uniprot_to_qs, q_to_label,
+                     property_for_q)
 from ..utils import sanitize_q
 from ..wikipedia import q_to_bibliography_templates
 
@@ -132,6 +133,110 @@ def redirect_q(q):
     class_ = q_to_class(q)
     method = 'app.show_' + class_
     return redirect(url_for(method, q=q), code=302)
+
+
+@main.route("/" + q_pattern + "/bioschemas")
+def bioschemas_for(q):
+    """Detect a Bioschemas API request and return Bioschemas for this item.
+
+    Parameters
+    ----------
+    q : str
+        Wikidata item identifier
+
+    """
+    class_ = q_to_class(q)
+    label = q_to_label(q)
+
+    # get the aspect specific bits
+    typeLine = ""
+    if (class_ == "author"):
+        typeLine = """
+    "@type" : "Person",'
+    "http://purl.org/dc/terms/conformsTo": { "@type": "CreativeWork", "@id": "https://bioschemas.org/profiles/Person/0.2-DRAFT-2019_07_19/" },
+    "description" : "A person" ,"""
+    elif (class_ == "substance"):
+        typeLine = """
+    "@type" : "ChemicalSubstance" ,
+    "http://purl.org/dc/terms/conformsTo": { "@type": "CreativeWork", "@id": "https://bioschemas.org/profiles/ChemicalSubstance/0.4-RELEASE/" },"""
+    elif (class_ == "taxon"):
+        typeLine = """
+    "@type" : "Taxon" ,
+    "http://purl.org/dc/terms/conformsTo": { "@type": "CreativeWork", "@id": "https://bioschemas.org/profiles/Taxon/0.6-RELEASE/" },"""
+        taxonName = property_for_q(q, "P225")
+        if (taxonName):
+            typeLine = typeLine + """
+    "name" : "{taxonName}",""".format(taxonName=taxonName)
+        rank = property_for_q(q, "P105")
+        if (rank):
+            typeLine = typeLine + """
+    "taxonRank" : "{rank}",""".format(rank=rank)
+        taxonParent = property_for_q(q, "P171")
+        if (taxonParent):
+            typeLine = typeLine + """
+    "taxonParent" : "{taxonParent}",""".format(taxonParent=taxonParent)
+    elif (class_ == "chemical"):
+        typeLine = """
+    "@type" : "MolecularEntity" ,
+    "http://purl.org/dc/terms/conformsTo": { "@type": "CreativeWork", "@id": "https://bioschemas.org/profiles/MolecularEntity/0.5-RELEASE/" },"""
+        inchiKey = property_for_q(q, "P235")
+        if (inchiKey):
+            typeLine = typeLine + """
+    "inChIKey" : "{inchiKey}",""".format(inchiKey=inchiKey)
+        inchi = property_for_q(q, "P234")
+        if (inchi):
+            typeLine = typeLine + """
+    "inChI" : "{inchi}",""".format(inchi=inchi)
+        molecularFormula = property_for_q(q, "P274")
+        if (molecularFormula):
+            typeLine = typeLine + """
+    "molecularFormula" : "{molecularFormula}",""".format(molecularFormula=molecularFormula)
+        isoSMILES = property_for_q(q, "P2017")
+        if (isoSMILES):
+            typeLine = typeLine + """
+    "smiles" : "{isoSMILES}",""".format(isoSMILES=isoSMILES)
+        else:
+            SMILES = property_for_q(q, "233")
+            if (SMILES):
+                typeLine = typeLine + """
+    "smiles" : "{SMILES}",""".format(SMILES=SMILES)
+    elif (class_ == "protein"):
+        typeLine = """
+    "@type" : "Protein" ,
+    "http://purl.org/dc/terms/conformsTo": { "@type": "CreativeWork", "@id": "https://bioschemas.org/profiles/Protein/0.11-RELEASE/" },"""
+        uniprot = property_for_q(q, "P352")
+        if (uniprot):
+            typeLine = typeLine + """
+    "sameAs": "https://www.uniprot.org/uniprot/{uniprot}",""".format(uniprot=uniprot)
+    elif (class_ == "gene"):
+        typeLine = """
+    "@type" : "Gene" ,
+    "http://purl.org/dc/terms/conformsTo": { "@type": "CreativeWork", "@id": "https://bioschemas.org/profiles/Gene/0.7-RELEASE/" },"""
+        counter = 0
+        sameAsLines = """
+    "sameAs": ["""
+        ncbi = property_for_q(q, "P351")
+        if (ncbi):
+            sameAsLines = sameAsLines + """
+        "https://www.ncbi.nlm.nih.gov/gene/{ncbi}",""".format(ncbi=ncbi)
+            counter = counter + 1
+        ensembl = property_for_q(q, "P594")
+        if (ensembl):
+            sameAsLines = sameAsLines + """
+        "http://identifiers.org/ensembl/{ensembl}",""".format(ensembl=ensembl)
+            counter = counter + 1
+        if (counter > 0):
+            typeLine = typeLine + sameAsLines + """
+    ],"""
+
+    # glue stuff together
+    content = """{{
+    "@context" : "https://schema.org",{typeLine}
+    "name" : "{label}",
+    "identifier" : "{q}",
+    "mainEntityOfPage" : "http://www.wikidata.org/entity/{q}"
+}}""".format(q=q, typeLine=typeLine, label=label)
+    return content
 
 
 @main.route("/" + p_pattern)

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -2,7 +2,7 @@
 
 import re
 
-from flask import (Blueprint, current_app, redirect, render_template, request,
+from flask import (Blueprint, current_app, jsonify, redirect, render_template, request,
                    Response, url_for)
 from jinja2 import TemplateNotFound
 from werkzeug.routing import BaseConverter
@@ -143,100 +143,107 @@ def bioschemas_for(q):
     ----------
     q : str
         Wikidata item identifier
-
     """
-    class_ = q_to_class(q)
-    label = q_to_label(q)
+    entity_class = q_to_class(q)
 
     # get the aspect specific bits
-    typeLine = ""
-    if (class_ == "author"):
-        typeLine = """
-    "@type" : "Person",'
-    "http://purl.org/dc/terms/conformsTo": { "@type": "CreativeWork", "@id": "https://bioschemas.org/profiles/Person/0.2-DRAFT-2019_07_19/" },
-    "description" : "A person" ,"""
-    elif (class_ == "substance"):
-        typeLine = """
-    "@type" : "ChemicalSubstance" ,
-    "http://purl.org/dc/terms/conformsTo": { "@type": "CreativeWork", "@id": "https://bioschemas.org/profiles/ChemicalSubstance/0.4-RELEASE/" },"""
-    elif (class_ == "taxon"):
-        typeLine = """
-    "@type" : "Taxon" ,
-    "http://purl.org/dc/terms/conformsTo": { "@type": "CreativeWork", "@id": "https://bioschemas.org/profiles/Taxon/0.6-RELEASE/" },"""
-        taxonName = property_for_q(q, "P225")
-        if (taxonName):
-            typeLine = typeLine + """
-    "name" : "{taxonName}",""".format(taxonName=taxonName)
+    if entity_class == "author":
+        data = {
+            "@type": "Person",
+            "http://purl.org/dc/terms/conformsTo": {
+                "@type": "CreativeWork",
+                "@id": "https://bioschemas.org/profiles/Person/0.2-DRAFT-2019_07_19/",
+            },
+            "description": "A person",
+        }
+    elif entity_class == "substance":
+        data = {
+            "@type": "ChemicalSubstance",
+            "http://purl.org/dc/terms/conformsTo": {
+                "@type": "CreativeWork",
+                "@id": "https://bioschemas.org/profiles/ChemicalSubstance/0.4-RELEASE/",
+            },
+        }
+    elif entity_class == "taxon":
+        data = {
+            "@type": "Taxon",
+            "http://purl.org/dc/terms/conformsTo": {
+                "@type": "CreativeWork",
+                "@id": "https://bioschemas.org/profiles/Taxon/0.6-RELEASE/",
+            },
+        }
+        taxon_name = property_for_q(q, "P225")
+        if taxon_name:
+            data['name'] = taxon_name
         rank = property_for_q(q, "P105")
-        if (rank):
-            typeLine = typeLine + """
-    "taxonRank" : "{rank}",""".format(rank=rank)
-        taxonParent = property_for_q(q, "P171")
-        if (taxonParent):
-            typeLine = typeLine + """
-    "taxonParent" : "{taxonParent}",""".format(taxonParent=taxonParent)
-    elif (class_ == "chemical"):
-        typeLine = """
-    "@type" : "MolecularEntity" ,
-    "http://purl.org/dc/terms/conformsTo": { "@type": "CreativeWork", "@id": "https://bioschemas.org/profiles/MolecularEntity/0.5-RELEASE/" },"""
-        inchiKey = property_for_q(q, "P235")
-        if (inchiKey):
-            typeLine = typeLine + """
-    "inChIKey" : "{inchiKey}",""".format(inchiKey=inchiKey)
-        inchi = property_for_q(q, "P234")
-        if (inchi):
-            typeLine = typeLine + """
-    "inChI" : "{inchi}",""".format(inchi=inchi)
-        molecularFormula = property_for_q(q, "P274")
-        if (molecularFormula):
-            typeLine = typeLine + """
-    "molecularFormula" : "{molecularFormula}",""".format(molecularFormula=molecularFormula)
-        isoSMILES = property_for_q(q, "P2017")
-        if (isoSMILES):
-            typeLine = typeLine + """
-    "smiles" : "{isoSMILES}",""".format(isoSMILES=isoSMILES)
+        if rank:
+            data['taxonRank']: rank
+        taxon_parent = property_for_q(q, "P171")
+        if taxon_parent:
+            data['taxonParent'] = taxon_parent
+    elif entity_class == "chemical":
+        data = {
+            "@type": "MolecularEntity",
+            "http://purl.org/dc/terms/conformsTo": {
+                "@type": "CreativeWork",
+                "@id": "https://bioschemas.org/profiles/MolecularEntity/0.5-RELEASE/",
+            },
+        }
+        inchi_key = property_for_q(q, "P235")
+        if inchi_key:
+            data['inChIKey'] = inchi_key
+        if inchi:
+            data['inChI'] = inchi
+        molecular_formula = property_for_q(q, "P274")
+        if molecular_formula:
+            data['molecularFormula'] = molecular_formula
+        isomeric_smiles = property_for_q(q, "P2017")
+        if isomeric_smiles:
+            data['smiles'] = isomeric_smiles
         else:
-            SMILES = property_for_q(q, "233")
-            if (SMILES):
-                typeLine = typeLine + """
-    "smiles" : "{SMILES}",""".format(SMILES=SMILES)
-    elif (class_ == "protein"):
-        typeLine = """
-    "@type" : "Protein" ,
-    "http://purl.org/dc/terms/conformsTo": { "@type": "CreativeWork", "@id": "https://bioschemas.org/profiles/Protein/0.11-RELEASE/" },"""
+            canonical_smiles = property_for_q(q, "P233")
+            if canonical_smiles:
+                data['smiles'] = canonical_smiles
+    elif entity_class == "protein":
+        data = {
+            "@type": "Protein",
+            "http://purl.org/dc/terms/conformsTo": {
+                "@type": "CreativeWork",
+                "@id": "https://bioschemas.org/profiles/Protein/0.11-RELEASE/",
+            }
+        }
         uniprot = property_for_q(q, "P352")
-        if (uniprot):
-            typeLine = typeLine + """
-    "sameAs": "https://www.uniprot.org/uniprot/{uniprot}",""".format(uniprot=uniprot)
-    elif (class_ == "gene"):
-        typeLine = """
-    "@type" : "Gene" ,
-    "http://purl.org/dc/terms/conformsTo": { "@type": "CreativeWork", "@id": "https://bioschemas.org/profiles/Gene/0.7-RELEASE/" },"""
-        counter = 0
-        sameAsLines = """
-    "sameAs": ["""
+        if uniprot:
+            data['sameAs'] = f"https://www.uniprot.org/uniprot/{uniprot}"
+    elif entity_class == "gene":
+        data = {
+            "@type": "Gene",
+            "http://purl.org/dc/terms/conformsTo": {
+                "@type": "CreativeWork", "@id": "https://bioschemas.org/profiles/Gene/0.7-RELEASE/",
+            },
+        }
+        same_genes = []
         ncbi = property_for_q(q, "P351")
-        if (ncbi):
-            sameAsLines = sameAsLines + """
-        "https://www.ncbi.nlm.nih.gov/gene/{ncbi}",""".format(ncbi=ncbi)
-            counter = counter + 1
+        if ncbi:
+            same_genes.append(f"https://www.ncbi.nlm.nih.gov/gene/{ncbi}")
         ensembl = property_for_q(q, "P594")
-        if (ensembl):
-            sameAsLines = sameAsLines + """
-        "http://identifiers.org/ensembl/{ensembl}",""".format(ensembl=ensembl)
-            counter = counter + 1
-        if (counter > 0):
-            typeLine = typeLine + sameAsLines + """
-    ],"""
+        if ensembl:
+            same_genes.append(f"http://identifiers.org/ensembl/{ensembl}")
+        if same_genes:
+            data['sameAs'] = same_genes
+    else:
+        # No schema information inferred for this type
+        data = {}
 
     # glue stuff together
-    content = """{{
-    "@context" : "https://schema.org",{typeLine}
-    "name" : "{label}",
-    "identifier" : "{q}",
-    "mainEntityOfPage" : "http://www.wikidata.org/entity/{q}"
-}}""".format(q=q, typeLine=typeLine, label=label)
-    return content
+    content = {
+        "@context": "https://schema.org",
+        "name": q_to_label(q),
+        "identifier": q,
+        "mainEntityOfPage": f"http://www.wikidata.org/entity/{q}",
+        **data,
+    }
+    return jsonify(content)
 
 
 @main.route("/" + p_pattern)

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -20,8 +20,8 @@ from ..query import (arxiv_to_qs, cas_to_qs, atomic_symbol_to_qs, doi_to_qs,
                      cordis_to_qs, mesh_to_qs, pubmed_to_qs,
                      lipidmaps_to_qs, ror_to_qs, wikipathways_to_qs,
                      pubchem_to_qs, atomic_number_to_qs, ncbi_taxon_to_qs,
-                     ncbi_gene_to_qs, uniprot_to_qs, q_to_label_and_description,
-                     properties_for_q)
+                     ncbi_gene_to_qs, uniprot_to_qs,
+                     q_to_label_and_description, properties_for_q)
 from ..utils import sanitize_q
 from ..wikipedia import q_to_bibliography_templates
 
@@ -136,7 +136,7 @@ def redirect_q(q):
 
 
 def bioschemas_type(bioschemas_type, conforms_to):
-    """Helper function to create the basic content of Bioschemas.
+    """Create the basic and common content of Bioschemas.
 
     Parameters
     ----------

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -21,7 +21,7 @@ from ..query import (arxiv_to_qs, cas_to_qs, atomic_symbol_to_qs, doi_to_qs,
                      lipidmaps_to_qs, ror_to_qs, wikipathways_to_qs,
                      pubchem_to_qs, atomic_number_to_qs, ncbi_taxon_to_qs,
                      ncbi_gene_to_qs, uniprot_to_qs, q_to_label,
-                     property_for_q)
+                     property_for_q, properties_for_q)
 from ..utils import sanitize_q
 from ..wikipedia import q_to_bibliography_templates
 
@@ -173,15 +173,9 @@ def bioschemas_for(q):
                 "@id": bsProfile + "Taxon/0.6-RELEASE/",
             },
         }
-        taxon_name = property_for_q(q, "P225")
-        if taxon_name:
-            data['name'] = taxon_name
-        rank = property_for_q(q, "P105")
-        if rank:
-            data['taxonRank']: rank
-        taxon_parent = property_for_q(q, "P171")
-        if taxon_parent:
-            data['taxonParent'] = taxon_parent
+        data.update(properties_for_q(q,
+            {"P225":"name", "P105":"taxonRank", "P171":"taxonParent"}
+        ))
     elif entity_class == "chemical":
         data = {
             "@type": "MolecularEntity",
@@ -190,22 +184,12 @@ def bioschemas_for(q):
                 "@id": bsProfile + "MolecularEntity/0.5-RELEASE/",
             },
         }
-        inchi_key = property_for_q(q, "P235")
-        inchi = property_for_q(q, "P234")
-        if inchi_key:
-            data['inChIKey'] = inchi_key
-        if inchi:
-            data['inChI'] = inchi
-        molecular_formula = property_for_q(q, "P274")
-        if molecular_formula:
-            data['molecularFormula'] = molecular_formula
-        isomeric_smiles = property_for_q(q, "P2017")
-        if isomeric_smiles:
-            data['smiles'] = isomeric_smiles
-        else:
-            canonical_smiles = property_for_q(q, "P233")
-            if canonical_smiles:
-                data['smiles'] = canonical_smiles
+        data.update(
+            properties_for_q(q, {
+                "P235":"inChIKey", "P234":"inChI",
+                "P274":"molecularFormula", "P2017":"smiles", "P233":"smiles"
+            })
+        )
     elif entity_class == "protein":
         data = {
             "@type": "Protein",
@@ -214,9 +198,9 @@ def bioschemas_for(q):
                 "@id": bsProfile + "Protein/0.11-RELEASE/",
             }
         }
-        uniprot = property_for_q(q, "P352")
-        if uniprot:
-            data['sameAs'] = f"https://www.uniprot.org/uniprot/{uniprot}"
+        data.update(properties_for_q(q, {"P352":"sameAs"},
+            {"P352":"https://www.uniprot.org/uniprot/"})
+        )
     elif entity_class == "gene":
         data = {
             "@type": "Gene",
@@ -225,15 +209,13 @@ def bioschemas_for(q):
                 "@id": bsProfile + "Gene/0.7-RELEASE/",
             },
         }
-        same_genes = []
-        ncbi = property_for_q(q, "P351")
-        if ncbi:
-            same_genes.append(f"https://www.ncbi.nlm.nih.gov/gene/{ncbi}")
-        ensembl = property_for_q(q, "P594")
-        if ensembl:
-            same_genes.append(f"http://identifiers.org/ensembl/{ensembl}")
-        if same_genes:
-            data['sameAs'] = same_genes
+        data.update(
+            properties_for_q(q, {"P351":"sameAs", "P594":"sameAs"},
+                # and the prefixes:
+                {"P351":"https://www.ncbi.nlm.nih.gov/gene/",
+                 "P594":"http://identifiers.org/ensembl/"}
+            )
+        )
     else:
         # No schema information inferred for this type
         data = {}

--- a/scholia/query.py
+++ b/scholia/query.py
@@ -809,6 +809,42 @@ def q_to_label(q, language='en'):
         return None
 
 
+def property_for_q(q, prop):
+    """Get the value for a property for Q item.
+
+    Parameters
+    ----------
+    q : str
+        String with Wikidata Q item.
+    prop : str
+        String with the property identifier (e.g. P235)
+
+    Returns
+    -------
+    label : str
+        String with value for the corresponding property.
+
+    Examples
+    --------
+    >>> property_for_q('Q80', "P1971")
+    2
+
+    """
+    query = """SELECT ?value WHERE {{ wd:{q} wdt:{prop} ?value . }}""".format(
+        q=q, prop=prop)
+
+    url = 'https://query.wikidata.org/sparql'
+    params = {'query': query, 'format': 'json'}
+    response = requests.get(url, params=params, headers=HEADERS)
+    data = response.json()
+
+    results = data['results']['bindings']
+    if len(results) == 1:
+        return results[0]['value']['value']
+    else:
+        return None
+
+
 def search_article_titles(q, search_string=None):
     """Search articles with q item.
 

--- a/scholia/query.py
+++ b/scholia/query.py
@@ -1122,6 +1122,11 @@ def q_to_class(q):
             ]):
         class_ = 'disease'
     elif set(classes).intersection([
+            'Q47461491', # JRC representative nanomaterial
+            'Q967847',   # nanomaterial
+            ]):
+        class_ = 'substance'
+    elif set(classes).intersection([
             'Q11173',  # chemical compound
             'Q36496',  # ion
             'Q79529',  # chemical substance

--- a/scholia/query.py
+++ b/scholia/query.py
@@ -809,42 +809,6 @@ def q_to_label(q, language='en'):
         return None
 
 
-def property_for_q(q, prop):
-    """Get the value for a property for Q item.
-
-    Parameters
-    ----------
-    q : str
-        String with Wikidata Q item.
-    prop : str
-        String with the property identifier (e.g. P235)
-
-    Returns
-    -------
-    label : str
-        String with value for the corresponding property.
-
-    Examples
-    --------
-    >>> property_for_q('Q80', "P1971")
-    2
-
-    """
-    query = """SELECT ?value WHERE {{ wd:{q} wdt:{prop} ?value . }}""".format(
-        q=q, prop=prop)
-
-    url = 'https://query.wikidata.org/sparql'
-    params = {'query': query, 'format': 'json'}
-    response = requests.get(url, params=params, headers=HEADERS)
-    data = response.json()
-
-    results = data['results']['bindings']
-    if len(results) == 1:
-        return results[0]['value']['value']
-    else:
-        return None
-
-
 def properties_for_q(q, props, prefixes=None):
     """Get the value for a property for Q item.
 

--- a/scholia/query.py
+++ b/scholia/query.py
@@ -838,7 +838,10 @@ def properties_for_q(q, props, prefixes=None):
         map(lambda s: f"  OPTIONAL {{ ?item wdt:{s} ?{s} }}", props)
     )))
     variables = ' '.join(list(map(lambda s: f"?{s}", props.keys())))
-    query = f"SELECT {variables} WHERE {{\n VALUES ?item {{ wd:{q} }}\n{optionals}\n}}"
+    query = f"""SELECT {variables} WHERE {{
+        VALUES ?item {{ wd:{q} }}
+        {optionals}
+    }}"""
 
     url = 'https://query.wikidata.org/sparql'
     params = {'query': query, 'format': 'json'}

--- a/scholia/query.py
+++ b/scholia/query.py
@@ -873,10 +873,11 @@ def properties_for_q(q, props, prefixes=None):
     {"inChIKey": "QTBSBXVTEAMEQO-UHFFFAOYSA-N"}
 
     """
-    optionals = str('\n'.join(list(
-        map(lambda s: f"  OPTIONAL {{ ?item wdt:{s} ?{s} }}", props)
-    )))
-    variables = ' '.join(list(map(lambda s: f"?{s}", props.keys())))
+    optionals = str('\n'.join(
+        f"  OPTIONAL {{ ?item wdt:{key} ?{key} }}"
+        for key in props.keys()
+    ))
+    variables = ' '.join(f"?{key}" for key in props.keys())
     query = f"""SELECT {variables} WHERE {{
         VALUES ?item {{ wd:{q} }}
         {optionals}

--- a/scholia/query.py
+++ b/scholia/query.py
@@ -1122,7 +1122,7 @@ def q_to_class(q):
             ]):
         class_ = 'disease'
     elif set(classes).intersection([
-            'Q47461491', # JRC representative nanomaterial
+            'Q47461491',  # JRC representative nanomaterial
             'Q967847',   # nanomaterial
             ]):
         class_ = 'substance'

--- a/scholia/query.py
+++ b/scholia/query.py
@@ -856,8 +856,8 @@ def properties_for_q(q, props, prefixes=None):
         Dictionary object with the Wikidata property identifier as key and the
         matching BioSchemas key as value
     prefixes : dictionary
-        Dictionary object with the prefixes for the Bioschemas values, where the keys
-        are Wikidata properties and the prefix as value
+        Dictionary object with the prefixes for the Bioschemas values, where
+        the keys are Wikidata properties and the prefix as value
 
     Returns
     -------
@@ -891,7 +891,7 @@ def properties_for_q(q, props, prefixes=None):
                 # add the given prefix for this Wikidata property
                 value = prefixes[var] + value
             bskey = props[var]
-            # okay, some Bioschemas keys will have multiple values, in 
+            # okay, some Bioschemas keys will have multiple values, in
             # which case the string type needs to be replaced by a list type
             if bskey in bioschemas.keys():
                 if isinstance(bioschemas[bskey], list):

--- a/scholia/query.py
+++ b/scholia/query.py
@@ -809,6 +809,45 @@ def q_to_label(q, language='en'):
         return None
 
 
+def q_to_label_and_description(q, language='en'):
+    """Get label and description for Q item.
+
+    Parameters
+    ----------
+    q : str
+        String with Wikidata Q item.
+    language : str
+        String with language identifier
+
+    Returns
+    -------
+    label : str
+        String with label corresponding to Wikidata item.
+    description : str
+        String with the description of the corresponding Wikidata item.
+    """
+    query = """SELECT ?label ?description WHERE {{
+          wd:{q} rdfs:label ?label .
+          wd:{q} schema:description ?description .
+          FILTER (LANG(?label) = "{language}")
+          FILTER (LANG(?description) = "{language}")
+        }}""".format(q=q, language=language)
+
+    url = 'https://query.wikidata.org/sparql'
+    params = {'query': query, 'format': 'json'}
+    response = requests.get(url, params=params, headers=HEADERS)
+    data = response.json()
+
+    results = data['results']['bindings']
+    if not results:
+        return {}
+    else:
+        return {
+            "label": results[0]['label']['value'],
+            "description": results[0]['description']['value']
+        }
+
+
 def properties_for_q(q, props, prefixes=None):
     """Get the value for a property for Q item.
 

--- a/scholia/query.py
+++ b/scholia/query.py
@@ -821,10 +821,9 @@ def q_to_label_and_description(q, language='en'):
 
     Returns
     -------
-    label : str
-        String with label corresponding to Wikidata item.
-    description : str
-        String with the description of the corresponding Wikidata item.
+    results : dictionary
+        Dictionary with label of and description for the corresponding
+        Wikidata item.
     """
     query = """SELECT ?label ?description WHERE {{
           wd:{q} rdfs:label ?label .

--- a/scholia/query.py
+++ b/scholia/query.py
@@ -875,8 +875,6 @@ def properties_for_q(q, props, prefixes=None):
     )))
     variables = ' '.join(list(map(lambda s: f"?{s}", props.keys())))
     query = f"SELECT {variables} WHERE {{\n{optionals}\n}}"
-    print(query)
-    print(prefixes)
 
     url = 'https://query.wikidata.org/sparql'
     params = {'query': query, 'format': 'json'}

--- a/scholia/query.py
+++ b/scholia/query.py
@@ -835,10 +835,10 @@ def properties_for_q(q, props, prefixes=None):
 
     """
     optionals = str('\n'.join(list(
-        map(lambda s: f"  OPTIONAL {{ wd:{q} wdt:{s} ?{s} }}", props)
+        map(lambda s: f"  OPTIONAL {{ ?item wdt:{s} ?{s} }}", props)
     )))
     variables = ' '.join(list(map(lambda s: f"?{s}", props.keys())))
-    query = f"SELECT {variables} WHERE {{\n{optionals}\n}}"
+    query = f"SELECT {variables} WHERE {{\n VALUES ?item {{ wd:{q} }}\n{optionals}\n}}"
 
     url = 'https://query.wikidata.org/sparql'
     params = {'query': query, 'format': 'json'}

--- a/scholia/query.py
+++ b/scholia/query.py
@@ -896,7 +896,7 @@ def properties_for_q(q, props, prefixes=None):
             # okay, some Bioschemas keys will have multiple values, in 
             # which case the string type needs to be replaced by a list type
             if bskey in bioschemas.keys():
-                if type(bioschemas[bskey]) == "list":
+                if isinstance(bioschemas[bskey], list):
                     bioschemas[bskey].append(value)
                 else:
                     bioschemas[bskey] = [bioschemas[bskey], value]


### PR DESCRIPTION
@fnielsen, this is now a finished patch, but if you have additional ideas, plz let me know (if not, please do merge in).

The new design solve the problem of the `robots.txt` blocking calls and limiting the SEO indexing of Scholia pages:

- a Scholia proxy is defined with the URL pattern `/$qid/bioschemas` which returns JSON
- the existing `base.html` uses this new call instead of a call to wikidata.org (with the `robots.txt` problem)

The extra call is only made when the aspect template has an `id=bioschemas` holder.

Possibly future optimization:

- [x] `property_for_q()` calls are replaced by a single `properties_for_q(q, {"P235": "key1", "Pxx": "key2", ...})`
- [x] 2-3 helper functions get added to simplify the code
- [x] other bits of the page get included in a similar way (like descriptions), making it also available for SEO
- [x] use the Wikidata description as Bioschemas content