### PR TITLE
Add links to curation pages

### DIFF
--- a/scholia/app/templates/base.html
+++ b/scholia/app/templates/base.html
@@ -87,9 +87,6 @@ sparqlToShortInchiKey(`# tool: scholia
 <script type="text/javascript" src="{{ url_for('static', filename='bootstrap-autocomplete.min.js')}}"></script>
 
 <script type="text/javascript">
-    var currentURL = window.location.pathname.split("/");
-    var currentAspect = currentURL[1];
-    
     {% if q %}
     var url = 'https://www.wikidata.org/w/api.php?action=wbgetentities&ids=' +
 	       '{{ q }}' + 
@@ -382,33 +379,18 @@ sparqlToShortInchiKey(`# tool: scholia
 	 }
 
      });
-	
-    var currentURL  = window.location.pathname.split("/")
+
+    var currentURL = window.location.pathname.split("/");
     var currentAspect = currentURL[1];
-
-	{% if q2 %}
-
-		var url2 = 'https://www.wikidata.org/w/api.php?action=wbgetentities&ids=' +
-				   '{{ q2 }}' +
-				   '&format=json&callback=?';
-		$.getJSON(url2, function (data) {
-			 var item = data.entities["{{ q2 }}"];
-			 if ('en' in item.labels) {
-				 $("#h1").append(' - '+item.labels.en.value);
-			 }
-			 $("#h1").append(' (<a href="https://www.wikidata.org/wiki/{{ q2 }}">{{ q2 }}</a>)');
-		});
-	{% endif %}
-
-    var curation = document.getElementById("curation-link");
+    var curationElement = document.getElementById("curation-link");
 
     if (currentURL[3] == "curation") {
-      curation.innerText = "Back"
-      curation.href = "/" + currentAspect + "/{{ q }}";
+      curationElement.innerText = "Back"
+      curationElement.href = "/" + currentAspect + "/{{ q }}";
     } else {
-      curation.href = "/" + currentAspect + "/{{ q }}/curation";
+      curationElement.href = "/" + currentAspect + "/{{ q }}/curation";
     }
-    curation.classList.remove("d-none");
+    curationElement.classList.remove("d-none");
 
      // this query opens the Wikidata item as a different aspect
      var endpointUrl = 'https://query.wikidata.org/sparql';

