### PR TITLE
added missing equal sign to URL parameter in WhatLinksHere link from q_curation.html

### DIFF
--- a/scholia/app/templates/q_curation.html
+++ b/scholia/app/templates/q_curation.html
@@ -9,7 +9,7 @@
   directly to an item's page (in this case, <a
     href='https://www.wikidata.org/{{q}}'>https://www.wikidata.org/{{q}}</a>). Some information however, like an
   author's papers, are stored on the item for the paper itself. The "<a
-    href="https://www.wikidata.org/w/index.php?title=Special%3AWhatLinksHere&target{{q}}&namespace=0">What links
+    href="https://www.wikidata.org/w/index.php?title=Special%3AWhatLinksHere&target={{q}}&namespace=0">What links
     here</a>" link in the sidebar of an item can show these items.</p>
 
 <p>There are also various <a href="https://www.wikidata.org/wiki/Wikidata:Tools/Edit_items">tools</a> available which


### PR DESCRIPTION
Fixes #1770

### Description

Added the missing equal sign.
