### PR TITLE
Fix ellipses

### DIFF
--- a/scholia/app/templates/base.html
+++ b/scholia/app/templates/base.html
@@ -261,7 +261,7 @@ sparqlToIframe(`# tool: scholia
 	     
 	     $.getJSON(wikipediaApiUrl, function(data) {
 		 var pages = data.query.pages;
-		 var text = pages[Object.keys(pages)[0]].extract + " ... "
+		 var text = pages[Object.keys(pages)[0]].extract + ".. "
 		 var html = "(from the <a href=\"" + wikipediaUrl + "\">English Wikipedia</a>)";
 		 $("#intro").text(text).append(html);
 	     }).fail(function(d, textStatus, error) {


### PR DESCRIPTION
Currently a description will look like:

> Sentence one. Sentence two. Sentence three. ... (From Wikipedia)

This PR will instead have:

> Sentence one. Sentence two. Sentence three... (From Wikipedia)

Some more formal (legal, journal) sources say if the source ends in a period you must show this by having four periods, but I don't think we require such rigour for this description.