### PR TITLE
Fix #1830 Eclipse to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,7 @@ ENV/
 
 # Jetbrains
 .idea
+
+# Eclipse
+.pydev
+.pydevproject


### PR DESCRIPTION
Add .project and .pydevproject to the .gitignore file.

Fixes #1830

### Description
For development add .project and .pydevproject to gitignore
    
