### PR TITLE
Listen to all hosts 1327

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -7,7 +7,7 @@ ports:
 tasks:
 - before: |
     export FLASK_APP=runserver.py
-- init: >
+  init: >
     python -m pip install -r requirements.txt 
   command: >
-    flask run
+    flask run -p 8100

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -10,4 +10,4 @@ tasks:
   init: >
     python -m pip install -r requirements.txt 
   command: >
-    flask run -p 8100
+    flask run -h 0.0.0.0 -p 8100

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -5,7 +5,9 @@ ports:
 - port: 8100
   onOpen: open-preview
 tasks:
+- before: |
+    export FLASK_APP=runserver.py
 - init: >
     python -m pip install -r requirements.txt 
   command: >
-    python runserver.py
+    flask run

--- a/runserver.py
+++ b/runserver.py
@@ -7,4 +7,4 @@ app = create_app(
 app.config['APPLICATION_ROOT'] = '/'
 
 if __name__ == '__main__':
-    app.run(debug=True, port=8100, host='0.0.0.0')
+    app.run(debug=True, port=8100)


### PR DESCRIPTION
It solves the redirection to localhost problem using a host 0.0.0.0 inside gitpod.yaml when the server runs. Gitpod uses GitHub authentication by default and the port used are not exposed to all public. This would keep the environment isolated.