### PR TITLE
Fix #1736: Tox error and style error in #1722

### DIFF
--- a/scholia/utils.py
+++ b/scholia/utils.py
@@ -92,16 +92,18 @@ def string_to_type(string):
 
 
 def remove_special_characters_url(url):
-    """Remove url encoded characters and normalize non-ascii characters
+    """Remove url encoded characters and normalize non-ascii characters.
+
     Parameters
     ----------
     url : str
-        url encoded string
+        URL-encoded string
 
     Returns
     -------
     formatted_string : str
         Normalized string without non-ascii characters or spaces
+
     """
     decoded_url = urllib.parse.unquote(url)
     encode_string = decoded_url.encode("ascii", "ignore")

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8, pydocstyle, py27, py35, py37
+envlist = flake8, pydocstyle, py35, py37
 
 
 [testenv:py27]


### PR DESCRIPTION
The #1722 pull request introduced a couple of minor styling errors as well
as an incompatibility with Python 2 and since this was tested via the tox.ini
file, a text with tox would err.

This PR fixes the two styling errors and also more importantly removes the
test with Python 2.7, so that Python 2.x is no longer supported. The default
Python installation on older Linux system, e.g., Ubuntu 18.04 LTS would then
not work. python3 in such systems which uses 3.6 should now still work,
thus Scholia should be started with python3 runserver.py on such old systems.

Fixes # (issue number, if applicable) 

### Description
> Please include a summary of the change, relevant motivation and context. If possible and applicable, include before and after screenshots and a URL where the changes can be seen.
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

* Test A
* Test B

### Checklist
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered accessibility in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
