### PR TITLE
Fix table of contents bug

### DIFF
--- a/scholia/app/templates/base.html
+++ b/scholia/app/templates/base.html
@@ -589,6 +589,9 @@ sparqlToShortInchiKey(`# tool: scholia
 
       if (element.tagName === "H3") {
         sublist.appendChild(tocListItem);
+        if (i == headings.length - 1) {
+          tocList.appendChild(sublist);
+        }
       } else {
         if (sublist) {
           tocList.appendChild(sublist);


### PR DESCRIPTION
Previously, the sublist would only be added if there was a following H2. This went unnoticed as this is almost always the case. The affected aspects are event_series.html, event.html, publisher.html, topic.html and works.hml

![image](https://user-images.githubusercontent.com/6676843/130154164-0e983134-d6e4-4bdf-9487-bfb1742e74cc.png)