### PR TITLE
add spacing for citation graph title

### DIFF
--- a/scholia/app/templates/topic.html
+++ b/scholia/app/templates/topic.html
@@ -186,6 +186,8 @@ The colours indicate how many publications on the topic are associated with orga
     </iframe>
 </div>
 
+<br>
+
 <h3 id="country-citation-graph">Citation graph of works about the topic, aggregated by country</h3>
 
 The graph indicates the countries associated with organizations whose authors have published works on the topic, and indicates the most cited countries (arrowheads) as well as the countries they are most frequently cited from.


### PR DESCRIPTION
Fixes #1880

### Description
Added a line break between [Map of organizations associated with works about the topic](https://scholia.toolforge.org/topic/Q110983345#organization-map) and [Citation graph of works about the topic, aggregated by country](https://scholia.toolforge.org/topic/Q110983345#country-citation-graph) to clearly distinguish the titles

|Before|After|
| ---- | ---- |
| ![image](https://user-images.githubusercontent.com/67158080/155220969-70cf8a09-75bf-4843-b411-a4e48afa8d19.png)|![image](https://user-images.githubusercontent.com/67158080/155221134-008285b2-c14f-4370-8621-a80159a925c8.png)|

### Checklist
* [ ] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered accessibility in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
