### PR TITLE
Fix #1633 set package_data in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,20 @@ setup(
     keywords='wikidata',
     url='https://github.com/WDscholia/scholia',
     packages=['scholia'],
-    package_data={},
+    package_data={
+        "scholia": [
+            "data/*",
+            "app/templates/*",
+            "app/static/*",
+            "app/static/css/*",
+            "app/static/favicon/*",
+            "app/static/fonts/*",
+            "app/static/images/*",
+            "app/static/js/*",
+            "app/static/widgets/select2/css/*",
+            "app/static/widgets/select2/js/*"
+        ]
+    },
     install_requires=requirements,
     long_description='',
     classifiers=[


### PR DESCRIPTION
When building the Scholia package the data files, such as html, js, and sparql,
were not included in the distribution package. That meant they were not
installed when installing with pip. Now they are explicitly mentioned with the
package_data field in the call to setup in setup.py.