### PR TITLE
corrected the link from curation page to Wikidata item

### DIFF
--- a/scholia/app/templates/q_curation.html
+++ b/scholia/app/templates/q_curation.html
@@ -7,7 +7,7 @@
 <p>Our data source is <a href="https://www.wikidata.org/wiki/Wikidata:Main_Page">Wikidata</a>, a structured data project
   similar to the encyclopedia project Wikipedia. Each item is identified by a Q number, and information can be added
   directly to an item's page (in this case, <a
-    href='https://www.wikidata.org/{{q}}'>https://www.wikidata.org/{{q}}</a>). Some information however, like an
+    href='https://www.wikidata.org/entity/{{q}}'>https://www.wikidata.org/entity/{{q}}</a>). Some information however, like an
   author's papers, are stored on the item for the paper itself. The "<a
     href="https://www.wikidata.org/w/index.php?title=Special%3AWhatLinksHere&target{{q}}&namespace=0">What links
     here</a>" link in the sidebar of an item can show these items.</p>


### PR DESCRIPTION
Fixes #1775 

### Description
A simple link fix. I went for the ```/entity/``` option.

### Screenshot

![Screenshot from 2022-01-28 01-02-51](https://user-images.githubusercontent.com/465923/151463556-dc2fe836-8d85-404a-b300-6e44fdeb2766.png)


