### PR TITLE
add PREFIX declaration to scholia/app/templates/pathway_citing-articles.sparql

### DIFF
--- a/scholia/app/templates/pathway_citing-articles.sparql
+++ b/scholia/app/templates/pathway_citing-articles.sparql
@@ -1,5 +1,6 @@
 #defaultView:Table
-Q202864
+
+PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
 SELECT ?citations ?publication_date ?citing_work ?citing_workLabel
 WITH {


### PR DESCRIPTION
Fixes #1868 

### Description
> Please include a summary of the change, relevant motivation and context. If possible and applicable, include before and after screenshots and a URL where the changes can be seen.

Added a declaration of the ```target:``` prefix.

Works as expected now.

![Screenshot 2022-02-18 at 03-35-53 Aryl hydrocarbon receptor Netpath - Scholia](https://user-images.githubusercontent.com/465923/154607430-f5fc601c-ab86-404a-a2c3-708ebfe61620.png)

