### PR TITLE
Fix #1800 escaping of image filename

### DIFF
--- a/scholia/app/templates/base.html
+++ b/scholia/app/templates/base.html
@@ -133,11 +133,11 @@ sparqlToShortInchiKey(`# tool: scholia
 	    var imageNameMd5 = md5(imageName);
 	    var imageURL = "https://upload.wikimedia.org/wikipedia/commons/" 
 	    imageURL += imageNameMd5[0] + "/" + imageNameMd5.slice(0,2) + "/"
-	    imageURL += imageName
+	    imageURL += encodeURIComponent(imageName);
 	    var itemImage = document.getElementById("item-image");
 	    if (itemImage) {
-		itemImage.src = encodeURI(imageURL);
-		itemImage.alt = imageName
+		itemImage.src = imageURL;
+		itemImage.setAttribute('alt', imageName);
 	    }
 	}
 


### PR DESCRIPTION
Image filename of Wikimedia Commons image was not escaped
correctly.

Fixes #1800 

### Description
https://github.com/WDscholia/scholia/issues/1800
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

* Test A
* Test B

### Checklist
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [ ] I have considered accessibility in my implementation 
* [ ] There are no remaining debug statements (print, console.log, ...)
