### PR TITLE
Fix #1805 disable horizontal scrollbar

### DIFF
--- a/scholia/app/static/scholia.js
+++ b/scholia/app/static/scholia.js
@@ -228,7 +228,7 @@ function sparqlToDataTablePost(sparql, element, filename, options = {}) {
             order: [],
             paging: paging,
             sDom: sDom,
-            scrollX: true,
+            scrollX: false,
         });
 
         $(element).append(
@@ -295,7 +295,7 @@ function sparqlToDataTable(sparql, element, filename, options = {}) {
             order: [],
             paging: paging,
             sDom: sDom,
-            scrollX: true,
+            scrollX: false,
             language: {
               emptyTable: "This query yielded no results. ",
               sZeroRecords: "This query yielded no results."


### PR DESCRIPTION
The horizontal scrollbar was shown in the table even
though the full table width was displayed.

Fixes #1805

### Description
The horizontal scrollbar was shown in the table even though the full table width was displayed. The scrollbar is disabled now.
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [x]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

* Test A
* Test B

### Checklist
* [ ] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered accessibility in my implementation 
* [ ] There are no remaining debug statements (print, console.log, ...)
