### PR TITLE
Hide paging controls if there is only one page

### DIFF
--- a/scholia/app/static/scholia.js
+++ b/scholia/app/static/scholia.js
@@ -182,6 +182,10 @@ function sparqlToDataTablePost(sparql, element, filename, options={}) {
             }
             columns.push(column)
         }
+	
+        if (convertedData.data.length <= 10) {
+          paging = false;
+        }
 
         var table = $(element).DataTable({
             data: convertedData.data,

--- a/scholia/app/static/scholia.js
+++ b/scholia/app/static/scholia.js
@@ -231,6 +231,10 @@ function sparqlToDataTable2(sparql, element, filename, options={}) {
             columns.push(column)
         }
 	
+        if (convertedData.data.length <= 10) {
+            paging = false;
+        }
+
         var table = $(element).DataTable({ 
             data: convertedData.data,
             columns: columns,


### PR DESCRIPTION
Controls that cannot be used are distracting

![image](https://user-images.githubusercontent.com/6676843/125921005-225e1297-57c0-44b0-8822-682fd35bb455.png)

