### PR TITLE
Fix #1547 wrong links in country-topic

### DIFF
--- a/scholia/app/templates/country_topic.html
+++ b/scholia/app/templates/country_topic.html
@@ -4,7 +4,15 @@
 
 {% block in_ready %}
 
-{{ sparql_to_table('authors') }}
+{{ sparql_to_table('authors',
+     options={
+         "linkPrefixes": {
+             "author": "../../../author/",
+             "example_work": "../../../work/"
+         }
+     }
+   )
+}}
 
 {{ sparql_to_iframe('coauthors-graph') }}
 


### PR DESCRIPTION
"Authors of the country who published on the topics" panel in country-topic
aspect had wrong links. This is now fix with linkPrefixes optional
arguments.

Fixes # (issue number, if applicable) 

### Description
> Please include a summary of the change, relevant motivation and context. If possible and applicable, include before and after screenshots and a URL where the changes can be seen.
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [x]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

* Test A
* Test B

### Checklist
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered accessibility in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
