### PR TITLE
Use arXiv API

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ requests
 simplejson
 werkzeug>=0.9
 urllib3>=1.25.1
-arxiv
+feedparser

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ requests
 simplejson
 werkzeug>=0.9
 urllib3>=1.25.1
+arxiv

--- a/scholia/arxiv_.py
+++ b/scholia/arxiv_.py
@@ -36,6 +36,8 @@ except ImportError:
 
 import requests
 
+from arxiv import Search
+
 
 USER_AGENT = 'Scholia'
 
@@ -79,45 +81,19 @@ def get_metadata(arxiv):
 
     """
     arxiv = arxiv.strip()
-    url = ARXIV_URL + '/abs/' + arxiv
-    headers = {'User-agent': USER_AGENT}
-    response = requests.get(url, headers=headers)
-    tree = etree.HTML(response.content)
 
-    submissions = tree.xpath('//div[@class="submission-history"]/text()')
-    submissions = [
-        submission
-        for submission in submissions
-        if len(submission.strip()) > 0
-    ]
-    datetime_as_string = submissions[-1][5:30]
-    isodatetime = parse_datetime(datetime_as_string).isoformat()
-
-    subjects = tree.xpath(
-        '//td[@class="tablecell subjects"]/span/text()'
-        '|'
-        '//td[@class="tablecell subjects"]/text()')
-    arxiv_classifications = [
-        match
-        for subject in subjects
-        for match in re.findall(r'\((.*?)\)', subject)
-    ]
+    search = Search(id_list=[arxiv])
+    result = next(search.results())
 
     metadata = {
         'arxiv': arxiv,
-        'authornames': tree.xpath('//div[@class="authors"]/a/text()'),
+        'authornames': [str(author) for author in result.authors],
         'full_text_url': 'https://arxiv.org/pdf/' + arxiv + '.pdf',
-        'publication_date': isodatetime[:10],
-        'title': re.sub(r'\s+', ' ', tree.xpath('//h1/text()')[-1].strip()),
-        'arxiv_classifications': arxiv_classifications,
+        'publication_date': result.published.date().isoformat(),
+        'title': result.title,
+        'arxiv_classifications': result.categories,
+        'doi': result.doi
     }
-
-    # Optional DOI
-    doi = tree.xpath('//td[@class="tablecell doi"]/a/text()')
-    if not doi:
-        doi = tree.xpath('//td[@class="tablecell msc_classes"]/a/text()')
-    if doi:
-        metadata['doi'] = doi[0]
 
     return metadata
 


### PR DESCRIPTION
Close #43 and close #1059

This is an exact replica of the previous version using the API instead

---

Message about the first commit:

> I looked into the API and they only serve [Atom](https://en.wikipedia.org/wiki/Atom_(Web_standard)) not JSON or anything familiar. They recommend using [feedparser](https://pypi.org/project/feedparser/). As we would be importing an external module any way, I looked into it and found the [arxiv](https://pypi.org/project/arxiv/) module. This makes things really easy and externalises the handling of the API to another project, great!

> Unfortunately as the name clashes with the file, and Python does not like importing things with the same name we either have to:
> [ ] Find a workaround for the Python import system which is robust (I looked into a lot of options, but I'm also not too familiar with this)
> [ ] Rename our module (which has a nice, fitting name)
> [ ] Implement the parsing using the feedparser module

> Will do the latter option tomorrow if I don't hear back.

> P.S. I've changed the default behaviour to return null for entries without doi's, which seems easier to handle to me. Reflecting I should probably just maintain the behaviour we currently have. Will also do this tomorrow.
![image](https://user-images.githubusercontent.com/6676843/125533877-2bd44fb5-9378-41f7-8035-9d3fdd91ec39.png)
