### PR TITLE
Redirect to non-OAuth Author Disambiguator by default

### DIFF
--- a/scholia/app/templates/author_curation.html
+++ b/scholia/app/templates/author_curation.html
@@ -163,7 +163,7 @@ Missing information with respect to the author.
 <h2>Author name strings to be resolved</h2>
 
 The authorship may be represented as an author name string rather than a Wikidata item.
-To try to resolve the author name strings, follow the links below to use the Author disambiguator tool, which also has a <a href="https://author-disambiguator.toolforge.org/author_item_oauth.php?id={{ q }}">dedicated page for this author</a>.
+To try to resolve the author name strings, follow the links below to use the Author disambiguator tool, which also has a <a href="https://author-disambiguator.toolforge.org/author_item.php?id={{ q }}">dedicated page for this author</a>.
 
 <table class="table table-hover" id="missing-author-resolving"></table>
 


### PR DESCRIPTION
The user facing links should be changed to without-OAuth as author disambiguator has bad UX when you are not logged in

![image](https://user-images.githubusercontent.com/6676843/127349188-529a228e-c523-4b73-bd8a-2b48378402be.png)

Compare with 

![image](https://user-images.githubusercontent.com/6676843/127349341-bb8cfe55-406e-4aa7-bddb-df36afe45508.png)

Will remove draft status when I thoroughly check the other links 