### PR TITLE
Property aspect target fix 1866

### DIFF
--- a/scholia/app/templates/property_item-counts.sparql
+++ b/scholia/app/templates/property_item-counts.sparql
@@ -1,11 +1,11 @@
 #defaultView:BubbleChart
 
-PREFIX target: <http://www.wikidata.org/entity/{{ p }}>
+PREFIX target: <http://www.wikidata.org/prop/direct/{{ p }}>
 
 SELECT ?count ?s ?sLabel 
 WITH {
   SELECT (COUNT(?o) AS ?count) ?s WHERE {
-    ?s wdt:target: ?o .
+    ?s target: ?o .
   }
   GROUP BY ?s
   ORDER BY DESC(?count)

--- a/scholia/app/templates/property_item-counts.sparql
+++ b/scholia/app/templates/property_item-counts.sparql
@@ -1,6 +1,6 @@
 #defaultView:BubbleChart
 
-PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
+PREFIX target: <http://www.wikidata.org/entity/{{ p }}>
 
 SELECT ?count ?s ?sLabel 
 WITH {

--- a/scholia/app/templates/property_property-value-counts.sparql
+++ b/scholia/app/templates/property_property-value-counts.sparql
@@ -1,4 +1,7 @@
 #defaultView:BubbleChart
+
+PREFIX target: <http://www.wikidata.org/entity/{{ p }}>
+
 SELECT ?count ?o ?oLabel 
 WITH {
   SELECT (COUNT(?s) AS ?count) ?o WHERE {

--- a/scholia/app/templates/property_property-value-counts.sparql
+++ b/scholia/app/templates/property_property-value-counts.sparql
@@ -1,11 +1,11 @@
 #defaultView:BubbleChart
 
-PREFIX target: <http://www.wikidata.org/entity/{{ p }}>
+PREFIX target: <http://www.wikidata.org/prop/direct/{{ p }}>
 
 SELECT ?count ?o ?oLabel 
 WITH {
   SELECT (COUNT(?s) AS ?count) ?o WHERE {
-    ?s wdt:target: ?o .
+    ?s target: ?o .
   }
   GROUP BY ?o
   ORDER BY DESC(?count)

--- a/scholia/app/templates/property_use.sparql
+++ b/scholia/app/templates/property_use.sparql
@@ -1,7 +1,7 @@
-PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
+PREFIX target: <http://www.wikidata.org/prop/direct/{{ p }}>
 
 SELECT ?item ?itemLabel ?property_value ?property_valueLabel WHERE {
-  ?item wdt:target: ?property_value .
+  ?item target: ?property_value .
   SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }
 LIMIT 500


### PR DESCRIPTION
Fixes #1866

### Description
> Please include a summary of the change, relevant motivation and context. If possible and applicable, include before and after screenshots and a URL where the changes can be seen.

I adapted the PREFIX to work for properties and also fixed the way target was called.

In this branch, things work as expected now:
![Screenshot 2022-02-18 at 02-28-51 Scholia](https://user-images.githubusercontent.com/465923/154601899-be61a55e-f52f-46bf-a118-cc2da5d8c7e5.png)
    
### Caveats

On the way, I accidentally committed to master : https://github.com/WDscholia/scholia/commit/e1a022c5f83b8e8da5a3d26907292e6574bbb20c . Since that is straightforward to sort out while merging, I left it that way.