### PR TITLE
Present 404.html for pages that don't exist

### DIFF
--- a/scholia/app/__init__.py
+++ b/scholia/app/__init__.py
@@ -40,7 +40,9 @@ def create_app(text_to_topic_q_text_enabled=True, third_parties_enabled=False):
     app.extensions['bootstrap']['cdns']['bootstrap'] = StaticCDN()
 
     from .views import main as main_blueprint
+    from .views import page_not_found
     app.register_blueprint(main_blueprint)
+    app.register_error_handler(404, page_not_found)
 
     app.text_to_topic_q_text_enabled = text_to_topic_q_text_enabled
     if text_to_topic_q_text_enabled:

--- a/scholia/app/templates/404.html
+++ b/scholia/app/templates/404.html
@@ -2,6 +2,11 @@
 
 {% block page_content %}
 
-Not found.
+<h1>Page not found</h1>
+
+<div class="text-center">
+  <a href="/search?q={{ request.path[1:] }}"
+    class="btn btn-primary">Search for "{{ request.path[1:] }}"</a>
+</div>
 
 {% endblock %}

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -2151,3 +2151,7 @@ def show_aspect_missing(aspect, q):
         return render_template(f'{aspect}_curation.html', q=q)
     except TemplateNotFound:
         return render_template("404.html")
+
+
+def page_not_found(e):
+    return render_template("404.html"), 404


### PR DESCRIPTION
Close #1536 

For the page https://scholia.toolforge.org/einstein

![image](https://user-images.githubusercontent.com/6676843/127028953-3f19a92d-85b5-46f4-8b47-dca8592a938a.png)

Had to add in __init__.py as you need to add the handler to the application level, not blueprint