### PR TITLE
Fix #1192: use column link in use aspect

### DIFF
--- a/scholia/app/templates/use-index.html
+++ b/scholia/app/templates/use-index.html
@@ -5,7 +5,7 @@
 
 {% block in_ready %}
 
-{{ sparql_to_table('most-used') }}
+{{ sparql_to_table('most-used', options={ "linkPrefixes":{ "use": '../use/' }}) }}
 
 {% endblock %}
 


### PR DESCRIPTION
The item in "use" column the "most used" panel in the "use" aspect
would typically redirect to a topic, rather than a use aspect.
This change explicitly link to the use aspect for that column.

The PR #1628 also work on this issue.

Fixes #1192

### Description
> Please include a summary of the change, relevant motivation and context. If possible and applicable, include before and after screenshots and a URL where the changes can be seen.
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [x]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

* Test A
* Test B

### Checklist
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered accessibility in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
