### PR TITLE
Fix #1672 newline in arxiv title

### DIFF
--- a/scholia/arxiv.py
+++ b/scholia/arxiv.py
@@ -81,7 +81,11 @@ def get_metadata(arxiv):
         'authornames': [author.name for author in entry.authors],
         'full_text_url': 'https://arxiv.org/pdf/' + arxiv + '.pdf',
         'publication_date': entry.published[:10],
-        'title': entry.title,
+
+        # Some titles may have a newline in them. This should be converted to
+        # an ordinary space character
+        'title': re.sub(r'\s+', ' ', entry.title),
+
         'arxiv_classifications': [tag.term for tag in entry.tags],
     }
 


### PR DESCRIPTION
If a newline was present in an arxiv title, then quickstatement would not accept
it. This removes the newline from the scraped content.

Fixes #1672

### Description

Fix newline in arXiv title
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [x]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

* Test A
* Test B

### Checklist
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered accessibility in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
