### PR TITLE
adding a LIMIT

### DIFF
--- a/scholia/app/templates/use_authors-of-works-using-the-resource.sparql
+++ b/scholia/app/templates/use_authors-of-works-using-the-resource.sparql
@@ -12,3 +12,4 @@ WHERE {
   SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,nl,no,ru,sv,zh" . }
 }
 ORDER BY DESC(?count)
+LIMIT 200


### PR DESCRIPTION
Fixes #1813 .

### Description

Adds a ```LIMIT``` to the ```authors-of-works-using-the-resource``` query on the ```use``` aspect.