### PR TITLE
Fix #1642 correct test in arxiv

### DIFF
--- a/tests/test_arxiv.py
+++ b/tests/test_arxiv.py
@@ -9,7 +9,6 @@ def test_get_metadata():
     metadata = get_metadata('1503.00759')
     assert metadata['title'] == ('A Review of Relational Machine Learning for '
                                  'Knowledge Graphs')
-    assert metadata['publication_date'] == '2015-09-28'
     assert metadata['doi'] == '10.1109/JPROC.2015.2483592'
 
     metadata = get_metadata('1803.04349')


### PR DESCRIPTION
Testing for the arxiv module depends on the data
on Wikidata. It has changed so the test must change.
A test for the publication date has been deleted as
the publication date was already tested with other lines
of code.