### PR TITLE
Fix #1789 pathway aspect did not show

### DIFF
--- a/scholia/app/templates/pathway.html
+++ b/scholia/app/templates/pathway.html
@@ -8,7 +8,7 @@
 {{ sparql_to_table('citing-articles') }}
 {{ sparql_to_table('recent-articles') }}
 {{ sparql_to_iframe('publications-per-year') }}
-{{ sparql_to_pathway_viewer('optional_data_values') }}
+{{ sparql_to_pathway_viewer('optional-data-values') }}
 
 {% endblock %}
 


### PR DESCRIPTION
Pathway aspect did not show. The name of the sparql
file in the HTML template was wrong.

Fixes #1789

### Description
Fix the problem that the pathway aspect did not show and generated an error.
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [x]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

* Test A
* Test B

### Checklist
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered accessibility in my implementation 
* [ ] There are no remaining debug statements (print, console.log, ...)
