### PR TITLE
putting panels back into organization curation pages

### DIFF
--- a/scholia/app/templates/organization-curation.html
+++ b/scholia/app/templates/organization-curation.html
@@ -11,7 +11,7 @@
 {% endblock %}
 
 
-{% block author_disambiguator %}
+{% block curation_panels %}
 
 <h2 id="authors">Missing author items</h2>
 


### PR DESCRIPTION
Fixes #1776

### Description
Fixed the block for curation panels
    
### Screenshot
![Screenshot from 2022-01-28 02-12-30](https://user-images.githubusercontent.com/465923/151469596-f98ad05c-d2e5-45e4-9be6-ca438c339e23.png)


