### PR TITLE
Added detection of taxons for creating buttons

### DIFF
--- a/scholia/app/templates/base.html
+++ b/scholia/app/templates/base.html
@@ -342,6 +342,8 @@ sparqlToIframe(`# tool: scholia
     UNION
     { wd:{{ q }} wdt:P235 [] . BIND("chemical" AS ?aspect) }
     UNION
+    { wd:{{ q }} wdt:P225 [] . BIND("taxon" AS ?aspect) }
+    UNION
     { wd:{{ q }} ^wdt:P31/wdt:P235 [] . BIND("chemical-class" AS ?aspect) }
     UNION
     { wd:{{ q }} wdt:P644 [] . BIND("gene" AS ?aspect) }


### PR DESCRIPTION
'Taxon' button is missing:

![image](https://user-images.githubusercontent.com/26721/126956960-23f59779-1466-46ed-b1cd-bd21774d187e.png)

And added by this PR:

![image](https://user-images.githubusercontent.com/26721/126956924-207fe19e-f1ce-40b0-a8c0-7e9936db15d6.png)

@carlinmack, when you think the patch is okay, add your reviewer decision, assign to Finn, and add the label 'ready for merge'.