### PR TITLE
Add message when query fail 1646

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: Python package
 
-on: [push]
+on: [push, workflow_dispatch]
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: Python package
 
-on: [push, workflow_dispatch]
+on: [push]
 
 jobs:
   build:

--- a/scholia/app/static/scholia.js
+++ b/scholia/app/static/scholia.js
@@ -255,7 +255,8 @@ function sparqlToDataTable(sparql, element, filename, options = {}) {
         );
     }).fail(function () {
         $(element).append(
-            '<p>This query has timed out, we encourage you to modify next query on Wikidata to be less intensive </p> <caption><span style="float:left; font-size:smaller;"><a href="https://query.wikidata.org/#' +
+            '<p>This query has timed out, we recommend that you follow the link to the Wikidata Query Service below to modify the query to be less intensive. </p> ' +
+            '<caption><span style="float:left; font-size:smaller;"><a href="https://query.wikidata.org/#' +
                 encodeURIComponent(sparql) +
                 '">Wikidata Query Service</a></span>' +
                 '<span style="float:right; font-size:smaller;"><a href="https://github.com/WDscholia/scholia/blob/master/scholia/app/templates/' +

--- a/scholia/app/static/scholia.js
+++ b/scholia/app/static/scholia.js
@@ -253,6 +253,16 @@ function sparqlToDataTable(sparql, element, filename, options = {}) {
                 filename.replace("_", ": ") +
                 '</a></span></caption>'
         );
+    }).fail(function () {
+        $(element).append(
+            '<p>This query has timed out, we encourage you to modify next query on Wikidata to be less intensive </p> <caption><span style="float:left; font-size:smaller;"><a href="https://query.wikidata.org/#' +
+                encodeURIComponent(sparql) +
+                '">Wikidata Query Service</a></span>' +
+                '<span style="float:right; font-size:smaller;"><a href="https://github.com/WDscholia/scholia/blob/master/scholia/app/templates/' +
+                filename + '">' +
+                filename.replace("_", ": ") +
+                '</a></span></caption>'
+        );
     });
 };
 


### PR DESCRIPTION
fix #1646 

### Description
> Please include a summary of the change, relevant motivation and context. If possible and applicable, include before and after screenshots and a URL where the changes can be seen.

add message when query fail also add a link to Wikidata to edit the query

<img width="1166" alt="Screen Shot 2021-09-01 at 7 29 39 AM" src="https://user-images.githubusercontent.com/14321810/131671488-a0c0f359-dbd8-46c7-b2ce-ffd144fbb32d.png">

