### PR TITLE
Add curation pages for all aspects

### DIFF
--- a/scholia/app/templates/author_curation.html
+++ b/scholia/app/templates/author_curation.html
@@ -54,8 +54,8 @@ the authors.
 
 {% block wikidata %}
 
-<p>For example, here are authored works by {{q}} that do not have topics. You can improve the data by clicking the link
-  on the right, scrolling to "+ add statement" and adding a "main subject" if you know it:</p>
+<p>For example, here are works authored by {{q}} that do not have topics listed in Wikidata. You can improve the data by clicking the link
+  on the right, scrolling to "+ add statement" and adding a <a href="https://www.wikidata.org/wiki/Property:P921">"main subject" (P921)</a> if you know it:</p>
 
 <table class="table table-hover" id="missing-topic-table"></table>
 

--- a/scholia/app/templates/author_curation.html
+++ b/scholia/app/templates/author_curation.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "q_curation.html" %}
 
 {% set aspect = "author-curation" %}
 
@@ -20,13 +20,7 @@
 {% endblock %}
 
 
-
-{% block page_content %}
-
-<h1 id="h1">Author</h1>
-
-Missing information with respect to the author.
-
+{% block author_disambiguator %}
 
 <h2 id="missing-author-resolving-header">Author name strings to be resolved</h2>
 
@@ -55,11 +49,16 @@ the authors.
 
 <table class="table table-hover" id="missing-citing-author-items-table"></table>
 
+{% endblock %}
 
-<h2 id="missing-topic-header">Authored works with missing topics</h2>
+
+{% block wikidata %}
+
+<p>For example, here are authored works by {{q}} that do not have topics. You can improve the data by clicking the link
+  on the right, scrolling to "+ add statement" and adding a "main subject" if you know it:</p>
 
 <table class="table table-hover" id="missing-topic-table"></table>
 
-
+<hr>
 
 {% endblock %}

--- a/scholia/app/templates/award_curation.html
+++ b/scholia/app/templates/award_curation.html
@@ -36,7 +36,7 @@ the authors.
 
 {% block wikidata %}
 
-<p>For example, here are authored works by {{q}} that do not have topics. You can improve the data by clicking the link
+<p>For example, here are works by winners of {{q}} that do not have topics. You can improve the data by clicking the link
   on the right, scrolling to "+ add statement" and adding a "main subject" if you know it:</p>
 
 <table class="table table-hover" id="missing-topics-table"></table>

--- a/scholia/app/templates/award_curation.html
+++ b/scholia/app/templates/award_curation.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "q_curation.html" %}
 
 {% set aspect = "award-curation" %}
 
@@ -10,13 +10,7 @@
 
 {% endblock %}
 
-{% block page_content %}
-
-<h1 id="h1">Award</h1>
-
-Missing information with respect to the award.
-
-
+{% block author_disambiguator %}
 
   <h2 id="missing-author-items-header">Missing author items</h2>
 
@@ -37,12 +31,16 @@ the authors.
 
 <table class="table table-hover" id="missing-coauthor-items-table"></table>
 
-  <h2 id="missing-topics-header">Missing topics</h2>
+{% endblock %}
 
-The works listed below do not currently have statements about their main subjects.
+
+{% block wikidata %}
+
+<p>For example, here are authored works by {{q}} that do not have topics. You can improve the data by clicking the link
+  on the right, scrolling to "+ add statement" and adding a "main subject" if you know it:</p>
 
 <table class="table table-hover" id="missing-topics-table"></table>
 
-
+<hr>
 
 {% endblock %}

--- a/scholia/app/templates/organization_curation.html
+++ b/scholia/app/templates/organization_curation.html
@@ -1,5 +1,4 @@
-{% extends "base.html" %}
-
+{% extends "q_curation.html" %}
 
 {% set aspect = "organization_missing" %}
 
@@ -12,11 +11,7 @@
 {% endblock %}
 
 
-{% block page_content %}
-
-<h1 id="h1">Organization</h1>
-
-Missing information with respect to the organization.
+{% block author_disambiguator %}
 
 <h2 id="authors-header">Missing author items</h2>
 

