### PR TITLE
Fix #1528: Python2 incompatible syntax

### DIFF
--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -2148,6 +2148,7 @@ def show_aspect_missing(aspect, q):
 
     """
     try:
-        return render_template(f'{aspect}_curation.html', q=q)
+        return render_template('{aspect}_curation.html'.format(aspect=aspect),
+                               q=q)
     except TemplateNotFound:
         return render_template("404.html")


### PR DESCRIPTION
A recent change introduced a Python3 syntax. This change
change it to a python2/3 compatible syntax.