--- a/scholia/app/templates/base.html
+++ b/scholia/app/templates/base.html
@@ -87,6 +87,9 @@ sparqlToShortInchiKey(`# tool: scholia
 <script type="text/javascript" src="{{ url_for('static', filename='bootstrap-autocomplete.min.js')}}"></script>
 
 <script type="text/javascript">
+    var currentURL = window.location.pathname.split("/");
+    var currentAspect = currentURL[1];
+    
     {% if q %}
     var url = 'https://www.wikidata.org/w/api.php?action=wbgetentities&ids=' +
 	       '{{ q }}' + 
@@ -100,6 +103,7 @@ sparqlToShortInchiKey(`# tool: scholia
        $("title").text(title + " - Scholia");
 
 	     {% if request.path.endswith("curation") or request.path.endswith("curation/") %}
+	     $("#h1").text("Improve " + currentAspect + ": " + title);
 
 	     var linkedToFrom = "<p><a href='https://www.wikidata.org/w/index.php?hidecategorization=1&target={{ q }}&showlinkedto=1&limit=500&days=7&enhanced=1&title=Special:RecentChangesLinked&urlversion=2' >";
 	     linkedToFrom += "Recent changes to items that link <em>to</em> " + $('<div>').text(title).html() + "</a> and ";
@@ -381,19 +385,30 @@ sparqlToShortInchiKey(`# tool: scholia
 	
     var currentURL  = window.location.pathname.split("/")
     var currentAspect = currentURL[1];
-    var curation = document.getElementById("curation-link");
-    var validCurationPages = ["author", "award", "organization", "topic", "venue"]
 
-    // only show curation link if a curation page is defined
-    if (validCurationPages.indexOf(currentAspect) != -1) {
-      if (currentURL[3] == "curation") {
-        curation.innerText = "Back"
-        curation.href = "/" + currentAspect + "/{{ q }}";
-      } else {
-        curation.href = "/" + currentAspect + "/{{ q }}/curation";
-      }
-      curation.classList.remove("d-none");
+	{% if q2 %}
+
+		var url2 = 'https://www.wikidata.org/w/api.php?action=wbgetentities&ids=' +
+				   '{{ q2 }}' +
+				   '&format=json&callback=?';
+		$.getJSON(url2, function (data) {
+			 var item = data.entities["{{ q2 }}"];
+			 if ('en' in item.labels) {
+				 $("#h1").append(' - '+item.labels.en.value);
+			 }
+			 $("#h1").append(' (<a href="https://www.wikidata.org/wiki/{{ q2 }}">{{ q2 }}</a>)');
+		});
+	{% endif %}
+
+    var curation = document.getElementById("curation-link");
+
+    if (currentURL[3] == "curation") {
+      curation.innerText = "Back"
+      curation.href = "/" + currentAspect + "/{{ q }}";
+    } else {
+      curation.href = "/" + currentAspect + "/{{ q }}/curation";
     }
+    curation.classList.remove("d-none");
 
      // this query opens the Wikidata item as a different aspect
      var endpointUrl = 'https://query.wikidata.org/sparql';
@@ -500,7 +515,8 @@ sparqlToShortInchiKey(`# tool: scholia
         aspectDropdown.id = id;
         aspectDropdown.classList = 'btn btn-outline-secondary';
 
-        // Only show aspects which have a valid curation page
+        // only show aspects which have a curation page with author-disambig or wikidata links
+        var validCurationPages = ["author", "award", "organization", "topic", "venue"]
         if (currentURL[3] == "curation") {
           data.results.bindings = data.results.bindings.filter(elem => {
             return validCurationPages.indexOf(elem.aspect.value) != -1

--- a/scholia/app/templates/base.html
+++ b/scholia/app/templates/base.html
@@ -379,6 +379,17 @@ sparqlToShortInchiKey(`# tool: scholia
 
      });
 	
+    var currentURL  = window.location.pathname.split("/")
+    var currentAspect = currentURL[1];
+    var curation = document.getElementById("curation-link");
+    if (currentURL[3] == "curation") {
+      curation.innerText = "Back"
+      curation.href = "/" + currentAspect + "/{{ q }}";
+    } else {
+      curation.href = "/" + currentAspect + "/{{ q }}/curation";
+    }
+    curation.classList.remove("d-none");
+
      // this query opens the Wikidata item as a different aspect
      var endpointUrl = 'https://query.wikidata.org/sparql';
     if ("{{q2}}".length) {
@@ -872,7 +883,10 @@ sparqlToShortInchiKey(`# tool: scholia
 
 {% block content %}
 <div class="content">
-<div class="container dropdown" id="aspect-chooser">
+<div class="container d-flex justify-content-between">
+    <div class="dropdown" id="aspect-chooser">
+    </div>
+    <a id='curation-link' role="button" class="btn btn-outline-secondary d-none">Add missing info</a>
 </div>
 <div class="container">
     {% block page_content %}{% endblock %}

--- a/scholia/app/templates/base.html
+++ b/scholia/app/templates/base.html
@@ -91,6 +91,8 @@ sparqlToShortInchiKey(`# tool: scholia
     var url = 'https://www.wikidata.org/w/api.php?action=wbgetentities&ids=' +
 	       '{{ q }}' + 
 	       '&format=json&callback=?';
+    
+    const currentAspect = window.location.pathname.split("/")[1];
      
     $.getJSON(url, function (data) {
 	 var item = data.entities["{{ q }}"];
@@ -380,16 +382,14 @@ sparqlToShortInchiKey(`# tool: scholia
 
      });
 
-    var currentURL = window.location.pathname.split("/");
-    var currentAspect = currentURL[1];
     var curationElement = document.getElementById("curation-link");
 
-    if (currentURL[3] == "curation") {
+    {% if request.path.endswith("curation") or request.path.endswith("curation/") %}
       curationElement.innerText = "Back"
       curationElement.href = "/" + currentAspect + "/{{ q }}";
-    } else {
+    {% else %}
       curationElement.href = "/" + currentAspect + "/{{ q }}/curation";
-    }
+    {% endif %}
     curationElement.classList.remove("d-none");
 
      // this query opens the Wikidata item as a different aspect
@@ -457,7 +457,6 @@ sparqlToShortInchiKey(`# tool: scholia
      };
      
       $.ajax(endpointUrl, settings).then(function (data) {
-        var currentAspect = window.location.pathname.split("/")[1];
         createDropdownButton("aspect-chooser", 'aspectMenuButton', currentAspect, data, "{{q}}")
 
         if (data.results.bindings.length > 1) {
@@ -475,7 +474,6 @@ sparqlToShortInchiKey(`# tool: scholia
           };
 
           $.ajax(endpointUrl, settings).then(function (data) {
-            var currentAspect = window.location.pathname.split("/")[1];
             var aspectLabel = " / <a href='/" + currentAspect + "/{{q}}'>{{q}}</a> / "   
             document.getElementById("aspect-chooser-label").innerHTML = aspectLabel;
 
@@ -499,11 +497,11 @@ sparqlToShortInchiKey(`# tool: scholia
 
         // only show aspects which have a curation page with author-disambig or wikidata links
         var validCurationPages = ["author", "award", "organization", "topic", "venue"]
-        if (currentURL[3] == "curation") {
+        {% if request.path.endswith("curation") or request.path.endswith("curation/") %}
           data.results.bindings = data.results.bindings.filter(elem => {
             return validCurationPages.indexOf(elem.aspect.value) != -1
           })
-        }
+        {% endif %}
 
         if (data.results.bindings.length > 1) {
           aspectDropdown.classList.add('dropdown-toggle');
@@ -530,9 +528,9 @@ sparqlToShortInchiKey(`# tool: scholia
             var dropdownItem = document.createElement('a');
             dropdownItem.classList = 'dropdown-item';
             dropdownItem.href = "{{ url_for('app.index') }}" + aspect + '/{{ q }}';
-            if (currentURL[3] == "curation") {
+            {% if request.path.endswith("curation") or request.path.endswith("curation/") %}
               dropdownItem.href += "/curation"
-            }
+            {% endif %}
             dropdownItem.innerText = aspect;
             aspectDropdownMenu.append(dropdownItem);
           }

--- a/scholia/app/templates/base.html
+++ b/scholia/app/templates/base.html
@@ -902,7 +902,7 @@ sparqlToShortInchiKey(`# tool: scholia
 <div class="container d-flex justify-content-between">
     <div class="dropdown" id="aspect-chooser">
     </div>
-    <a id='curation-link' role="button" class="btn btn-outline-secondary d-none">Add missing info</a>
+    <a id='curation-link' role="button" class="btn btn-outline-secondary d-none">Improve data</a>
 </div>
 <div class="container">
     {% block page_content %}{% endblock %}

--- a/scholia/app/templates/base.html
+++ b/scholia/app/templates/base.html
@@ -382,13 +382,18 @@ sparqlToShortInchiKey(`# tool: scholia
     var currentURL  = window.location.pathname.split("/")
     var currentAspect = currentURL[1];
     var curation = document.getElementById("curation-link");
-    if (currentURL[3] == "curation") {
-      curation.innerText = "Back"
-      curation.href = "/" + currentAspect + "/{{ q }}";
-    } else {
-      curation.href = "/" + currentAspect + "/{{ q }}/curation";
+    var validCurationPages = ["author", "award", "organization", "topic", "venue"]
+
+    // only show curation link if a curation page is defined
+    if (validCurationPages.indexOf(currentAspect) != -1) {
+      if (currentURL[3] == "curation") {
+        curation.innerText = "Back"
+        curation.href = "/" + currentAspect + "/{{ q }}";
+      } else {
+        curation.href = "/" + currentAspect + "/{{ q }}/curation";
+      }
+      curation.classList.remove("d-none");
     }
-    curation.classList.remove("d-none");
 
      // this query opens the Wikidata item as a different aspect
      var endpointUrl = 'https://query.wikidata.org/sparql';
@@ -494,6 +499,14 @@ sparqlToShortInchiKey(`# tool: scholia
         aspectDropdown.type = 'button';
         aspectDropdown.id = id;
         aspectDropdown.classList = 'btn btn-outline-secondary';
+
+        // Only show aspects which have a valid curation page
+        if (currentURL[3] == "curation") {
+          data.results.bindings = data.results.bindings.filter(elem => {
+            return validCurationPages.indexOf(elem.aspect.value) != -1
+          })
+        }
+
         if (data.results.bindings.length > 1) {
           aspectDropdown.classList.add('dropdown-toggle');
           aspectDropdown.setAttribute('data-toggle', 'dropdown');
@@ -519,6 +532,9 @@ sparqlToShortInchiKey(`# tool: scholia
             var dropdownItem = document.createElement('a');
             dropdownItem.classList = 'dropdown-item';
             dropdownItem.href = "{{ url_for('app.index') }}" + aspect + '/{{ q }}';
+            if (currentURL[3] == "curation") {
+              dropdownItem.href += "/curation"
+            }
             dropdownItem.innerText = aspect;
             aspectDropdownMenu.append(dropdownItem);
           }


### PR DESCRIPTION
2nd half of closing #1322 
Close #1122 

This PR adds a link to the curation page for all Q number pages. 

![image](https://user-images.githubusercontent.com/6676843/127559697-8ac8d2b0-df3a-4685-8d78-d0400f6664a5.png)

This PR relies on #1552 as the curation aspect chooser is filtered based upon whether there is a useful curation page for that aspect. On this curation page, the aspect chooser is filtered of the aspects which don't have curation page templates:

![image](https://user-images.githubusercontent.com/6676843/127652158-264ff588-3555-4dc8-bdd5-e3ae9786cce6.png)

----

I'm happy with this PR now, text below preserved for reference

---

This needs some iteration/discussion before it's ready, due to design choices etc.

The position was chosen as users are accustomed to finding edit controls in the top right of the page. 

In terms of the text:

* "Edit" would have to direct the user to Wikidata, which would be odd
* "Curate" does make sense if you have the right mental model, but would be initially confusing to the user (especially with the current page, more on this below). 
* "Add more info" is clearer, but not ideal
* I've gone with "Improve data" as this doesn't have the connotation of directly editing

I have no comment on what the URL of the curation pages should be, I do prefer "curation" to "missing" 


> In terms of the curation page itself, I think it needs some work, definitely in regards to #374. As far as I can tell, this page largely functions to provide quick access to (hopefully) fruitful Author Disambiguator pages and Wikidata pages that have missing properties. As a user I would expect this page to provide some context of where information comes from, where it can be added, what tools are available, and _then_ links to pages on these tools.

> If we take the user story "As an academic, I want to add a notable paper to an academic's page, so that the Scholia profile is more complete", there is no direction for the best way to do something like this, and what tools are available to do this. 

> There is currently a hardcoded list of valid aspects for curation, but if we can close #281 then we do not need this.

> I will work on a prototype of this in another PR :)

PR has been created