--- a/scholia/app/templates/q_curation.html
+++ b/scholia/app/templates/q_curation.html
@@ -7,7 +7,7 @@
 <p>Our data source is <a href="https://www.wikidata.org/wiki/Wikidata:Main_Page">Wikidata</a>, a structured data project
   similar to the encyclopedia project Wikipedia. Each item is identified by a Q number, and information can be added
   directly to an item's page (in this case, <a
-    href='https://www.wikidata.com/{{q}}'>https://www.wikidata.com/{{q}}</a>). Some information however, like an
+    href='https://www.wikidata.org/{{q}}'>https://www.wikidata.org/{{q}}</a>). Some information however, like an
   author's papers, are stored on the item for the paper itself. The "<a
     href="https://www.wikidata.org/w/index.php?title=Special%3AWhatLinksHere&target{{q}}&namespace=0">What links
     here</a>" link in the sidebar of an item can show these items.</p>
@@ -21,8 +21,8 @@
   can make editing Wikidata quicker and more rigorous.</p>
 
 {% if self.author_disambiguator() %}
-<p>Most importantly for Scholia is the <a href="https://author-disambiguator.toolforge.org">Author
-    Disambiguator</a>, which can be used to quickly create new authors and find
+<p>Most important for Scholia is the <a href="https://author-disambiguator.toolforge.org">Author
+    Disambiguator</a>, which can be used to quickly create new dedicated items for authors and find
   existing papers which do not link to the author. In the tables below, you can see
   how many results there are per author, and use the "author-disambiguator" link to add information for them.</p>
 {% endif %}

--- a/scholia/app/templates/q_curation.html
+++ b/scholia/app/templates/q_curation.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+
+{% block page_content %}
+
+<h1 id="h1">Improve...</h1>
+
+<p>Our data source is <a href="https://www.wikidata.org/wiki/Wikidata:Main_Page">Wikidata</a>, a structured data project
+  similar to the encyclopedia project Wikipedia. Each item is identified by a Q number, and information can be added
+  directly to an item's page (in this case, <a
+    href='https://www.wikidata.com/{{q}}'>https://www.wikidata.com/{{q}}</a>). Some information however, like an
+  author's papers, are stored on the item for the paper itself. The "<a
+    href="https://www.wikidata.org/w/index.php?title=Special%3AWhatLinksHere&target{{q}}&namespace=0">What links
+    here</a>" link in the sidebar of an item can show these items.</p>
+
+{% if self.wikidata() %}
+{% endif %}
+
+{% block wikidata %}{% endblock %}
+
+<p>There are also various <a href="https://www.wikidata.org/wiki/Wikidata:Tools/Edit_items">tools</a> available which
+  can make editing Wikidata quicker and more rigorous.</p>
+
+{% if self.author_disambiguator() %}
+<p>Most importantly for Scholia is the <a href="https://author-disambiguator.toolforge.org">Author
+    Disambiguator</a>, which can be used to quickly create new authors and find
+  existing papers which do not link to the author. In the tables below, you can see
+  how many results there are per author, and use the "author-disambiguator" link to add information for them.</p>
+{% endif %}
+
+{% block author_disambiguator %}{% endblock %}
+
+{% endblock %}

--- a/scholia/app/templates/topic_curation.html
+++ b/scholia/app/templates/topic_curation.html
@@ -45,7 +45,7 @@ The following works have only been tagged with this one topic.
 {% block wikidata %}
 
 <p>For example, here are works with this topic that do not have a <b>publication venue</b>. You can improve the data by clicking the link
-  on the right and adding a "published in" statement if you know it:</p>
+  on the right and adding a <a href="https://www.wikidata.org/wiki/Property:P1433">"published in" (P1433)</a> statement if you know it:</p>
 
 <table class="table table-hover" id="missing-pub-venue-table"></table>
 

--- a/scholia/app/templates/topic_curation.html
+++ b/scholia/app/templates/topic_curation.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "q_curation.html" %}
 
 {% set aspect = "topic-curation" %}
 
@@ -24,12 +24,7 @@
 
 {% endblock %}
 
