### PR TITLE
Remove "-header" from IDs

### DIFF
--- a/scholia/app/templates/author.html
+++ b/scholia/app/templates/author.html
@@ -45,7 +45,7 @@
 
 <div id="details"></div>
 
-<h2 id="list-of-publications-header">List of publications <a href="{{ url_for('app.show_author_index') }}{{ q }}/latest-works/rss"><img height="24" width="48" src="{{ url_for('static', filename='images/rss-40674_320.png') }}" alt="RSS icon" /></a></h2>
+<h2 id="list-of-publications">List of publications <a href="{{ url_for('app.show_author_index') }}{{ q }}/latest-works/rss"><img height="24" width="48" src="{{ url_for('static', filename='images/rss-40674_320.png') }}" alt="RSS icon" /></a></h2>
 
 <table class="table table-hover" id="list-of-publications-table"></table>
 
@@ -67,14 +67,14 @@ div>
 </div -->
 
 
-<h3 id="publications-per-year-header">Number of publications per year</h3>
+<h3 id="publications-per-year">Number of publications per year</h3>
 
 <div class="embed-responsive embed-responsive-16by9">
     <iframe class="embed-responsive-item" id="publications-per-year-iframe"></iframe>
 </div>
 
 
-<h3 id="pages-per-year-header">Number of pages per year</h3>
+<h3 id="pages-per-year">Number of pages per year</h3>
 
 (Only articles with number of pages set are displayed)
 
@@ -85,7 +85,7 @@ div>
 <h2>Topics</h2>
 
 
-<h3 id="topic-scores-header">Topic scores</h3>
+<h3 id="topic-scores">Topic scores</h3>
 
 Topics based on a weighting between fields of work,
 topics of authored works and topics of citing works.  
@@ -95,7 +95,7 @@ topics of authored works and topics of citing works.
 </div>
 
 
-<h3 id="topics-header">Topics of authored works</h3>
+<h3 id="topics">Topics of authored works</h3>
 
 <table class="table table-hover" id="topics-table"></table>
 
@@ -104,7 +104,7 @@ topics of authored works and topics of citing works.
 <div id="topics-works-matrix"></div>
 
 
-<h2 id="venue-statistics-header">Venue statistics</h2>
+<h2 id="venue-statistics">Venue statistics</h2>
 
 <div class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" id="venue-statistics-chart-iframe"></iframe>
@@ -112,11 +112,11 @@ topics of authored works and topics of citing works.
 
 <table class="table table-hover" id="venue-statistics-table"></table>
 
-<h2 id="review-statistics-header">Review statistics</h2>
+<h2 id="review-statistics">Review statistics</h2>
 <p>This author has reviewed for the following journals.</p>
 <table class="table table-hover" id="review-statistics-table"></table>
 
-<h2 id="coauthors-header" data-toogle="tooltip" title="Co-author graph for the author (up to 1000 links)">Co-author graph</h2>
+<h2 id="coauthors" data-toogle="tooltip" title="Co-author graph for the author (up to 1000 links)">Co-author graph</h2>
 
 <div class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" id="coauthors-iframe"></iframe>
@@ -124,28 +124,28 @@ topics of authored works and topics of citing works.
 
 Are co-authors missing here? You can help curate them via the <a href="{{ url_for('app.show_author_index') }}{{ q }}/curation">curation</a> page.
 
-<h2 id="coauthor-map-header">Co-author map</h2>
+<h2 id="coauthor-map">Co-author map</h2>
 
 <div class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" id="coauthor-map-iframe"></iframe>
 </div>
 
 
-<h2 id="other-locations-header">Other locations</h2>
+<h2 id="other-locations">Other locations</h2>
 
 <div class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" id="other-locations-iframe"></iframe>
 </div>
 
 
-<h2 id="timeline-header">Timeline</h2>
+<h2 id="timeline">Timeline</h2>
 
 
 <div class="embed-responsive embed-responsive-16by9">
     <iframe class="embed-responsive-item" id="timeline-iframe"></iframe>
 </div>
 
-<h2 id="academic-tree-header">Academic tree</h2>
+<h2 id="academic-tree">Academic tree</h2>
 
 <div class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" id="academic-tree-iframe"></iframe>
@@ -154,21 +154,21 @@ Are co-authors missing here? You can help curate them via the <a href="{{ url_fo
 
 <h2>Citation statistics</h2>
 
-<h3 id="most-cited-works-header">Most cited works</h3>
+<h3 id="most-cited-works">Most cited works</h3>
 
 Works of the author ordered according to number of citations received.
 
 <table class="table table-hover" id="most-cited-works-table"></table>
 
 
-<h3 id="citations-by-year-header">Citations by year</h3>
+<h3 id="citations-by-year">Citations by year</h3>
 
 <div class="embed-responsive embed-responsive-16by9">
     <iframe class="embed-responsive-item" id="citations-by-year-iframe"></iframe>
 </div>
 
 
-<h3 id="most-citing-authors-header">Citing authors</h3>
+<h3 id="most-citing-authors">Citing authors</h3>
 
 Authors that cite the author (excluding self citations).
 
@@ -176,14 +176,14 @@ Authors that cite the author (excluding self citations).
 
 Are citing authors missing here? You can help curate them via the <a href="{{ url_for('app.show_author_index') }}{{ q }}/curation">curation</a> page.
 
-<h2 id="associated-images-header">Associated images</h2>
+<h2 id="associated-images">Associated images</h2>
 
 <div class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" id="associated-images-iframe"></iframe>
 </div>
 
 
-<h2 id="events-header">Events</h2>
+<h2 id="events">Events</h2>
 
 Conferences, workshops and other events the author has attended or otherwise been associated with.
 

--- a/scholia/app/templates/author_curation.html
+++ b/scholia/app/templates/author_curation.html
@@ -28,7 +28,7 @@
 Missing information with respect to the author.
 
 
-<h2 id="missing-author-resolving-header">Author name strings to be resolved</h2>
+<h2 id="missing-author-resolving">Author name strings to be resolved</h2>
 
 The authorship may be represented as an author name string rather than a Wikidata item.
 To try to resolve the author name strings, follow the links below to use the Author disambiguator tool, which also has a <a href="https://author-disambiguator.toolforge.org/author_item_oauth.php?id={{ q }}">dedicated page for this author</a>.
@@ -36,7 +36,7 @@ To try to resolve the author name strings, follow the links below to use the Aut
 <table class="table table-hover" id="missing-author-resolving-table"></table>
 
 
-<h2 id="missing-coauthor-items-header">Missing coauthor items</h2>
+<h2 id="missing-coauthor-items">Missing coauthor items</h2>
 
 The coauthors listed below may only be represented as strings in Wikidata
 with no link to Wikidata items.
@@ -46,7 +46,7 @@ the authors.
 <table class="table table-hover" id="missing-coauthor-items-table"></table>
 
 
-<h2 id="missing-citing-author-items-header">Missing citing author items</h2>
+<h2 id="missing-citing-author-items">Missing citing author items</h2>
 
 The citing authors below are only represented as strings in Wikidata and not linked to
 Wikidata items.
@@ -56,7 +56,7 @@ the authors.
 <table class="table table-hover" id="missing-citing-author-items-table"></table>
 
 
-<h2 id="missing-topic-header">Authored works with missing topics</h2>
+<h2 id="missing-topic">Authored works with missing topics</h2>
 
 <table class="table table-hover" id="missing-topic-table"></table>
 

--- a/scholia/app/templates/authors.html
+++ b/scholia/app/templates/authors.html
@@ -23,11 +23,11 @@
 <table class="table table-hover" id="list-of-authors-table"></table>
 
 
-<h2 id="list-of-jointly-authored-works-header">List of jointly authored works</h2>
+<h2 id="list-of-jointly-authored-works">List of jointly authored works</h2>
 
 <table class="table table-hover" id="list-of-jointly-authored-works-table"></table>
 
-<h2 id="works-per-publication-year-header">Number of works per publication year</h2>
+<h2 id="works-per-publication-year">Number of works per publication year</h2>
 
 <div class="embed-responsive embed-responsive-16by9">
     <iframe class="embed-responsive-item" id="works-per-publication-year-iframe"></iframe>
@@ -35,14 +35,14 @@
 
 
 
-<h2 id="citations-per-publication-year-header">Number of citations per publication year</h2>
+<h2 id="citations-per-publication-year">Number of citations per publication year</h2>
 
 <div class="embed-responsive embed-responsive-16by9">
     <iframe class="embed-responsive-item" id="citations-per-publication-year-iframe"></iframe>
 </div>
 
 
-<h2 id="co-author-header">Co-author graph</h2>
+<h2 id="co-author">Co-author graph</h2>
 
 <div class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" id="co-author-iframe"></iframe>

--- a/scholia/app/templates/award_curation.html
+++ b/scholia/app/templates/award_curation.html
@@ -18,7 +18,7 @@ Missing information with respect to the award.
 
 
 
-  <h2 id="missing-author-items-header">Missing author items</h2>
+  <h2 id="missing-author-items">Missing author items</h2>
 
 The authors listed below may only be represented as strings in Wikidata
 with no link to Wikidata items.
@@ -28,7 +28,7 @@ the authors.
 <table class="table table-hover" id="missing-author-items-table"></table>
 
 
-  <h2 id="missing-coauthor-items-header">Missing coauthor items</h2>
+  <h2 id="missing-coauthor-items">Missing coauthor items</h2>
 
 The coauthors listed below may only be represented as strings in Wikidata
 with no link to Wikidata items.
@@ -37,7 +37,7 @@ the authors.
 
 <table class="table table-hover" id="missing-coauthor-items-table"></table>
 
-  <h2 id="missing-topics-header">Missing topics</h2>
+  <h2 id="missing-topics">Missing topics</h2>
 
 The works listed below do not currently have statements about their main subjects.
 

--- a/scholia/app/templates/award_empty.html
+++ b/scholia/app/templates/award_empty.html
@@ -32,7 +32,7 @@ Awards, prizes.
 
 <h2>Aggregates</h2>
 
