### PR TITLE
Fix #1587: Add 'complex' to menu

### DIFF
--- a/scholia/app/templates/base.html
+++ b/scholia/app/templates/base.html
@@ -773,6 +773,7 @@ sparqlToShortInchiKey(`# tool: scholia
 		    <span class="caret"></span></button>
 		<ul class="dropdown-menu">
 		    <li role="presentation"><a href="{{ url_for('app.show_topic_index') }}">General</a></li>
+		    <li role="presentation"><a href="{{ url_for('app.show_complex_index') }}">Complex</a></li>
 		    <li role="presentation"><a href="{{ url_for('app.show_disease_index') }}">Disease</a></li>
 		    <li role="presentation"><a href="{{ url_for('app.show_taxon_index') }}">Taxon</a></li>
 		    <li role="presentation"><a href="{{ url_for('app.show_gene_index') }}">Gene</a></li>


### PR DESCRIPTION
Fixes  #1587

### Description

Add 'complex' to topic menu: It was missing.
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [x]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

1. `python3 runserver.py`
2. Open webbrowser on http://127.0.0.1:8100/
3. See that 'complex' is under 'Topic' menu

### Checklist
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered accessibility in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