-{% block page_content %}
-
-<h1 id="h1">Topic </h1>
-
-Missing information with respect to the topic <a href="{{ url_for('app.show_topic_empty') }}{{ q }}">{{ q }}</a>.
-
+{% block author_disambiguator %}
 
 <h2 id="missing-author-items-header">Missing author items</h2>
 
@@ -40,21 +35,26 @@ the authors.
 
 <table class="table table-hover" id="missing-author-items-table"></table>
 
-<h2 id="missing-pub-date-header">Missing publication date</h2>
-
-For the listed publications, Wikidata does not have publication dates.
-<table class="table table-hover" id="missing-pub-date-table"></table>
-
-
-<h2 id="missing-pub-venue-header">Missing publication venue</h2>
-
-For the listed publications, Wikidata does not have a statement as to where they were published.
-<table class="table table-hover" id="missing-pub-venue-table"></table>
-
-
 <h2 id="missing-co-topic-header">Works on the topic with missing additional topics</h2>
 
 The following works have only been tagged with this one topic.
 <table class="table table-hover" id="missing-co-topic-table"></table>
+
+{% endblock %}
+
+{% block wikidata %}
+
+<p>For example, here are works with this topic that do not have a <b>publication venue</b>. You can improve the data by clicking the link
+  on the right and adding a "published in" statement if you know it:</p>
+
+<table class="table table-hover" id="missing-pub-venue-table"></table>
+
+<hr> 
+
+These works are missing a <b>publication date</b>.
+
+<table class="table table-hover" id="missing-pub-date-table"></table>
+
+<hr>
 
 {% endblock %}

--- a/scholia/app/templates/venue_curation.html
+++ b/scholia/app/templates/venue_curation.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "q_curation.html" %}
 
 
 {% set aspect = "venue-curation" %}
@@ -15,8 +15,7 @@
 {% endblock %}
 
 
-{% block page_content %}
-<h1 id="h1">Venue</h1>
+{% block author_disambiguator %}
 
 <h2 id="missing-author-item-header">Missing author item</h2>
 
@@ -26,12 +25,14 @@ Follow the link to use the Author disambiguator tool to try to create links betw
 
 <table class="table table-hover" id="missing-author-item-table"></table>
 
-<h2 id="missing-topics-header">Missing topics</h2>
+{% endblock %}
 
-The following highly cited articles have few or no "main subject" statements.
+{% block wikidata %}
+
+<p>For example, here are authored works by {{q}} that have few or no main topics. You can improve the data by clicking the link
+  on the right and adding a "main subject" statement if you know it:</p>
 
 <table class="table table-hover" id="missing-topics-table"></table>
 
-
+<hr>
 {% endblock %}
-    

--- a/scholia/app/templates/venue_curation.html
+++ b/scholia/app/templates/venue_curation.html
@@ -29,8 +29,8 @@ Follow the link to use the Author disambiguator tool to try to create links betw
 
 {% block wikidata %}
 
-<p>For example, here are authored works by {{q}} that have few or no main topics. You can improve the data by clicking the link
-  on the right and adding a "main subject" statement if you know it:</p>
+<p>For example, here are works authored by {{q}} that have few or no main topics. You can improve the data by clicking the link
+  on the right and adding a <a href="https://www.wikidata.org/wiki/Property:P921">"main subject" (P921)</a> statement if you know it:</p>
 
 <table class="table table-hover" id="missing-topics-table"></table>
 

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -2151,4 +2151,4 @@ def show_aspect_missing(aspect, q):
         return render_template('{aspect}_curation.html'.format(aspect=aspect),
                                q=q)
     except TemplateNotFound:
-        return render_template("404.html")
+        return render_template('q_curation.html', q=q, aspect=aspect)


### PR DESCRIPTION
Close #281 . Working towards closing #374

Based on what I wrote in #1556, I've improved the curation pages and added pages for all aspects

Before and after where there is an existing curation page for aspect:

![image](https://user-images.githubusercontent.com/6676843/127651783-28c93133-9ac3-45e2-95de-72a92de4c560.png)

Before and after where there is __not__ an existing curation page for aspect:

![image](https://user-images.githubusercontent.com/6676843/127651834-4947c9e5-1742-460c-8bcd-32e67b09f2f1.png)
