### PR TITLE
Fix #1794: wrong syntax in CSS

### DIFF
--- a/scholia/app/static/css/scholia.css
+++ b/scholia/app/static/css/scholia.css
@@ -15,6 +15,32 @@ body {
     flex-shrink: 0;
 }
 
+.navbar {
+    height: 4rem;
+    flex-wrap: nowrap;
+    justify-content: flex-start;
+}
+
+.nav {
+    align-items: center;
+    flex-wrap: wrap;
+    margin: 0 0.5rem;
+}
+
+.nav-search {
+    max-width: 250px;
+}
+.nav-search #searchresult {
+    height: 0;
+    width: 100%;
+    z-index: 1;
+}
+
+.nav-search #searchresult div {
+    background: white;
+    width: 100%;
+}
+
 .content {
     flex-grow: 1;
 }
@@ -59,32 +85,6 @@ h3 {
 
 a.dropdown-item.active {
     color: white;
-}
-
-.navbar {
-    height: 4rem;
-    flex-wrap: nowrap;
-    justify-content: flex-start;
-}
-
-.nav {
-    align-items: center;
-    flex-wrap: wrap;
-    margin: 0 0.5rem;
-}
-
-.nav-search {
-    max-width: 250px;
-
-.nav-search #searchresult {
-    height: 0;
-    width: 100%;
-    z-index: 1;
-}
-
-.nav-search #searchresult div {
-    background: white;
-    width: 100%;
 }
 
 .full-width {


### PR DESCRIPTION
Syntax error has been fixed and lines have been reordered.

Fixes  #1794

### Description
Style errors in webpages was due to syntax error in Scholia's CSS file.
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [x]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

* Test A
* Test B

### Checklist
* [ ] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered accessibility in my implementation 
* [ ] There are no remaining debug statements (print, console.log, ...)
