### PR TITLE
Python 2.7 and 3.5 are no longer supported by flask/pip and test with…

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [2.7, 3.5, 3.7]
+        python: [3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
… newer Python release instead

Error messages in GitHub actions:

```
flake8 installed: DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. pip 21.0 will drop support for Python 2.7 in January 2021.
```