### PR TITLE
Add author score to the missing-author-items query

### DIFF
--- a/scholia/app/templates/topic-curation_missing-author-items.sparql
+++ b/scholia/app/templates/topic-curation_missing-author-items.sparql
@@ -2,6 +2,9 @@ SELECT
   # Number of works with the author
   ?count
 
+  # Author score - 3 points for authoring a work, 1 for being cited
+  ?score
+
   # Author as a string
   ?author
 
@@ -24,11 +27,37 @@ WITH {
   }
   GROUP BY ?author
 } AS %result
+
+# Generate a score for each author
+WITH {
+  SELECT (SUM(?score_) AS ?score) ?author
+  WHERE {
+    {
+      # Assign them 3 points if they are an author of a work on the subject
+      SELECT (3 AS ?score_) ?author ?work WHERE {
+        ?work wdt:P2093 ?author .
+        ?work wdt:P921/wdt:P279* wd:{{ q }} .
+      }
+    }
+    UNION
+    {
+      # Assign them 1 point if they are the author of a work that is cited by a work on the subject
+      SELECT (1 AS ?score_) ?author ?work WHERE {
+        ?work wdt:P2093 ?author .
+        ?citing_work wdt:P2860 ?work .
+        ?citing_work wdt:P921/wdt:P279* wd:{{ q }} .
+      }
+    }
+  }
+  GROUP BY ?author
+} AS %scores
+
 WHERE {
   INCLUDE %result
+  INCLUDE %scores
 
   # Label the result
   SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }
-ORDER BY DESC(?count)
+ORDER BY DESC(?count) DESC(?score)
 LIMIT 500


### PR DESCRIPTION
### Description
This adds the author score (using same scoring logic as in [author-scores.sparql](https://github.com/WDscholia/scholia/blob/0f891e9c6be2edad3de0e5b2ce32c4b5b6558afa/scholia/app/templates/topic_author-scores.sparql)) to the missing-author-items query on the topic curation page.

Prior to this, the only way to sort the list of missing authors was by their work count.

After you disambiguate the top authors, you're usually left with a long tail of authors who only have one or two works on the subject. Adding a "score" column to the table to makes it easier to prioritise disambiguation efforts.
    
### Caveats

* This is **not** a breaking change
* It only changes a single SPARQL query
* It should slightly increase the query time but the change is so small that it's hard to measure
* I don't believe any docs need to be changed as I couldn't find anything related to scoring

### Improvements

* I had considered just returning the number of citations but I thought that it'd be better to keep the consistency with the usual scoring logic
* The query could probably be improved but it illustrates what I was after and has already proved useful
* I'm open to any ideas!

### Testing
* I've tested the changes by using the query service directly and by running the Scholia application locally

### Checklist
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered accessibility in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
