### PR TITLE
Fix #1838 tox testing on py38 and py39

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,23 @@ deps=
     pytest
     -rrequirements.txt
 
+[testenv:py38]
+commands = 
+    python -m pytest --doctest-modules scholia
+    python -m pytest tests
+deps=
+    pytest
+    -rrequirements.txt
+
+[testenv:py39]
+commands = 
+    python -m pytest --doctest-modules scholia
+    python -m pytest tests
+deps=
+    pytest
+    -rrequirements.txt
+
+
 [testenv:flake8]
 commands = flake8 scholia
 deps = 


### PR DESCRIPTION
This adds py38 and py39 options to the configuration file of tox.
It does not add them to automatic testing if `tox` is run without
environment parameter.

Fixes #1838

### Description
We would like to be able to test with tox on the py38 and py39. This adds the options to `tox.ini`.
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [x]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

* Test A
* Test B

### Checklist
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered accessibility in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