-<h3 id="statistics-header">Male-female statistics</h3>
+<h3 id="statistics">Male-female statistics</h3>
 
 <div class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" id="statistics-iframe"></iframe>

--- a/scholia/app/templates/base.html
+++ b/scholia/app/templates/base.html
@@ -549,16 +549,6 @@ sparqlToShortInchiKey(`# tool: scholia
          }
      });
 
-     // Add anchor links to all headings
-     var headers = document.querySelectorAll('h2[id], h3[id]')
-     if (headers) {
-       headers.forEach(element => {
-         var title = element.innerText;
-         element.removeChild(element.childNodes[0])
-         element.insertAdjacentHTML('afterbegin', `<a href="#${element.id}" class="hlink"  ariaLabel="Anchor">${title}</a>`)
-       })
-     }
-
      // Add table of content
   var headings = document.querySelectorAll("h2,h3");
   if (headings.length >= 4) {
@@ -574,7 +564,7 @@ sparqlToShortInchiKey(`# tool: scholia
     for (let i = 0; i < headings.length; i++) {
       const element = headings[i];
       if (!element.id) {
-        element.id = element.innerText.replace(" ", "-")
+        element.id = element.innerText.replaceAll(" ", "-");
       }
       if (element.tagName === "H3" && !sublist) {
         var sublist = document.createElement("ul");
@@ -602,6 +592,15 @@ sparqlToShortInchiKey(`# tool: scholia
     document.querySelector("h2").insertAdjacentElement("beforebegin", toc)
   }
 
+    // Add anchor links to all headings
+    var headers = document.querySelectorAll('h2[id], h3[id]')
+    if (headers) {
+      headers.forEach(element => {
+        var title = element.innerText;
+        element.removeChild(element.childNodes[0])
+        element.insertAdjacentHTML('afterbegin', `<a href="#${element.id}" class="hlink"  ariaLabel="Anchor">${title}</a>`)
+      })
+    }
 
      {% block in_ready %}{% endblock %}
  });

--- a/scholia/app/templates/catalogue.html
+++ b/scholia/app/templates/catalogue.html
@@ -17,12 +17,12 @@
 <div id="intro"></div>
 
 
-<h2 id="items-header">Items in catalogue</h2>
+<h2 id="items">Items in catalogue</h2>
 
 <table class="table table-hover" id="items-table"></table>
 
 
-<h2 id="images-header">Images</h2>
+<h2 id="images">Images</h2>
 
 <div class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" id="images-iframe"></iframe>

--- a/scholia/app/templates/chemical-index-curation.html
+++ b/scholia/app/templates/chemical-index-curation.html
@@ -35,7 +35,7 @@ The following links prioritize chemical compounds that are listed in most Wikis
 (Wikipedias, Wikimedia Commons, etc). To go to the Wikidata page for each item, click its name
 below, which will lead to its Scholia page which links to the Wikidata page via the <a href="https://www.wikidata.org/wiki/Wikidata:Glossary">Q number</a> link at the top.
 
-<h2 id="missing-boiling-points-header">Missing Boiling Points</h2>
+<h2 id="missing-boiling-points">Missing Boiling Points</h2>
 
 The <a href="https://www.wikidata.org/wiki/Property:P2102">boiling point</a> is the temperature
 at which boiling occurs under a pressure of one bar.
@@ -47,7 +47,7 @@ it depends on the pressure, this is often also given, as shown in
 
 <table class="table table-hover" id="missing-boiling-points-table"></table>
 
-<h2 id="missing-melting-points-header">Missing Melting Points</h2>
+<h2 id="missing-melting-points">Missing Melting Points</h2>
 
 The <a href="https://www.wikidata.org/wiki/Property:P2101">melting point</a> is the temperature at which a compound melts. Typical units given include degrees
 <a href="{{ url_for('app.show_topic_empty') }}Q11579">Kelvin</a> and degrees
@@ -57,11 +57,11 @@ often found for organic chemicals as part of their unique characterization. Chec
 
 <table class="table table-hover" id="missing-melting-points-table"></table>
 
-<h2 id="missing-mass-header">Missing Mass</h2>
+<h2 id="missing-mass">Missing Mass</h2>
 
 <table class="table table-hover" id="missing-mass-table"></table>
 
-<h2 id="missing-solubility-header">Missing Solubility</h2>
+<h2 id="missing-solubility">Missing Solubility</h2>
 
 The <a href="https://www.wikidata.org/wiki/Property:P2177">solubility</a>
 of a compound is always in some solvent and depending on the temperature. The
@@ -70,42 +70,42 @@ latter two are therefore commonly given as qualifiers, as for this
 
 <table class="table table-hover" id="missing-solubility-table"></table>
 
-<h2 id="missing-enthalpy-of-formation-header">Missing Enthalpy of Formation</h2>
+<h2 id="missing-enthalpy-of-formation">Missing Enthalpy of Formation</h2>
 
 The <a href="https://www.wikidata.org/wiki/Property:P3078">enthalpy of formation</a>
 is a measure of the stability of the compound.
 
 <table class="table table-hover" id="missing-enthalpy-of-formation-table"></table>
 
-<h2 id="missing-vapor-pressure-header">Missing Vapor Pressure</h2>
+<h2 id="missing-vapor-pressure">Missing Vapor Pressure</h2>
 
 <table class="table table-hover" id="missing-vapor-pressure-table"></table>
 
-<h2 id="missing-molar-entropy-header">Missing Molar Entropy</h2>
+<h2 id="missing-molar-entropy">Missing Molar Entropy</h2>
 
 <table class="table table-hover" id="missing-molar-entropy-table"></table>
 
-<h2 id="missing-density-header">Missing Density</h2>
+<h2 id="missing-density">Missing Density</h2>
 
 <table class="table table-hover" id="missing-density-table"></table>
 
-<h2 id="missing-chemical-structure-header">Missing Chemical Structure</h2>
+<h2 id="missing-chemical-structure">Missing Chemical Structure</h2>
 
 <table class="table table-hover" id="missing-chemical-structure-table"></table>
 
-<h2 id="missing-flash-point-header">Missing Flash Point</h2>
+<h2 id="missing-flash-point">Missing Flash Point</h2>
 
 <table class="table table-hover" id="missing-flash-point-table"></table>
 
-<h2 id="missing-pKa-header">Missing pKa</h2>
+<h2 id="missing-pKa">Missing pKa</h2>
 
 <table class="table table-hover" id="missing-pKa-table"></table>
 
-<h2 id="missing-combustion-enthalpy-header">Missing Combustion Enthalpy</h2>
+<h2 id="missing-combustion-enthalpy">Missing Combustion Enthalpy</h2>
 
 <table class="table table-hover" id="missing-combustion-enthalpy-table"></table>
 
-<h2 id="missing-idlh-header">Missing IDLH</h2>
+<h2 id="missing-idlh">Missing IDLH</h2>
 
 The <a href="https://www.wikidata.org/wiki/Property:P2129">Immediately Dangerous to Life and Health value</a>
 (IDLH) is an indication provided by the U.S. <a href="{{ url_for('app.show_organization_empty') }}Q583725">CDC</a> about the danger of the compound.

--- a/scholia/app/templates/chemical-index.html
+++ b/scholia/app/templates/chemical-index.html
@@ -105,7 +105,7 @@ Chemical substances.
 </div>
 
 <div class="container">
-  <h2 id="statistics-header">Statistics</h2>
+  <h2 id="statistics">Statistics</h2>
 
   <table class="table table-hover" id="statistics-table"></table>
 

--- a/scholia/app/templates/chemical.html
+++ b/scholia/app/templates/chemical.html
@@ -47,23 +47,23 @@
 
 {% endif %}
 
-<h2 id="structural-identifiers-header">Structural Information</h2>
+<h2 id="structural-identifiers">Structural Information</h2>
 
 <table class="table table-hover" id="structural-identifiers-table"></table>
 
-<h2 id="Identifiers" id="identifiers-header">Identifiers</h2>
+<h2 id="Identifiers" id="identifiers">Identifiers</h2>
 
 <table class="table table-hover" id="identifiers-table"></table>
 
-<h2 id="Related" id="related-header">Related Compounds</h2>
+<h2 id="Related" id="related">Related Compounds</h2>
 
 <table class="table table-hover" id="related-table"></table>
 
-<h2 id="PhysChem" id="physchem-properties-header">Physchem Properties</h2>
+<h2 id="PhysChem" id="physchem-properties">Physchem Properties</h2>
 
 <table class="table table-hover" id="physchem-properties-table"></table>
 
-<h2 id="recent-literature-header">Recently published works on the chemical <a href="{{ url_for('app.show_topic_empty') }}{{ q }}/latest-works/rss"><img height="24" width="48" src="{{ url_for('static', filename='images/rss-40674_320.png') }}" alt="RSS icon" /></a></h2>
+<h2 id="recent-literature">Recently published works on the chemical <a href="{{ url_for('app.show_topic_empty') }}{{ q }}/latest-works/rss"><img height="24" width="48" src="{{ url_for('static', filename='images/rss-40674_320.png') }}" alt="RSS icon" /></a></h2>
 
 <table class="table table-hover" id="recent-literature-table"></table>
 
@@ -73,7 +73,7 @@
   <iframe class="embed-responsive-item" id="publications-per-year-iframe" ></iframe>
 </div>
 
-<h2 id="found-in-taxon-header">Taxa in which the chemical was found</h2>
+<h2 id="found-in-taxon">Taxa in which the chemical was found</h2>
 
 <table class="table table-hover" id="found-in-taxon-table"></table>
 

--- a/scholia/app/templates/chemical_class.html
+++ b/scholia/app/templates/chemical_class.html
@@ -17,25 +17,25 @@
 
 <div id="intro"></div>
 
-<h2 id="class-hierarchy-header">Class Hierarchy</h2>
+<h2 id="class-hierarchy">Class Hierarchy</h2>
 
 <div class="embed-responsive embed-responsive-4by3">
   <iframe class="embed-responsive-item" id="class-hierarchy-iframe" ></iframe>
 </div>
 
-<h2 id="identifiers-header">Identifiers</h2>
+<h2 id="identifiers">Identifiers</h2>
 
 <table class="table table-hover" id="identifiers-table"></table>
 
-<h2 id="related-chemicals-header">Example Compounds</h2>
+<h2 id="related-chemicals">Example Compounds</h2>
 
 <table class="table table-hover" id="related-chemicals-table"></table>
 
-<h2 id="recent-literature-header">Recently published works on the chemical <a href="{{ url_for('app.show_topic_empty') }}{{ q }}/latest-works/rss"><img height="24" width="48" src="{{ url_for('static', filename='images/rss-40674_320.png') }}" alt="RSS icon" /></a></h2>
+<h2 id="recent-literature">Recently published works on the chemical <a href="{{ url_for('app.show_topic_empty') }}{{ q }}/latest-works/rss"><img height="24" width="48" src="{{ url_for('static', filename='images/rss-40674_320.png') }}" alt="RSS icon" /></a></h2>
 
 <table class="table table-hover" id="recent-literature-table"></table>
 
-<h2 id="publications-per-year-header">Publications per year</h2>
+<h2 id="publications-per-year">Publications per year</h2>
 
 <div class="embed-responsive embed-responsive-16by9">
   <iframe class="embed-responsive-item" id="publications-per-year-iframe" ></iframe>

--- a/scholia/app/templates/chemical_element.html
+++ b/scholia/app/templates/chemical_element.html
@@ -17,15 +17,15 @@
 
 <div id="wembedder"></div>
 
-<h2 id="isotopes-header">Isotopes</h2>
+<h2 id="isotopes">Isotopes</h2>
 
 <table class="table table-hover" id="isotopes-table"></table>
 
-<h2 id="allotropes-header">Allotropes</h2>
+<h2 id="allotropes">Allotropes</h2>
 
 <table class="table table-hover" id="allotropes-table"></table>
 
-<h2 id="recent-literature-header">Recently published works on the chemical <a href="{{ url_for('app.show_topic_empty') }}{{ q }}/latest-works/rss"><img height="24" width="48" src="{{ url_for('static', filename='images/rss-40674_320.png') }}" alt="RSS icon" /></a></h2>
+<h2 id="recent-literature">Recently published works on the chemical <a href="{{ url_for('app.show_topic_empty') }}{{ q }}/latest-works/rss"><img height="24" width="48" src="{{ url_for('static', filename='images/rss-40674_320.png') }}" alt="RSS icon" /></a></h2>
 
 <table class="table table-hover" id="recent-literature-table"></table>
 

--- a/scholia/app/templates/cito.html
+++ b/scholia/app/templates/cito.html
@@ -31,14 +31,14 @@
 <div id="wembedder"></div>
 
 
-<h2 id="journals-header">Journals using this intention</h2>
+<h2 id="journals">Journals using this intention</h2>
 
 This table lists the journals with CiTO-annotated citations, sorted by decreasing number of articles
 making an citation for this intention.
 
 <table class="table table-hover" id="journals-table"></table>
 
-<h2 id="articles-by-year-header">Articles by year</h2>
+<h2 id="articles-by-year">Articles by year</h2>
 
 This plot shows the number of articles each year that use this citation intention.
 
@@ -46,7 +46,7 @@ This plot shows the number of articles each year that use this citation intentio
     <iframe class="embed-responsive-item" id="articles-by-year-iframe"></iframe>
 </div>
 
-<h2 id="articles-header">Articles most cited for this intention</h2>
+<h2 id="articles">Articles most cited for this intention</h2>
 
 This table lists the articles that are most cited for this intention.
 

--- a/scholia/app/templates/cito_empty.html
+++ b/scholia/app/templates/cito_empty.html
@@ -31,24 +31,24 @@
 
 Page with general info about CiTO annotation in Wikidata.
 
-<h2 id="statistics-header">Statistics</h2>
+<h2 id="statistics">Statistics</h2>
 
 <table class="table table-hover" id="statistics-table"></table>
 
-<h2 id="articles-by-year-header">Number of articles with CiTO-annotated citations by year</h2>
+<h2 id="articles-by-year">Number of articles with CiTO-annotated citations by year</h2>
 
 <div class="embed-responsive embed-responsive-16by9">
   <iframe class="embed-responsive-item" id="articles-by-year-iframe"></iframe>
 </div>
 
-<h2 id="article-counts-header">Use of the various CiTO intentions</h2>
+<h2 id="article-counts">Use of the various CiTO intentions</h2>
 
 This table shows the number of times each CiTO intention is used
 in the total number of citations and in a number of different articles.
 
 <table class="table table-hover" id="article-counts-table"></table>
 
-<h2 id="journal-counts-header">Journals and how many CiTO different intentions they use</h2>
+<h2 id="journal-counts">Journals and how many CiTO different intentions they use</h2>
 
 <table class="table table-hover" id="journal-counts-table"></table>
 

--- a/scholia/app/templates/clinical-trial-index.html
+++ b/scholia/app/templates/clinical-trial-index.html
@@ -20,31 +20,31 @@
 
 {% block page_content %}
 
-<h1 id="clinical-trials-header">Clinical trials</h1>
+<h1 id="clinical-trials">Clinical trials</h1>
 
-<h2 title="Recently initiated clinical trials" id="recent-clinical-trials-header">Recent clinical trials</h2>
+<h2 title="Recently initiated clinical trials" id="recent-clinical-trials">Recent clinical trials</h2>
 
 <table class="table table-hover" id="recent-clinical-trials-table"></table>
 
 
-<h2 title="Clinical trial phases during the years" id="phases-header">Phases</h2>
+<h2 title="Clinical trial phases during the years" id="phases">Phases</h2>
 
 <div class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" id="phases-iframe"></iframe>
 </div>
 
 
-<h2 title="Medical conditions in clinical trials sorted by number of trials" id="medical-conditions-header">Medical conditions</h2>
+<h2 title="Medical conditions in clinical trials sorted by number of trials" id="medical-conditions">Medical conditions</h2>
 
 <table class="table table-hover" id="medical-conditions-table"></table>
 
 
-<h2 title="Interventions in clinical trials sorted by number of trials" id="interventions-header">Interventions</h2>
+<h2 title="Interventions in clinical trials sorted by number of trials" id="interventions">Interventions</h2>
 
 <table class="table table-hover" id="interventions-table"></table>
 
 
-<h2 title="Statistics for clinical trials" id="statistics-header">Statistics</h2>
+<h2 title="Statistics for clinical trials" id="statistics">Statistics</h2>
 
 <table class="table table-hover" id="statistics-table"></table>
 

--- a/scholia/app/templates/clinical-trial.html
+++ b/scholia/app/templates/clinical-trial.html
@@ -14,16 +14,16 @@
 
 {% block page_content %}
 
-<h1 id="clinical-trial-header">Clinical trial</h1>
+<h1 id="clinical-trial">Clinical trial</h1>
 
 <div id="intro"></div>
 
-<h2 id="data-header">Data</h2>
+<h2 id="data">Data</h2>
 
 <table class="table table-hover" id="data-table"></table>
 
 
-<h2 id="related-trials-header">Related trials</h2>
+<h2 id="related-trials">Related trials</h2>
 
 <table class="table table-hover" id="related-trials-table"></table>
 

--- a/scholia/app/templates/complex.html
+++ b/scholia/app/templates/complex.html
@@ -20,19 +20,19 @@
 
 <div id="description"></div><br />
 
-<h2 id="identifiers-header">Identifiers</h2>
+<h2 id="identifiers">Identifiers</h2>
 
 <table class="table table-hover" id="identifiers-table"></table>
 
-<h2 id="participants-header">Participants</h2>
+<h2 id="participants">Participants</h2>
 
 <table class="table table-hover" id="participants-table"></table>
 
-<h2 id="articles-recent-header">Recent publications</h2>
+<h2 id="articles-recent">Recent publications</h2>
 
 <table class="table table-hover" id="articles-recent-table"></table>
 
-<h2 id="articles-by-year-header">Publications per year</h2>
+<h2 id="articles-by-year">Publications per year</h2>
 
 <div class="embed-responsive embed-responsive-16by9">
     <iframe class="embed-responsive-item" id="articles-by-year-iframe"></iframe>

--- a/scholia/app/templates/complex_empty.html
+++ b/scholia/app/templates/complex_empty.html
@@ -58,7 +58,7 @@
 </div>
 
 <div class="container">
-  <h2 id="statistics-header">Statistics</h2>
+  <h2 id="statistics">Statistics</h2>
 
   <table class="table table-hover" id="statistics-table"></table>
 

--- a/scholia/app/templates/countries.html
+++ b/scholia/app/templates/countries.html
@@ -10,7 +10,7 @@
 
 {% block page_content %}
 
-<h1 id="list-of-countries-header">Countries</h1>
+<h1 id="list-of-countries">Countries</h1>
 
 <div id="list-of-countries-intro"></div>
 

--- a/scholia/app/templates/country.html
+++ b/scholia/app/templates/country.html
@@ -25,16 +25,16 @@
 <div id="wembedder"></div>
 
 
-<h2 id="organizations-header">Organizations</h2>
+<h2 id="organizations">Organizations</h2>
 
 <table class="table table-hover" id="organizations-table"></table>
 
-<h2 id="authors-header">Authors</h2>
+<h2 id="authors">Authors</h2>
 
 <table class="table table-hover" id="authors-table"></table>
 
 
-<h2 id="locations-as-topics-header">Locations as topics</h2>
+<h2 id="locations-as-topics">Locations as topics</h2>
 
 Locations in the country that are the topic of a work.
 
@@ -43,7 +43,7 @@ Locations in the country that are the topic of a work.
 </div>
 
 
-<h2 id="narrative-locations-header">Narrative locations</h2>
+<h2 id="narrative-locations">Narrative locations</h2>
 
 Locations used as narrative locations in works.
 
@@ -52,7 +52,7 @@ Locations used as narrative locations in works.
 </div>
 
 
-<h2 id="co-organizations-header">Co-organizations</h2>
+<h2 id="co-organizations">Co-organizations</h2>
 
 International organizations with co-authors.
 

--- a/scholia/app/templates/country_topic.html
+++ b/scholia/app/templates/country_topic.html
@@ -19,19 +19,19 @@
 <div id="intro"></div>
 
 
-<h2 id="authors-header">Authors of the country who published on the topics</h2>
+<h2 id="authors">Authors of the country who published on the topics</h2>
 
 <table class="table table-hover" id="authors-table"></table>
 
 
-<h2 id="coauthors-graph-header">Co-author graph</h2>
+<h2 id="coauthors-graph">Co-author graph</h2>
 
 <div class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" id="coauthors-graph-iframe"></iframe>
 </div>
 
 
-<h2 id="cocitations-graph-header">Co-citation graph</h2>
+<h2 id="cocitations-graph">Co-citation graph</h2>
 
 Citations between authors of the country who published on the topic.
 

--- a/scholia/app/templates/dataset.html
+++ b/scholia/app/templates/dataset.html
@@ -21,7 +21,7 @@
 
 <div id="wembedder"></div>
 
-<h2 id="identifiers-header">Identifiers</h2>
+<h2 id="identifiers">Identifiers</h2>
 
 <table class="table table-hover" id="identifiers-table"></table>
 
@@ -29,11 +29,11 @@
 
 <table class="table table-hover" id="data-table"></table>
 
-<h2 id="list-of-authors-header">List of authors</h2>
+<h2 id="list-of-authors">List of authors</h2>
 
 <table class="table table-hover" id="list-of-authors-table"></table>
 
-<h2 id="topic-scores-header">Topic scores</h2>
+<h2 id="topic-scores">Topic scores</h2>
 
 Topics based on a weighting between main subject of work, cited and citing works.
 
@@ -41,7 +41,7 @@ Topics based on a weighting between main subject of work, cited and citing works
     <iframe class="embed-responsive-item" id="topic-scores-iframe"></iframe>
 </div>
 
-<h2 id="citations-header">Citations to the work</h2>
+<h2 id="citations">Citations to the work</h2>
 
 Recent citations to the work
 

--- a/scholia/app/templates/disease.html
+++ b/scholia/app/templates/disease.html
@@ -19,12 +19,12 @@
 <div id="wembedder"></div>
 
 
-<h2 id="clinical-trials-header">Clinical trials</h2>
+<h2 id="clinical-trials">Clinical trials</h2>
 
 <table class="table table-hover" id="clinical-trials-table"></table>
 
 
-<h2 id="related-diseases-header">Possibly related diseases</h2>
+<h2 id="related-diseases">Possibly related diseases</h2>
 
 Other diseases with reported genetic association via genes or symptom overlap, 
 ordered according to number of co-associated genes and symptoms.
@@ -32,7 +32,7 @@ ordered according to number of co-associated genes and symptoms.
 <table class="table table-hover" id="related-diseases-table"></table>
 
 
-<h2 id="publications-per-year-header">Publications per year</h2>
+<h2 id="publications-per-year">Publications per year</h2>
 
 <div class="embed-responsive embed-responsive-16by9">
     <iframe class="embed-responsive-item" id="publications-per-year-iframe"></iframe>

--- a/scholia/app/templates/gene.html
+++ b/scholia/app/templates/gene.html
@@ -18,25 +18,25 @@
 
 <div id="intro"></div>
 
-<h2 id="transcripts-header">Transcripts</h2>
+<h2 id="transcripts">Transcripts</h2>
 
 Transcripts encoded by this gene.
 
 <table class="table table-hover" id="transcripts-table"></table>
 
-<h2 id="proteins-header">Proteins</h2>
+<h2 id="proteins">Proteins</h2>
 
 Proteins encoded by this gene.
 
 <table class="table table-hover" id="proteins-table"></table>
 
-<h2 id="orthologs-header">Orthologs</h2>
+<h2 id="orthologs">Orthologs</h2>
 
 Orthologs encoded by this gene.
 
 <table class="table table-hover" id="orthologs-table"></table>
 
-<h2 id="variants-header">Variants</h2>
+<h2 id="variants">Variants</h2>
 
 Variants encoded by this gene.
 

--- a/scholia/app/templates/index-statistics.html
+++ b/scholia/app/templates/index-statistics.html
@@ -12,7 +12,7 @@
 
 <div class="container">
 
-    <h2 id="statistics-header">Statistics</h2>
+    <h2 id="statistics">Statistics</h2>
 
     Scholia uses Wikidata for all its data. What is the size of our data corpus?
 

--- a/scholia/app/templates/lexeme.html
+++ b/scholia/app/templates/lexeme.html
@@ -27,7 +27,7 @@
 
 <h1 id="h1">Lexeme</h1>
 
-<h2 id="works-header">Works</h2>
+<h2 id="works">Works</h2>
 
 <table class="table table-hover" id="works-table"></table>
 

--- a/scholia/app/templates/lexeme_empty.html
+++ b/scholia/app/templates/lexeme_empty.html
@@ -16,7 +16,7 @@
 
 {% block page_content %}
 
-<h1 id="lexemes-header">Lexeme</h1>
+<h1 id="lexemes">Lexeme</h1>
 
 <table class="table table-hover" id="lexemes-table"></table>
 

--- a/scholia/app/templates/location.html
+++ b/scholia/app/templates/location.html
@@ -38,13 +38,13 @@
 
 
 <h2 title="Nearby academic organizations with distances in kilometers"
-    id="nearby-organizations-header">Nearby organizations</h2>
+    id="nearby-organizations">Nearby organizations</h2>
 
 <table class="table table-hover" id="nearby-organizations-table"></table>
 
 
 <h2 title="Nearby locations as topics in works (may timeout)"
-    id="nearby-locations-as-topics-in-works-header">Nearby locations as topics in works</h2>
+    id="nearby-locations-as-topics-in-works">Nearby locations as topics in works</h2>
 
 <table class="table table-hover" id="nearby-locations-as-topics-in-works-table"></table>
 

--- a/scholia/app/templates/location_topic.html
+++ b/scholia/app/templates/location_topic.html
@@ -20,7 +20,7 @@
 
 
 <h2 title="Nearby researchers"
-    id="nearby-researchers-header">Nearby researchers</h2>
+    id="nearby-researchers">Nearby researchers</h2>
 
 <table class="table table-hover" id="nearby-researchers-table"></table>
 

--- a/scholia/app/templates/organization.html
+++ b/scholia/app/templates/organization.html
@@ -36,39 +36,39 @@
 
 <div id="details"></div>
 
-<h2 id="#employees-and-affiliated-header">Employees and affiliated</h2>
+<h2 id="#employees-and-affiliated">Employees and affiliated</h2>
 
 Past and present employees, affiliated, and members<br/>
 
 <table class="table table-hover" id="employees-and-affiliated-table"></table>
 
 
-<h2 id="co-author-graph-header">Co-author graph</h2>
+<h2 id="co-author-graph">Co-author graph</h2>
 
 <div class="embed-responsive embed-responsive-4by3">
     <iframe loading="lazy" class="embed-responsive-item" id="co-author-graph-iframe"></iframe>
 </div>
 
 
-<h2 id="advisor-graph-header">Advisor graph</h2>
+<h2 id="advisor-graph">Advisor graph</h2>
 
 <div class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" id="advisor-graph-iframe"></iframe>
 </div>
 
 
-<h2 id="topics-header">Topics that employees and affiliates have published on</h2>
+<h2 id="topics">Topics that employees and affiliates have published on</h2>
 
 Topics of publications by past and present employees, affiliates, and members, ranked by number of individuals having published on the topic.<br/>
 
 <table class="table table-hover" id="topics-table"></table>
 
-<h2 id="recent-literature-header">Recent publications <a href="{{ url_for('app.show_organization_empty') }}{{ q }}/latest-works/rss"><img height="24" width="48" src="{{ url_for('static', filename='images/rss-40674_320.png') }}" alt="RSS icon" /></a></h2>
+<h2 id="recent-literature">Recent publications <a href="{{ url_for('app.show_organization_empty') }}{{ q }}/latest-works/rss"><img height="24" width="48" src="{{ url_for('static', filename='images/rss-40674_320.png') }}" alt="RSS icon" /></a></h2>
 
 <table class="table table-hover" id="recent-literature-table"></table>
 
 
-<h2 id="page-production-header">Page production</h2>
+<h2 id="page-production">Page production</h2>
 
 Page production per year per author.
 The number of pages for a multiple-author paper is distributed among
@@ -83,29 +83,29 @@ has been set.
 
 <h2 id="Citations">Citations</h2>
 
-<h3 id="recent-citations-header">Recent citations</h3>
+<h3 id="recent-citations">Recent citations</h3>
 
 <table class="table table-hover" id="recent-citations-table"></table>
 
-<h3 id="most-cited-papers-header">Most cited papers with affiliated first author</h2>
+<h3 id="most-cited-papers">Most cited papers with affiliated first author</h2>
 
 <div class="embed-responsive embed-responsive-16by9">
   <iframe class="embed-responsive-item" id="most-cited-papers-iframe"></iframe>
 </div>
 
-<h3 id="co-author-normalized-citations-header">Co-author-normalized citations per year</h2>
+<h3 id="co-author-normalized-citations">Co-author-normalized citations per year</h2>
 
 <div class="embed-responsive embed-responsive-16by9">
   <iframe class="embed-responsive-item" id="co-author-normalized-citations-iframe"></iframe>
 </div>
 
 
-<h2 id="awards-header">Awards</h2>
+<h2 id="awards">Awards</h2>
 
 <table class="table table-hover" id="awards-table"></table>
 
 
-<h2 id="gender-distribution-header">Gender distribution</h2>
+<h2 id="gender-distribution">Gender distribution</h2>
 
 Count of the number of researchers wrt. gender.
 

--- a/scholia/app/templates/organization_curation.html
+++ b/scholia/app/templates/organization_curation.html
@@ -18,7 +18,7 @@
 
 Missing information with respect to the organization.
 
-<h2 id="authors-header">Missing author items</h2>
+<h2 id="authors">Missing author items</h2>
 
 The authors listed below may only be represented as strings in Wikidata
 with no link to Wikidata items.
@@ -30,7 +30,7 @@ the authors.
 <h2 id="h3">Author name strings to be resolved</h2>
 
 
-<h3 id="authors-no-initials-header">Author name strings without initials</h3>
+<h3 id="authors-no-initials">Author name strings without initials</h3>
 
 The author may be represented as a string rather than a Wikidata item.
 Follow the link to use the Author disambiguator tool to try to resolve the author name.
@@ -38,7 +38,7 @@ To facilitate curation, author name strings containing single-letter initials ha
 
 <table class="table table-hover" id="authors-no-initials-table"></table>
 
-<h3 id="authors-with-initials-header">Author name strings with initials</h3>
+<h3 id="authors-with-initials">Author name strings with initials</h3>
 
 This table shows author name strings that contain single-letter initials.
 

--- a/scholia/app/templates/organization_topic.html
+++ b/scholia/app/templates/organization_topic.html
@@ -24,7 +24,7 @@
 
 <div id="intro"></div>
 
-<h2 class="headline" id="recent-literature-header">Recent publications</h2>
+<h2 class="headline" id="recent-literature">Recent publications</h2>
 
 <table class="table table-hover" id="recent-literature-table"></table>
 

--- a/scholia/app/templates/organizations.html
+++ b/scholia/app/templates/organizations.html
@@ -19,34 +19,34 @@
 
 {% block page_content %}
 
-<h1 id="list-header">Organizations</h1>
+<h1 id="list">Organizations</h1>
 
 <div id="intro"></div>
 
 <table class="table table-hover" id="list-table"></table>
 
 
-<h2 id="coauthorships-header">Co-authorships</h2>
+<h2 id="coauthorships">Co-authorships</h2>
 
 <p>Past and present employees, affiliated, and members shared between organizations</p>
 
 <table class="table table-hover" id="coauthorships-table"></table>
 
 
-<h2 id="works-per-year-header">Works per year</h2>
+<h2 id="works-per-year">Works per year</h2>
 
 <div class="embed-responsive embed-responsive-16by9">
     <iframe class="embed-responsive-item" id="works-per-year-iframe"></iframe>
 </div>
 
 
-<h2 id="citations-per-year-header">Citations per year</h2>
+<h2 id="citations-per-year">Citations per year</h2>
 
 <div class="embed-responsive embed-responsive-16by9">
     <iframe class="embed-responsive-item" id="citations-per-year-iframe"></iframe></div>
 
 
-<h2 id="citations-to-works-header">Citations to works ratio</h2>
+<h2 id="citations-to-works">Citations to works ratio</h2>
 
 The ratio between the number of citations received and the works authored
 per organization per year.
@@ -55,7 +55,7 @@ per organization per year.
     <iframe class="embed-responsive-item" id="citations-to-works-iframe"></iframe></div>
 
 
-<h2 id="topic-tree-header">Topics</h2>
+<h2 id="topic-tree">Topics</h2>
 
 Tree map of most common topics in works authored by people associated with the
 organizations. 

--- a/scholia/app/templates/pathway.html
+++ b/scholia/app/templates/pathway.html
@@ -26,20 +26,20 @@
 
 <h2 id="Organism">Organism</h2>
 
-<h2 id="participants-header">Participants</h2>
+<h2 id="participants">Participants</h2>
 
 <table class="table table-hover" id="participants-table"></table>
 
-<h2 id="recent-articles-header">Published works related to the pathway</h2>
+<h2 id="recent-articles">Published works related to the pathway</h2>
 
 <table class="table table-hover" id="recent-articles-table"></table>
 
 
-<h2 id="citing-articles-header">Works citing this pathway</h2>
+<h2 id="citing-articles">Works citing this pathway</h2>
 
 <table class="table table-hover" id="citing-articles-table"></table>
 
-<h2 id="publications-per-year-header">Publications per year</h2>
+<h2 id="publications-per-year">Publications per year</h2>
 
 <div class="embed-responsive embed-responsive-16by9">
   <iframe class="embed-responsive-item" id="publications-per-year-iframe" referrerpolicy="origin" sandbox="allow-scripts allow-same-origin allow-popups"></iframe>

--- a/scholia/app/templates/pathway_empty.html
+++ b/scholia/app/templates/pathway_empty.html
@@ -62,7 +62,7 @@
 </div>
 
 <div class="container">
-  <h2 id="statistics-header">Statistics</h2>
+  <h2 id="statistics">Statistics</h2>
 
   <table class="table table-hover" id="statistics-table"></table>
 

--- a/scholia/app/templates/project.html
+++ b/scholia/app/templates/project.html
@@ -25,26 +25,26 @@
 
 <div id="intro"></div>
 
-<h2 id="partners-header">Project Partners</h2>
+<h2 id="partners">Project Partners</h2>
 
 <div class="embed-responsive embed-responsive-4by3">
   <iframe class="embed-responsive-item" id="partners-iframe"></iframe>
 </div>
 
 
-<h2 id="timeline-header">Timeline</h2>
+<h2 id="timeline">Timeline</h2>
 
 <div class="embed-responsive embed-responsive-4by3">
   <iframe class="embed-responsive-item" id="timeline-iframe"></iframe>
 </div>
 
 
-<h2 id="recent-articles-header">Recently published works about or funded by the project</h2>
+<h2 id="recent-articles">Recently published works about or funded by the project</h2>
 
 <table class="table table-hover" id="recent-articles-table"></table>
 
 
-<h2 id="topic-scores-header">Topic scores</h2>
+<h2 id="topic-scores">Topic scores</h2>
 
 Topics based on a weighting between fields of work,
 topics of research output and topics of citing works.  
@@ -53,13 +53,13 @@ topics of research output and topics of citing works.
   <iframe class="embed-responsive-item" id="topic-scores-iframe"></iframe>
 </div>
 
-<h2 id="authors-header">Authors</h3>
+<h2 id="authors">Authors</h3>
 
-<h3 id="prolific-authors-header">Prolific authors</h3>
+<h3 id="prolific-authors">Prolific authors</h3>
 
 <table class="table table-hover" id="prolific-authors-table"></table>
 
-<h2 id="publications-per-year-header">Publications per year</h2>
+<h2 id="publications-per-year">Publications per year</h2>
 
 <div class="embed-responsive embed-responsive-16by9">
   <iframe class="embed-responsive-item" id="publications-per-year-iframe"></iframe>

--- a/scholia/app/templates/project_empty.html
+++ b/scholia/app/templates/project_empty.html
@@ -14,14 +14,14 @@
 
 {% block page_content %}
 
-<h1 id="project-header">Project</h1>
+<h1 id="project">Project</h1>
 
 Research projects.
 
 
 <div class="container">
 
-<h2 id="examples-header">Examples</h2>
+<h2 id="examples">Examples</h2>
 
 <div class="card-deck mb-3">
 	<div class="card mb-4 box-shadow">
@@ -95,11 +95,11 @@ Research projects.
 
 <div class="container">
 
-<h2 id="statistics-header">Statistics</h2>
+<h2 id="statistics">Statistics</h2>
 
 <table class="table table-hover" id="statistics-table"></table>
 
-<h3 id="citations-per-budget-header">Citations per budget</h3>
+<h3 id="citations-per-budget">Citations per budget</h3>
 
 <table class="table table-hover" id="citations-per-budget-table"></table>
 

--- a/scholia/app/templates/property.html
+++ b/scholia/app/templates/property.html
@@ -20,19 +20,19 @@
 
 <h1>Property: {{ p }}</h1>
 
-<h2 id="use-header">Use</h2>
+<h2 id="use">Use</h2>
 
 <table class="table table-hover" id="use-table"></table>
 
 
-<h2 id="item-counts-header">Item counts</h2>
+<h2 id="item-counts">Item counts</h2>
 
 <div class="embed-responsive embed-responsive-4by3">
   <iframe class="embed-responsive-item" id="item-counts-iframe"></iframe>
 </div>
     
 
-<h2 id="property-value-counts-header">Property value counts</h2>
+<h2 id="property-value-counts">Property value counts</h2>
 
 <div class="embed-responsive embed-responsive-4by3">
   <iframe class="embed-responsive-item" id="property-value-counts-iframe"></iframe>

--- a/scholia/app/templates/protein.html
+++ b/scholia/app/templates/protein.html
@@ -18,7 +18,7 @@
 <div id="intro"></div>
 
 <!-- 
-     <h2 id="similar-proteins-header">Similar proteins</h2>
+     <h2 id="similar-proteins">Similar proteins</h2>
 
      Proteins sharing similar properties (molecular function(s),
      cell components, biological process, physical interaction).
@@ -26,21 +26,21 @@
      <table class="table table-hover" id="similar-proteins-table"></table>
    -->
 
-<h2 id="cofunctional-proteins-header">Cofunctional proteins</h2>
+<h2 id="cofunctional-proteins">Cofunctional proteins</h2>
 
 Proteins sharing molecular function(s).
 
 <table class="table table-hover" id="cofunctional-proteins-table"></table>
 
 
-<h2 id="participates-in-header">Participates in</h2>
+<h2 id="participates-in">Participates in</h2>
 
 This protein participates in the following protein complexes and biological processes:
 
 <table class="table table-hover" id="participates-in-table"></table>
 
 
-<h2 id="publications-per-year-header">Publications per year</h2>
+<h2 id="publications-per-year">Publications per year</h2>
 
 <div class="embed-responsive embed-responsive-16by9">
     <iframe class="embed-responsive-item" id="publications-per-year-iframe"></iframe>

--- a/scholia/app/templates/series.html
+++ b/scholia/app/templates/series.html
@@ -23,28 +23,28 @@
 <div id="wembedder"></div>
 
 
-<h2 id="in-series-header">In series</h2>
+<h2 id="in-series">In series</h2>
 
 <table class="table table-hover" id="in-series-table"></table>
 
 
-<h2 id="works-header">Published works</h2>
+<h2 id="works">Published works</h2>
 
 <table class="table table-hover" id="works-table"></table>
 
 
-<h2 id="topics-header">Topics</h2>
+<h2 id="topics">Topics</h2>
 
 <div class="embed-responsive embed-responsive-16by9">
     <iframe class="embed-responsive-item" id="topics-iframe"></iframe>
 </div>
 
-<h2 id="authors-header">Authors</h2>
+<h2 id="authors">Authors</h2>
 
 <table class="table table-hover" id="authors-table"></table>
 
 
-<h2 id="organizations-header">Organizations</h2>
+<h2 id="organizations">Organizations</h2>
 
 Employment relationships per year.
 

--- a/scholia/app/templates/software.html
+++ b/scholia/app/templates/software.html
@@ -17,29 +17,29 @@
 
 <div id="intro"></div>
 
-<h2 id="recent-works-header">Recent work using the software</h2>
+<h2 id="recent-works">Recent work using the software</h2>
 
 <table class="table table-hover" id="recent-works-table"></table>
 
 
-<h2 id="coused-header">Co-used</h2>
+<h2 id="coused">Co-used</h2>
 
 <table class="table table-hover" id="coused-table"></table>
 
-<h2 id="topics-header">Topics of works using the software</h2>
+<h2 id="topics">Topics of works using the software</h2>
 
 <div class="embed-responsive embed-responsive-4by3">
   <iframe class="embed-responsive-item" id="topics-iframe"></iframe>
 </div>
 
-<h2 id="authors-header">Authors of works using the software</h2>
+<h2 id="authors">Authors of works using the software</h2>
 
 <div class="embed-responsive embed-responsive-4by3">
   <iframe class="embed-responsive-item" id="authors-iframe"></iframe>
 </div>
 
 
-<h2 id="software-dependencies-header">Software dependencies</h2>
+<h2 id="software-dependencies">Software dependencies</h2>
 
 <div class="embed-responsive embed-responsive-4by3">
   <iframe class="embed-responsive-item" id="software-dependencies-iframe"></iframe>

--- a/scholia/app/templates/software_empty.html
+++ b/scholia/app/templates/software_empty.html
@@ -26,7 +26,7 @@
 
 <h2>Overview</h2>
 
-<h3 id="most-used-software-header">Most used software</h3>
+<h3 id="most-used-software">Most used software</h3>
 
 <table class="table table-hover" id="most-used-software-table"></table>
 

--- a/scholia/app/templates/sponsor.html
+++ b/scholia/app/templates/sponsor.html
@@ -47,7 +47,7 @@
 <div id="wembedder"></div>
 
 
-<h2 id="recently-published-sponsored-works-header">Recently published sponsored works <a href="{{ url_for('app.show_sponsor_empty') }}{{ q }}/latest-works/rss"><img height="24" width="48" src="{{ url_for('static', filename='images/rss-40674_320.png') }}" alt="RSS icon" /></a></h2>
+<h2>Recently published sponsored works <a href="{{ url_for('app.show_sponsor_empty') }}{{ q }}/latest-works/rss"><img height="24" width="48" src="{{ url_for('static', filename='images/rss-40674_320.png') }}" alt="RSS icon" /></a></h2>
 
 <table class="table table-hover" id="recently-published-sponsored-works-table"></table>
 

--- a/scholia/app/templates/sponsor.html
+++ b/scholia/app/templates/sponsor.html
@@ -47,17 +47,17 @@
 <div id="wembedder"></div>
 
 
-<h2>Recently published sponsored works <a href="{{ url_for('app.show_sponsor_empty') }}{{ q }}/latest-works/rss"><img height="24" width="48" src="{{ url_for('static', filename='images/rss-40674_320.png') }}" alt="RSS icon" /></a></h2>
+<h2 id="recently-published-sponsored-works">Recently published sponsored works <a href="{{ url_for('app.show_sponsor_empty') }}{{ q }}/latest-works/rss"><img height="24" width="48" src="{{ url_for('static', filename='images/rss-40674_320.png') }}" alt="RSS icon" /></a></h2>
 
 <table class="table table-hover" id="recently-published-sponsored-works-table"></table>
 
 
-<h2 id="authors-on-sponsored-works-header">Authors on sponsored works</h2>
+<h2 id="authors-on-sponsored-works">Authors on sponsored works</h2>
 
 <table class="table table-hover" id="authors-on-sponsored-works-table"></table>
 
 
-<h2 id="topics-of-sponsored-works-header">Topics of sponsored works</h2>
+<h2 id="topics-of-sponsored-works">Topics of sponsored works</h2>
 
 <div class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" id="topics-of-sponsored-works-iframe"></iframe>
@@ -65,12 +65,12 @@
 
    
 
-<h2 id="co-sponsors-header">Co-sponsors</h2>
+<h2 id="co-sponsors">Co-sponsors</h2>
 
 <table class="table table-hover" id="co-sponsors-table"></table>
 
 
-<h2 id="project-budgets-header">Project budgets</h2>
+<h2 id="project-budgets">Project budgets</h2>
 
 
 <div class="embed-responsive embed-responsive-4by3">

--- a/scholia/app/templates/taxon.html
+++ b/scholia/app/templates/taxon.html
@@ -22,11 +22,11 @@
 
 <div id="wembedder"></div>
 
-<h2 id="identifiers-header">Identifiers</h2>
+<h2 id="identifiers">Identifiers</h2>
 
 <table class="table table-hover" id="identifiers-table"></table>
 
-<h2 id="parent-taxa-header">Parent Taxa</h2>
+<h2 id="parent-taxa">Parent Taxa</h2>
 
 <table class="table table-hover" id="parent-taxa-table"></table>
 
@@ -34,17 +34,17 @@
   <iframe class="embed-responsive-item" id="tree-iframe" ></iframe>
 </div>
 
-<h2 id="genome-header">Genome</h2>
+<h2 id="genome">Genome</h2>
 
 <table class="table table-hover" id="genome-table"></table>
 
 
-<h2 id="proteome-header">Proteome</h2>
+<h2 id="proteome">Proteome</h2>
 
 <table class="table table-hover" id="proteome-table"></table>
 
 
-<h2 id="metabolome-header">Metabolome</h2>
+<h2 id="metabolome">Metabolome</h2>
 
 <table class="table table-hover" id="metabolome-table"></table>
 

--- a/scholia/app/templates/topic.html
+++ b/scholia/app/templates/topic.html
@@ -73,25 +73,25 @@
 
 <div id="wembedder"></div>
 
-<h2 id="context-header">The topic in context</h2>
+<h2 id="context">The topic in context</h2>
 
 <div class="embed-responsive embed-responsive-16by9">
     <iframe class="embed-responsive-item" id="context-iframe"></iframe>
 </div>
 
-<h2 id="recently-published-works-header">Recently published works on the topic <a href="{{ url_for('app.show_topic_empty') }}{{ q }}/latest-works/rss"><img height="24" width="48" src="{{ url_for('static', filename='images/rss-40674_320.png') }}" alt="RSS icon" /></a></h2>
+<h2 id="recently-published-works">Recently published works on the topic <a href="{{ url_for('app.show_topic_empty') }}{{ q }}/latest-works/rss"><img height="24" width="48" src="{{ url_for('static', filename='images/rss-40674_320.png') }}" alt="RSS icon" /></a></h2>
 
 <table class="table table-hover" id="recently-published-works-table"></table>
 
 
-<h2 id="publications-per-year-header">Publications per year</h2>
+<h2 id="publications-per-year">Publications per year</h2>
 
 <div class="embed-responsive embed-responsive-16by9">
     <iframe class="embed-responsive-item" id="publications-per-year-iframe"></iframe>
 </div>
 
 
-<h2 id="earliest-published-works-header">Earliest published works on the topic</h2>
+<h2 id="earliest-published-works">Earliest published works on the topic</h2>
 
 <table class="table table-hover" id="earliest-published-works-table"></table>
 
@@ -99,11 +99,11 @@
 <h2 id="Authors">Authors</h2>
 
 
-<h3 id="authors-header">Authors publishing about the topic</h3>
+<h3 id="authors">Authors publishing about the topic</h3>
 
 <table class="table table-hover" id="authors-table"></table>
 
-<h3 id="author-scores-header">Author score</h3>
+<h3 id="author-scores">Author score</h3>
 
 Authors scored according to field of work, publications within the topic
 and citing works within the topic.
@@ -119,7 +119,7 @@ Then go to the
 <a href="{{ url_for('app.show_topic_empty') }}{{ q }}/curation">curation</a>
 page to resolve the author names.
 
-<h3 id="coauthor-graph-header">Co-author graph</h3>
+<h3 id="coauthor-graph">Co-author graph</h3>
 
 The 25 most prolific authors and some of their key co-authors.
 
@@ -127,18 +127,18 @@ The 25 most prolific authors and some of their key co-authors.
     <iframe class="embed-responsive-item" id="coauthor-graph-iframe"></iframe>
 </div>
 
-<h3 id="author-awards-header">Awards received by authors who published on the topic</h3>
+<h3 id="author-awards">Awards received by authors who published on the topic</h3>
 
 <table class="table table-hover" id="author-awards-table"></table>
 
 
 <h2 id="Topics">Topics</h2>
 
-<h3 id="topics-header">Co-occurring topics</h3>
+<h3 id="topics">Co-occurring topics</h3>
 
 <table class="table table-hover" id="topics-table"></table>
 
-<h3 id="co-occurring-header">Co-occurring topics graph</h3>
+<h3 id="co-occurring">Co-occurring topics graph</h3>
 
 Only a maximum of the 400 most often occuring links are shown.
 
@@ -146,28 +146,28 @@ Only a maximum of the 400 most often occuring links are shown.
     <iframe class="embed-responsive-item" id="co-occurring-iframe"></iframe>
 </div>
 
-<h3 id="co-occurring-map-header">Co-occurring topics map</h3>
+<h3 id="co-occurring-map">Co-occurring topics map</h3>
 
 <div class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" id="co-occurring-map-iframe"></iframe>
 </div>
 
 
-<h2 id="venues-header">Venues and series publishing works about the topic</h2>
+<h2 id="venues">Venues and series publishing works about the topic</h2>
 
 <table class="table table-hover" id="venues-table"></table>
 
 <h2 id="Citations">Citations</h2>
 
-<h3 id="top-cited-header">Works cited from works on the topic</h3>
+<h3 id="top-cited">Works cited from works on the topic</h3>
 
 <table class="table table-hover" id="top-cited-table"></table>
 
-<h3 id="most-cited-authors-header">Authors cited from works on the topic</h3>
+<h3 id="most-cited-authors">Authors cited from works on the topic</h3>
 
 <table class="table table-hover" id="most-cited-authors-table"></table>
 
-<h3 id="organization-map-header">Map of organizations associated with works about the topic</h3>
+<h3 id="organization-map">Map of organizations associated with works about the topic</h3>
 
 The colours indicate how many publications on the topic are associated with organizations in the given location, as detailed in the legend (top right).
 
@@ -177,7 +177,7 @@ The colours indicate how many publications on the topic are associated with orga
     </iframe>
 </div>
 
-<h3 id="country-citation-graph-header">Citation graph of works about the topic, aggregated by country</h3>
+<h3 id="country-citation-graph">Citation graph of works about the topic, aggregated by country</h3>
 
 The graph indicates the countries associated with organizations whose authors have published works on the topic, and indicates the most cited countries (arrowheads) as well as the countries they are most frequently cited from.
 

--- a/scholia/app/templates/topic_curation.html
+++ b/scholia/app/templates/topic_curation.html
@@ -31,7 +31,7 @@
 Missing information with respect to the topic <a href="{{ url_for('app.show_topic_empty') }}{{ q }}">{{ q }}</a>.
 
 
-<h2 id="missing-author-items-header">Missing author items</h2>
+<h2 id="missing-author-items">Missing author items</h2>
 
 The authors listed below may only be represented as strings in Wikidata
 with no link to Wikidata items.
@@ -40,19 +40,19 @@ the authors.
 
 <table class="table table-hover" id="missing-author-items-table"></table>
 
-<h2 id="missing-pub-date-header">Missing publication date</h2>
+<h2 id="missing-pub-date">Missing publication date</h2>
 
 For the listed publications, Wikidata does not have publication dates.
 <table class="table table-hover" id="missing-pub-date-table"></table>
 
 
-<h2 id="missing-pub-venue-header">Missing publication venue</h2>
+<h2 id="missing-pub-venue">Missing publication venue</h2>
 
 For the listed publications, Wikidata does not have a statement as to where they were published.
 <table class="table table-hover" id="missing-pub-venue-table"></table>
 
 
-<h2 id="missing-co-topic-header">Works on the topic with missing additional topics</h2>
+<h2 id="missing-co-topic">Works on the topic with missing additional topics</h2>
 
 The following works have only been tagged with this one topic.
 <table class="table table-hover" id="missing-co-topic-table"></table>

--- a/scholia/app/templates/topics.html
+++ b/scholia/app/templates/topics.html
@@ -38,12 +38,12 @@
 <table class="table table-hover" id="list-of-topics-table"></table>
 
 
-<h2 id="list-of-works-header">List of works on any combination of these topics</h2>
+<h2 id="list-of-works">List of works on any combination of these topics</h2>
 
 <table class="table table-hover" id="list-of-works-table"></table>
 
 
-<h2 id="authors-header">Authors</h2>
+<h2 id="authors">Authors</h2>
 
 <table class="table table-hover" id="authors-table"></table>
 

--- a/scholia/app/templates/use.html
+++ b/scholia/app/templates/use.html
@@ -29,33 +29,33 @@
 
 <div id="wikiversity-extract"></div>
 
-<h2 id="recent-work-using-the-used-header">Recent work using the resource</h2>
+<h2 id="recent-work-using-the-used">Recent work using the resource</h2>
 
 <table class="table table-hover" id="recent-work-using-the-used-table"></table>
 
 
-<h2 id="co-used-header">Co-usage</h2>
+<h2 id="co-used">Co-usage</h2>
 
 Resources used together.
 
 <table class="table table-hover" id="co-used-table"></table>
 
 
-<h2 id="topics-of-works-using-the-resource-header">Topics of works using the resource</h2>  
+<h2 id="topics-of-works-using-the-resource">Topics of works using the resource</h2>  
 
 
 <div class="embed-responsive embed-responsive-4by3">
   <iframe class="embed-responsive-item" id="topics-of-works-using-the-resource-iframe"></iframe>
 </div>
 
-<h2 id="authors-of-works-using-the-resource-header">Authors of works using the resource</h2> 
+<h2 id="authors-of-works-using-the-resource">Authors of works using the resource</h2> 
 
 <div class="embed-responsive embed-responsive-4by3">
   <iframe class="embed-responsive-item" id="authors-of-works-using-the-resource-iframe"></iframe>
 </div>
 
 
-<h2 id="usage-over-time-header">Usage over time</h2>
+<h2 id="usage-over-time">Usage over time</h2>
 
 Works using the resource over time.
 

--- a/scholia/app/templates/use_empty.html
+++ b/scholia/app/templates/use_empty.html
@@ -33,7 +33,7 @@ Datasets:
 
 <h2>Overview</h2>
 
-<h3 id="most-used-header">Most used</h3>
+<h3 id="most-used">Most used</h3>
 
 <table class="table table-hover" id="most-used-table"></table>
 

--- a/scholia/app/templates/venue.html
+++ b/scholia/app/templates/venue.html
@@ -51,12 +51,12 @@
 <div id="wembedder"></div>
 
 
-<h2 id="recently-published-works-header">Recently published works <a href="{{ url_for('app.show_venue_empty') }}{{ q }}/latest-works/rss"><img height="24" width="48" src="{{ url_for('static', filename='images/rss-40674_320.png') }}" alt="RSS icon" /></a></h2>
+<h2 id="recently-published-works">Recently published works <a href="{{ url_for('app.show_venue_empty') }}{{ q }}/latest-works/rss"><img height="24" width="48" src="{{ url_for('static', filename='images/rss-40674_320.png') }}" alt="RSS icon" /></a></h2>
 
 <table class="table table-hover" id="recently-published-works-table"></table>
 
 
-<h2 id="topics-header">Topics</h2>
+<h2 id="topics">Topics</h2>
 
 <table class="table table-hover" id="topics-table"></table>
 
@@ -64,14 +64,14 @@
 <h2 id="Authors">Authors</h3>
 
 
-<h3 id="author-images-header">Author images</h2>
+<h3 id="author-images">Author images</h2>
 
 <div class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" id="author-images-iframe"></iframe>
 </div>
 
 
-<h3 id="authors-header">Authors</h3>
+<h3 id="authors">Authors</h3>
 
 <table class="table table-hover" id="authors-table"></table>
 
@@ -81,7 +81,7 @@ Then go to the
 page to resolve the author names.
 
 
-<h3 id="co-author-graph-header">Co-author graph</h3>
+<h3 id="co-author-graph">Co-author graph</h3>
 
 <div class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" id="co-author-graph-iframe"></iframe>
@@ -91,36 +91,36 @@ page to resolve the author names.
 
 <h2 id="Citations">Citations</h2>
 
-<h3 id="most-cited-articles-header"
+<h3 id="most-cited-articles"
     title="Most cited articles published in the venue, where the citations may come from any venue">Most cited articles</h3>
 
 <table class="table table-hover" id="most-cited-articles-table"></table>
 
 
-<h3 id="most-cited-authors-header"
+<h3 id="most-cited-authors"
     title="Most cited authors based on articles published in the venue and where citations may come from any venue">Most cited authors</h3>
 
 <table class="table table-hover" id="most-cited-authors-table"></table>
 
 
-<h3 id="citation-distribution-header">Citation distribution</h2>
+<h3 id="citation-distribution">Citation distribution</h2>
 
 <div class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" id="citation-distribution-iframe"></iframe>
 </div>
 
 
-<h3 id="cited-venues-header">Cited venues</h3>
+<h3 id="cited-venues">Cited venues</h3>
 
 <table class="table table-hover" id="cited-venues-table"></table>
 
 
-<h3 id="citing-venues-header">Citing venues</h3>
+<h3 id="citing-venues">Citing venues</h3>
 
 <table class="table table-hover" id="citing-venues-table"></table>
 
 
-<h2 id="articles-citing-retracted-articles-header">Articles citing retracted articles</h2>
+<h2 id="articles-citing-retracted-articles">Articles citing retracted articles</h2>
 
 <table class="table table-hover" id="articles-citing-retracted-articles-table"></table>
 
@@ -128,17 +128,17 @@ page to resolve the author names.
 <h2>Gender distribution</h2>
 
 
-<h3 id="author-gender-distribution-header">Authors</h3>
+<h3 id="author-gender-distribution">Authors</h3>
 
 <table class="table table-hover" id="author-gender-distribution-table"></table>
 
 
-<h3 id="authorship-gender-distribution-header">Authorships</h3>
+<h3 id="authorship-gender-distribution">Authorships</h3>
 
 <table class="table table-hover" id="authorship-gender-distribution-table"></table>
 
 
-<h2 id="author-awards-header">Author awards</h2>
+<h2 id="author-awards">Author awards</h2>
 
 <table class="table table-hover" id="author-awards-table"></table>
 

--- a/scholia/app/templates/venue_cito.html
+++ b/scholia/app/templates/venue_cito.html
@@ -36,13 +36,13 @@ The various sections show what intention types are used by article in this venue
 the intentions why articles in this venue are cited (incoming) and the intentions
 why articles in this venue are citing other articles (outgoing).
 
-<h2 id="articles-by-intention-header">Number of articles using a particular intention type</h2>
+<h2 id="articles-by-intention">Number of articles using a particular intention type</h2>
 
 <div class="embed-responsive embed-responsive-16by9">
     <iframe class="embed-responsive-item" id="articles-by-intention-iframe"></iframe>
 </div>
 
-<h2 id="incoming-bubble-header">Incoming citations</h2>
+<h2 id="incoming-bubble">Incoming citations</h2>
 
 <div class="embed-responsive embed-responsive-16by9">
     <iframe class="embed-responsive-item" id="incoming-bubble-iframe"></iframe>
@@ -50,7 +50,7 @@ why articles in this venue are citing other articles (outgoing).
 
 <table class="table table-hover" id="incoming-table"></table>
 
-<h2 id="outgoing-bubble-header">Outgoing citations</h2>
+<h2 id="outgoing-bubble">Outgoing citations</h2>
 
 <div class="embed-responsive embed-responsive-16by9">
     <iframe class="embed-responsive-item" id="outgoing-bubble-iframe"></iframe>
@@ -58,7 +58,7 @@ why articles in this venue are citing other articles (outgoing).
 
 <table class="table table-hover" id="outgoing-table"></table>
 
-<h2 id="most-reused-articles-header">Most reused articles</h2>
+<h2 id="most-reused-articles">Most reused articles</h2>
 
 This list shows articles most cited because of 'uses method in', 'cites as data source',
 'uses data from'. This number is there always equals or lower than the total number of

--- a/scholia/app/templates/venue_curation.html
+++ b/scholia/app/templates/venue_curation.html
@@ -18,7 +18,7 @@
 {% block page_content %}
 <h1 id="h1">Venue</h1>
 
-<h2 id="missing-author-item-header">Missing author item</h2>
+<h2 id="missing-author-item">Missing author item</h2>
 
 If there are any author names listed below, it means that these name strings have not been matched to Wikidata items for at least some of the works published in the venue.
 
@@ -26,7 +26,7 @@ Follow the link to use the Author disambiguator tool to try to create links betw
 
 <table class="table table-hover" id="missing-author-item-table"></table>
 
-<h2 id="missing-topics-header">Missing topics</h2>
+<h2 id="missing-topics">Missing topics</h2>
 
 The following highly cited articles have few or no "main subject" statements.
 

--- a/scholia/app/templates/venues.html
+++ b/scholia/app/templates/venues.html
@@ -24,21 +24,21 @@
 
 
 
-<h2 id="published-works-per-year-header">Published works per year</h2>
+<h2 id="published-works-per-year">Published works per year</h2>
 
 <div class="embed-responsive embed-responsive-16by9">
     <iframe class="embed-responsive-item" id="published-works-per-year-iframe"></iframe>
 </div>
 
 
-<h2 id="citations-per-year-header">Citations per year</h2>
+<h2 id="citations-per-year">Citations per year</h2>
 
 <div class="embed-responsive embed-responsive-16by9">
     <iframe class="embed-responsive-item" id="citations-per-year-iframe"></iframe>
 </div>
 
 
-<h2 id="citations-to-work-ratio-header">Citations to work ratio</h2>
+<h2 id="citations-to-work-ratio">Citations to work ratio</h2>
 
 <div class="embed-responsive embed-responsive-16by9">
     <iframe class="embed-responsive-item" id="citations-to-work-ratio-iframe"></iframe>

--- a/scholia/app/templates/work.html
+++ b/scholia/app/templates/work.html
@@ -30,13 +30,13 @@
 
 <table class="table table-hover" id="data-table"></table>
 
-<h2 id="list-of-authors-header">List of authors</h2>
+<h2 id="list-of-authors">List of authors</h2>
 
 <table class="table table-hover" id="list-of-authors-table"></table>
 
 Are authors missing here? You can help curate them via the <a href="https://author-disambiguator.toolforge.org/work_item_oauth.php?id={{ q }}&doit=Get+author+links+for+work">Author Disambiguator page for this work</a>.
 
-<h2 id="topic-scores-header">Topic scores</h2>
+<h2 id="topic-scores">Topic scores</h2>
 
 Topics based on a weighting between main subject of work, cited and citing works.
 
@@ -45,7 +45,7 @@ Topics based on a weighting between main subject of work, cited and citing works
 </div>
 
 
-<h2 id="timeline-header">Timeline</h2>
+<h2 id="timeline">Timeline</h2>
 
 <div class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" id="timeline-iframe"></iframe>
@@ -53,7 +53,7 @@ Topics based on a weighting between main subject of work, cited and citing works
 
 <h2>Related works</h2>
 
-<h3 title="related-works-header">Related works from co-citation analysis</h3>
+<h3 title="related-works">Related works from co-citation analysis</h3>
 
 <table class="table table-hover" id="related-works-table"></table>
 
@@ -66,30 +66,30 @@ Topics based on a weighting between main subject of work, cited and citing works
 <h2>Citations</h2>
 
 
-<h3 id="citations-header">Citations to the work</h3>
+<h3 id="citations">Citations to the work</h3>
 
 Recent citations to the work
 
 <table class="table table-hover" id="citations-table"></table>
 
 
-<h3 id="cited-works-header">Cited works</h3>
+<h3 id="cited-works">Cited works</h3>
 
 <table class="table table-hover" id="cited-works-table"></table>
 
 
-<h3 id="cited-work-authors-header">Authors of cited works</h3>
+<h3 id="cited-work-authors">Authors of cited works</h3>
 
 <table class="table table-hover" id="cited-work-authors-table"></table>
 
 
-<h3 id="citation-graph-header" title="Partial citation graph around the work with the up to 40 most important works displayed">Citation graph</h3>
+<h3 id="citation-graph" title="Partial citation graph around the work with the up to 40 most important works displayed">Citation graph</h3>
 
 <div class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" id="citation-graph-iframe"></iframe>
 </div>
 
-<h3 id="citations-per-year-header"
+<h3 id="citations-per-year"
     title="Number of citations to the work per year">Citations per year</h3>
 
 <div class="embed-responsive embed-responsive-16by9">
@@ -97,13 +97,13 @@ Recent citations to the work
 </div>
 
 
-<h2 id="wikipedia-mentions-header">Wikipedia mentions</h2>
+<h2 id="wikipedia-mentions">Wikipedia mentions</h2>
 
 <table class="table table-hover" id="wikipedia-mentions-table"></table>
 
 
 
-<h2 id="statements-header">Supports the following statement(s)</h2>
+<h2 id="statements">Supports the following statement(s)</h2>
 
 Statements in Wikidata supported by references to this work.
 Only a maximum of around 2000 statements are shown.

--- a/scholia/app/templates/work_cito.html
+++ b/scholia/app/templates/work_cito.html
@@ -17,7 +17,7 @@
 {% block page_content %}
 <h1 id="h1">Work</h1>
 
-<h2 id="cito-incoming-header">Reasons why this article is cited</h2>
+<h2 id="cito-incoming">Reasons why this article is cited</h2>
 
 <div class="embed-responsive embed-responsive-16by9">
     <iframe class="embed-responsive-item" id="cito-incoming-chart-iframe"></iframe>

--- a/scholia/app/templates/work_empty.html
+++ b/scholia/app/templates/work_empty.html
@@ -103,7 +103,7 @@ Scientific articles, conference articles, books, ...
 
 <div class="container">
 
-    <h2 id="recently-retracted-works-header">Recently retracted works</h2>
+    <h2 id="recently-retracted-works">Recently retracted works</h2>
 
     <table class="table table-hover" id="recently-retracted-works-table"></table>
     

--- a/scholia/app/templates/works.html
+++ b/scholia/app/templates/works.html
@@ -25,12 +25,12 @@
 <table class="table table-hover" id="list-of-works-table"></table>
 
 
-<h2 id="authors-header">Authors</h2>
+<h2 id="authors">Authors</h2>
 
 <table class="table table-hover" id="authors-table"></table>
 
 
-<h2 id="topics-header">Topics</h2>
+<h2 id="topics">Topics</h2>
 
 <div class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" id="topics-iframe"></iframe>
@@ -39,12 +39,12 @@
 
 <h2 id="Citations">Citations</h2>
 
-<h3 id="citing-works-header">Citing works</h3>
+<h3 id="citing-works">Citing works</h3>
 
 <table class="table table-hover" id="citing-works-table"></table>
 
 
-<h3 id="citations-per-year-header">Citations per year</h3>
+<h3 id="citations-per-year">Citations per year</h3>
 
 <div class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" id="citations-per-year-iframe" referrerpolicy="origin" sandbox="allow-scripts allow-same-origin allow-popups" ></iframe>


### PR DESCRIPTION
Fix #1593 

### Description
> Please include a summary of the change, relevant motivation and context. If possible and applicable, include before and after screenshots and a URL where the changes can be seen.
    
Fixed a bug with the JS code to add IDs when they are missing. Also removed all the extra `-header` suffixes on ID's. Made sure to not touch `card-header` classes as they are used for bootstrap styling.

Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

### Testing
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

* Removed the ID from one header to see if the ID and link would be added to the heading, and the link to the table of contents. Only the last one was happening, and I made the changes to fix this.
* Manually skimmed through the changes to make sure it all looked good
* Did `python runserver.py` and checked a random sponsor and checked the heading links were correct.

### Checklist
* [ ]  I have commented my code, particularly in hard-to-understand areas
* [x]  My changes generate no new warnings

---

NB I am using the template from #1602. Anyone looking at this PR, feel free to note how you feel about this template on #1602.
