### PR TITLE
Pr not warning 1529

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,21 +8,21 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [2.7, 3.5, 3.7]
+        python-version: ['2.7', '3.5', '3.7']
 
     steps:
       - uses: actions/checkout@v2
       - name: Install lxml dependencies
         run: sudo apt install libxml2-dev libxslt-dev
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python }}
+          python-version: ${{ matrix.python-version }}
       - name: Install Cython for lxml installation
         run: pip install Cython
       - name: Install Tox and any other packages
         run: pip install tox
       - name: Run Tox
-        run: tox -e py  # Run tox using the version of Python in `PATH`
+        run: tox
       - name: Run flake8
         run: tox -e flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ requests
 simplejson
 werkzeug>=0.9
 urllib3>=1.25.1
+mock

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -1,11 +1,42 @@
 """Test scholia text module."""
 
 
+import mock
 from scholia.text import load_text_to_topic_q_text
 
 
-def test_text_to_topic_q_text():
+class RequestMock:
+    """
+    Mock class used for unit test, based on a request from wikidata query service
+    """
+
+    @staticmethod
+    def json():
+        """
+        used for simulate request.json() from requests.get()
+
+        Returns
+        -------
+        mock: dict
+            Dictionary where the keys are labels associated with Wikidata
+            Q identifiers
+        """
+        return {
+            "results": {
+                "bindings": [
+                    {
+                        "topic_label": {"value": "brain"},
+                        "topic": {"value": "0123456789012345678901234567890Q1073"},
+                    }
+                ]
+            }
+        }
+
+
+@mock.patch("requests.get")
+def test_text_to_topic_q_text(mock_request):
     """Test for class."""
+    mock_request.return_value = RequestMock()
     text_to_topic_q_text = load_text_to_topic_q_text()
-    qs = text_to_topic_q_text.text_to_topic_qs('brain')
-    assert qs == ['Q1073']
+    qs = text_to_topic_q_text.text_to_topic_qs("brain")
+    assert qs == ["Q1073"]

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
-envlist = flake8, pydocstyle, py27, py35, py37
+envlist = flake8, pydocstyle, python2.7, python3.5, python3.7
 
 
-[testenv:py27]
+[testenv:python2.7]
 commands = 
     python -m pytest --doctest-modules scholia
     python -m pytest tests
@@ -10,7 +10,7 @@ deps=
     pytest
     -rrequirements.txt
 
-[testenv:py35]
+[testenv:python3.5]
 commands = 
     python -m pytest --doctest-modules scholia
     python -m pytest tests
@@ -18,7 +18,7 @@ deps=
     pytest
     -rrequirements.txt
 
-[testenv:py37]
+[testenv:python3.7]
 commands = 
     python -m pytest --doctest-modules scholia
     python -m pytest tests


### PR DESCRIPTION
fix #1529 
fix #1442 

I update the version of [setup-python](https://github.com/actions/setup-python) with v2

I also found that a test was failing and I fixed it but I must comment that I found a practice that should be improved, in the unit tests you should not make requests to services, within the Scholia code I found that a request is made to the query service of Wikidata but this is very heavy so it cannot be processed during the test, to avoid this problem create a mock-up of the request using [mock](https://pypi.org/project/mock/) library.

@egonw @fnielsen @carlinmack 

these are the actions of our fork
![Screen Shot 2021-08-18 at 4 16 25 PM](https://user-images.githubusercontent.com/14321810/129973395-7d8aec02-8c3b-46c7-94a0-b6db236938c0.png)
