### PR TITLE
Add loading animations for tables

### DIFF
--- a/scholia/app/static/css/scholia.css
+++ b/scholia/app/static/css/scholia.css
@@ -105,5 +105,51 @@ h3 {
 
 .table-of-contents {
     margin: 1rem;
+}
 
+.loader {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.loader div {
+    display: inline-block;
+    box-sizing: border-box;
+    height: 40px;
+    width: 40px;
+    margin: 0 0.5rem;
+    border-width: 11px;
+    border-style: solid;
+    border-color: #09af8a;
+    animation-name: scholia;
+    animation-duration: 3s;
+    animation-timing-function: ease;
+    animation-iteration-count: infinite;
+}
+
+.loader div:nth-child(1) {
+    animation-delay: 0s;
+}
+
+.loader div:nth-child(2) {
+    animation-delay: 1s;
+}
+
+.loader div:nth-child(3) {
+    animation-delay: 2s;
+}
+
+@keyframes scholia {
+    33% {
+        border-color: #de3030;
+    }
+
+    66% {
+        border-color: #506aa7;
+    }
+
+    99% {
+        border-color: #09af8a;
+    }
 }

--- a/scholia/app/static/css/scholia.css
+++ b/scholia/app/static/css/scholia.css
@@ -111,6 +111,8 @@ h3 {
     display: flex;
     align-items: center;
     justify-content: center;
+    margin-top: 1rem;
+    margin-bottom: 1rem;
 }
 
 .loader div {

--- a/scholia/app/static/scholia.js
+++ b/scholia/app/static/scholia.js
@@ -150,6 +150,8 @@ function sparqlToDataTablePost(sparql, element, filename, options = {}) {
     var sDom = (typeof options.sDom === 'undefined') ? 'lfrtip' : options.sDom;
     var url = "https://query.wikidata.org/sparql";
 
+    $(element).html("<div class='loader'><div></div><div></div><div></div></div>");
+
     $.post(url, data = { query: sparql }, function (response, textStatus) {
         var simpleData = sparqlDataToSimpleData(response);
 
@@ -167,6 +169,8 @@ function sparqlToDataTablePost(sparql, element, filename, options = {}) {
         if (convertedData.data.length <= 10) {
           paging = false;
         }
+
+        $(element).html('');
 
         var table = $(element).DataTable({
             data: convertedData.data,

--- a/scholia/app/static/scholia.js
+++ b/scholia/app/static/scholia.js
@@ -200,6 +200,8 @@ function sparqlToDataTable(sparql, element, filename, options = {}) {
     var url = "https://query.wikidata.org/sparql?query=" +
         encodeURIComponent(sparql) + '&format=json';
 
+    $(element).html("<div class='loader'><div></div><div></div><div></div></div>")
+
     $.getJSON(url, function (response) {
         var simpleData = sparqlDataToSimpleData(response);
 
@@ -229,6 +231,8 @@ function sparqlToDataTable(sparql, element, filename, options = {}) {
         if (convertedData.data.length <= 10) {
             paging = false;
         }
+
+        $(element).html("");
 
         var table = $(element).DataTable({ 
             data: convertedData.data,


### PR DESCRIPTION
Close #1574. Loaders added for all DataTables

Animation looks like this https://codepen.io/carlinmack/pen/ZEKmoYr

Before
![image](https://user-images.githubusercontent.com/6676843/128694844-8d5279c5-ef40-4132-87d2-8280f1fc2504.png)

After
![image](https://user-images.githubusercontent.com/6676843/128694850-5530624e-8d3d-46ef-b81f-f5f232883c53.png)

----

Before
![image](https://user-images.githubusercontent.com/6676843/128701013-10d096ff-5560-4f3e-b119-66952a13f343.png)

After

![image](https://user-images.githubusercontent.com/6676843/128700869-bbce0c29-2731-4041-aee3-cedea57f97bb.png)
