### PR TITLE
Adding taxon curation page

### DIFF
--- a/scholia/app/templates/taxon-curation.html
+++ b/scholia/app/templates/taxon-curation.html
@@ -14,11 +14,11 @@
 
 <h2 id="missing-topic-tags-for-taxon-name">Missing topic tags for taxon name</h2>
 
-This table lists works which have this taxon's name in the title but that have not been annotated as having it as <i>main subject</i> (<a href="https://www.wikidata.org/entity/P921">P921</a>).<br /> 
+<p>This table lists works which have this taxon's name in the title but that have not been annotated as having it as <i>main subject</i> (<a href="https://www.wikidata.org/entity/P921">P921</a>).<p/> 
 
-The query is arranged such that you can edit it, comment out the line directly after the first <code>DISTINCT</code> (which creates the first two columns in the table below) and then rerun the query to get the results in a format that can be pasted directly into a <a href="https://quickstatements.toolforge.org/#/batch/new">new QuickStatements batch</a> to make the missing edits. See <a href="https://www.wikidata.org/wiki/Help:QuickStatements">Help:QuickStatements</a> for instructions on how to use QuickStatements.<br />
+<p>The query is arranged such that you can edit it, comment out the line directly after the first <code>DISTINCT</code> (which creates the first two columns in the table below) and then rerun the query to get the results in a format that can be pasted directly into a <a href="https://quickstatements.toolforge.org/#/batch/new">new QuickStatements batch</a> to make the missing edits. See <a href="https://www.wikidata.org/wiki/Help:QuickStatements">Help:QuickStatements</a> for instructions on how to use QuickStatements.</p>
 
-<b>Note that it is your responsibility to check whether these edits actually make sense &mdash; watch out for work titles containing taxon names of subspecies, variants, hybrids or similar, or for cases where titles just happen to contain this taxon name string but that are not actually about this taxon.</b>
+<p><b>Please note:</b> it is your responsibility to check whether these edits actually make sense &mdash; watch out for work titles containing taxon names of subspecies, variants, hybrids or similar, or for cases where titles just happen to contain this taxon name string but that are not actually about this taxon.</p>
 
 <hr>
 

--- a/scholia/app/templates/taxon-curation.html
+++ b/scholia/app/templates/taxon-curation.html
@@ -14,8 +14,11 @@
 
 <h2 id="missing-topic-tags-for-taxon-name">Missing topic tags for taxon name</h2>
 
-This table lists works which have this taxon's name in the title but that have not been annotated as having the main subject (<a href="https://www.wikidata.org/entity/P921">P921</a>). The query is arranged such that you can edit the query, comment out the line directly after the first <code>DISTINCT</code> and then rerun the query to get the results in a format that can be pasted directly into a <a href="https://quickstatements.toolforge.org/#/batch/new">new QuickStatements batch</a> to make the missing edits. Note that it is your responsibility to check whether these edits actually make sense &mdash; watch out for titles containing names of subspecies, variants, hybrids or similar, or for work titles that just happen to contain this taxon name string but that are not actually about this taxon.
-See <a href="https://www.wikidata.org/wiki/Help:QuickStatements">Help:QuickStatements</a> for instructions on how to use QuickStatements.
+This table lists works which have this taxon's name in the title but that have not been annotated as having the main subject (<a href="https://www.wikidata.org/entity/P921">P921</a>). 
+
+The query is arranged such that you can edit the query, comment out the line directly after the first <code>DISTINCT</code> and then rerun the query to get the results in a format that can be pasted directly into a <a href="https://quickstatements.toolforge.org/#/batch/new">new QuickStatements batch</a> to make the missing edits. See <a href="https://www.wikidata.org/wiki/Help:QuickStatements">Help:QuickStatements</a> for instructions on how to use QuickStatements.
+
+<b>Note that it is your responsibility to check whether these edits actually make sense &mdash; watch out for work titles containing taxon names of subspecies, variants, hybrids or similar, or for cases where titles just happen to contain this taxon name string but that are not actually about this taxon.</b>
 
 <hr>
 

--- a/scholia/app/templates/taxon-curation.html
+++ b/scholia/app/templates/taxon-curation.html
@@ -1,0 +1,19 @@
+{% extends "q_curation.html" %}
+
+{% set aspect = "taxon-curation" %}
+
+{% block in_ready %}
+
+{{ sparql_to_table('missing-topic-tags-for-taxon-name') }}
+
+{% endblock %}
+
+
+
+{% block curation_panels %}
+
+<h2 id="missing-topic-tags-for-taxon-names">Missing topic tags for taxon name</h2>
+
+Test
+
+{% endblock %}

--- a/scholia/app/templates/taxon-curation.html
+++ b/scholia/app/templates/taxon-curation.html
@@ -14,6 +14,11 @@
 
 <h2 id="missing-topic-tags-for-taxon-name">Missing topic tags for taxon name</h2>
 
+This table lists works which have this taxon's name in the title but that have not been annotated as having the main subject (<a href="https://www.wikidata.org/entity/P921">P921</a>). The query is arranged such that you can edit the query, comment out the line directly after the first <code>DISTINCT</code> and then rerun the query to get the results in a format that can be pasted directly into a <a href="https://quickstatements.toolforge.org/#/batch/new">new QuickStatements batch</a> to make the missing edits. Note that it is your responsibility to check whether these edits actually make sense &mdash; watch out for titles containing names of subspecies, variants, hybrids or similar, or for work titles that just happen to contain this taxon name string but that are not actually about this taxon.
+See <a href="https://www.wikidata.org/wiki/Help:QuickStatements">Help:QuickStatements</a> for instructions on how to use QuickStatements.
+
+<hr>
+
 <table class="table table-hover" id="missing-topic-tags-for-taxon-name-table"></table>
 
 <hr>

--- a/scholia/app/templates/taxon-curation.html
+++ b/scholia/app/templates/taxon-curation.html
@@ -12,8 +12,10 @@
 
 {% block curation_panels %}
 
-<h2 id="missing-topic-tags-for-taxon-names">Missing topic tags for taxon name</h2>
+<h2 id="missing-topic-tags-for-taxon-name">Missing topic tags for taxon name</h2>
 
-Test
+<table class="table table-hover" id="missing-topic-tags-for-taxon-name"></table>
+
+<hr>
 
 {% endblock %}

--- a/scholia/app/templates/taxon-curation.html
+++ b/scholia/app/templates/taxon-curation.html
@@ -14,9 +14,9 @@
 
 <h2 id="missing-topic-tags-for-taxon-name">Missing topic tags for taxon name</h2>
 
-This table lists works which have this taxon's name in the title but that have not been annotated as having the main subject (<a href="https://www.wikidata.org/entity/P921">P921</a>). 
+This table lists works which have this taxon's name in the title but that have not been annotated as having it as <i>main subject</i> (<a href="https://www.wikidata.org/entity/P921">P921</a>).<br /> 
 
-The query is arranged such that you can edit the query, comment out the line directly after the first <code>DISTINCT</code> and then rerun the query to get the results in a format that can be pasted directly into a <a href="https://quickstatements.toolforge.org/#/batch/new">new QuickStatements batch</a> to make the missing edits. See <a href="https://www.wikidata.org/wiki/Help:QuickStatements">Help:QuickStatements</a> for instructions on how to use QuickStatements.
+The query is arranged such that you can edit it, comment out the line directly after the first <code>DISTINCT</code> (which creates the first two columns in the table below) and then rerun the query to get the results in a format that can be pasted directly into a <a href="https://quickstatements.toolforge.org/#/batch/new">new QuickStatements batch</a> to make the missing edits. See <a href="https://www.wikidata.org/wiki/Help:QuickStatements">Help:QuickStatements</a> for instructions on how to use QuickStatements.<br />
 
 <b>Note that it is your responsibility to check whether these edits actually make sense &mdash; watch out for work titles containing taxon names of subspecies, variants, hybrids or similar, or for cases where titles just happen to contain this taxon name string but that are not actually about this taxon.</b>
 

--- a/scholia/app/templates/taxon-curation.html
+++ b/scholia/app/templates/taxon-curation.html
@@ -14,7 +14,7 @@
 
 <h2 id="missing-topic-tags-for-taxon-name">Missing topic tags for taxon name</h2>
 
-<table class="table table-hover" id="missing-topic-tags-for-taxon-name"></table>
+<table class="table table-hover" id="missing-topic-tags-for-taxon-name-table"></table>
 
 <hr>
 

--- a/scholia/app/templates/taxon-curation_missing-topic-tags-for-taxon-name.sparql
+++ b/scholia/app/templates/taxon-curation_missing-topic-tags-for-taxon-name.sparql
@@ -1,4 +1,4 @@
-PREFIX target: <http://www.wikidata.org/entity/(( q }}))>
+PREFIX target: <http://www.wikidata.org/entity/{{ q }}))>
 
 SELECT DISTINCT 
 ?item ?title ?taxonname

--- a/scholia/app/templates/taxon-curation_missing-topic-tags-for-taxon-name.sparql
+++ b/scholia/app/templates/taxon-curation_missing-topic-tags-for-taxon-name.sparql
@@ -1,4 +1,4 @@
-PREFIX target: <http://www.wikidata.org/entity/{{ q }}))>
+PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
 SELECT DISTINCT 
 ?item ?title ?taxonname

--- a/scholia/app/templates/taxon-curation_missing-topic-tags-for-taxon-name.sparql
+++ b/scholia/app/templates/taxon-curation_missing-topic-tags-for-taxon-name.sparql
@@ -16,10 +16,10 @@ WITH
   SERVICE wikibase:mwapi
   {
     bd:serviceParam wikibase:endpoint "www.wikidata.org";
-                    wikibase:api "Generator";
-                    mwapi:generator "search";
-                    mwapi:gsrsearch ?taxonname;
-                    mwapi:gsrlimit "max".
+      wikibase:api "Generator";
+      mwapi:generator "search";
+      mwapi:gsrsearch ?taxonname;
+      mwapi:gsrlimit "max".
     ?item wikibase:apiOutputItem mwapi:title.
   }
   ?item wdt:P1476 ?title .
@@ -28,7 +28,8 @@ WITH
   MINUS {?item wdt:P921 [wdt:P171* target: ] } # this filters out works about subspecies of the target
 
   FILTER (REGEX(LCASE(?title), LCASE(CONCAT( "\\\\", "b", ?taxonname ,"\\\\", "b"))))
-  }LIMIT 200
+  }
+  LIMIT 200
 }
 AS %items
 WHERE {

--- a/scholia/app/templates/taxon-curation_missing-topic-tags-for-taxon-name.sparql
+++ b/scholia/app/templates/taxon-curation_missing-topic-tags-for-taxon-name.sparql
@@ -1,15 +1,15 @@
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
 SELECT DISTINCT 
-?item ?title ?taxonname
+?item ?itemLabel ?taxonname
   (REPLACE(STR(?item), ".*Q", "Q") AS ?work) 
   ("P921" AS ?main_subject)
   (REPLACE(STR(target: ), ".*Q", "Q") AS ?taxon)
   ("S887" AS ?heuristic)
   ("Q69652283" AS ?deduced)
 
-WHERE
-{
+WITH
+{ SELECT  ?item ?taxonname WHERE {
   target: wdt:P225 ?taxonname .
   target: wdt:P105 wd:Q7432 . # this filters for species-level (Q7432) taxon names; comment out or adapt as necessary
 
@@ -28,5 +28,11 @@ WHERE
   MINUS {?item wdt:P921 [wdt:P171* target: ] } # this filters out works about subspecies of the target
 
   FILTER (REGEX(LCASE(?title), LCASE(CONCAT( "\\\\", "b", ?taxonname ,"\\\\", "b"))))
+  }LIMIT 200
+}
+AS %items
+WHERE {
+  INCLUDE %items
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
 }
 LIMIT 200

--- a/scholia/app/templates/taxon-curation_missing-topic-tags-for-taxon-name.sparql
+++ b/scholia/app/templates/taxon-curation_missing-topic-tags-for-taxon-name.sparql
@@ -1,0 +1,32 @@
+PREFIX target: <http://www.wikidata.org/entity/(( q }}))>
+
+SELECT DISTINCT 
+?item ?title ?taxonname
+  (REPLACE(STR(?item), ".*Q", "Q") AS ?work) 
+  ("P921" AS ?main_subject)
+  (REPLACE(STR(target: ), ".*Q", "Q") AS ?taxon)
+  ("S887" AS ?heuristic)
+  ("Q69652283" AS ?deduced)
+
+WHERE
+{
+  target: wdt:P225 ?taxonname .
+  target: wdt:P105 wd:Q7432 . # this filters for species-level (Q7432) taxon names; comment out or adapt as necessary
+
+  SERVICE wikibase:mwapi
+  {
+    bd:serviceParam wikibase:endpoint "www.wikidata.org";
+                    wikibase:api "Generator";
+                    mwapi:generator "search";
+                    mwapi:gsrsearch ?taxonname;
+                    mwapi:gsrlimit "max".
+    ?item wikibase:apiOutputItem mwapi:title.
+  }
+  ?item wdt:P1476 ?title .
+  
+  MINUS {?item wdt:P921 target: }
+  MINUS {?item wdt:P921 [wdt:P171* target: ] } # this filters out works about subspecies of the target
+
+  FILTER (REGEX(LCASE(?title), LCASE(CONCAT( "\\", "b", ?taxonname ,"\\", "b"))))
+}
+LIMIT 200

--- a/scholia/app/templates/taxon-curation_missing-topic-tags-for-taxon-name.sparql
+++ b/scholia/app/templates/taxon-curation_missing-topic-tags-for-taxon-name.sparql
@@ -27,6 +27,6 @@ WHERE
   MINUS {?item wdt:P921 target: }
   MINUS {?item wdt:P921 [wdt:P171* target: ] } # this filters out works about subspecies of the target
 
-  FILTER (REGEX(LCASE(?title), LCASE(CONCAT( "\\", "b", ?taxonname ,"\\", "b"))))
+  FILTER (REGEX(LCASE(?title), LCASE(CONCAT( "\\\\", "b", ?taxonname ,"\\\\", "b"))))
 }
 LIMIT 200


### PR DESCRIPTION
Fixes #1903 

### Description
> Please include a summary of the change, relevant motivation and context. If possible and applicable, include before and after screenshots and a URL where the changes can be seen.

Added a curation page to the taxon aspect, with one panel to get started.


![Screenshot 2022-03-15 at 17-56-07 Zika virus - Scholia](https://user-images.githubusercontent.com/465923/158430936-68f1bc12-07c3-4c04-ac77-53a67b40f2ba.png)

    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted

We could also indicate TABernacle as a way to do the topic tagging, as per
- #516
- #1268  

and I tried to build that [TABerncale query](https://tabernacle.toolforge.org/?#/tab/sparql/PREFIX%20target%3A%20%3Chttp%3A%2F%2Fwww.wikidata.org%2Fentity%2FQ202864%3E%0A%0ASELECT%20DISTINCT%20%0A%3Fitem%20%0AWITH%0A%7B%20SELECT%20%20%3Fitem%20%3Ftaxonname%20WHERE%20%7B%0A%20%20target%3A%20wdt%3AP225%20%3Ftaxonname%20.%0A%20%20target%3A%20wdt%3AP105%20wd%3AQ7432%20.%20%23%20this%20filters%20for%20species-level%20(Q7432)%20taxon%20names%3B%20comment%20out%20or%20adapt%20as%20necessary%0A%0A%20%20SERVICE%20wikibase%3Amwapi%0A%20%20%7B%0A%20%20%20%20bd%3AserviceParam%20wikibase%3Aendpoint%20%22www.wikidata.org%22%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20wikibase%3Aapi%20%22Generator%22%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20mwapi%3Agenerator%20%22search%22%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20mwapi%3Agsrsearch%20%3Ftaxonname%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20mwapi%3Agsrlimit%20%22max%22.%0A%20%20%20%20%3Fitem%20wikibase%3AapiOutputItem%20mwapi%3Atitle.%0A%20%20%7D%0A%20%20%3Fitem%20wdt%3AP1476%20%3Ftitle%20.%0A%20%20%0A%20%20MINUS%20%7B%3Fitem%20wdt%3AP921%20target%3A%20%7D%0A%20%20MINUS%20%7B%3Fitem%20wdt%3AP921%20%5Bwdt%3AP171*%20target%3A%20%5D%20%7D%20%23%20this%20filters%20out%20works%20about%20subspecies%20of%20the%20target%0A%0A%20%20FILTER%20(REGEX(LCASE(%3Ftitle)%2C%20LCASE(CONCAT(%20%22%5C%5C%22%2C%20%22b%22%2C%20%3Ftaxonname%20%2C%22%5C%5C%22%2C%20%22b%22))))%0A%20%20%7DLIMIT%20200%0A%7D%0AAS%20%25items%0AWHERE%20%7B%0A%20%20INCLUDE%20%25items%0A%7D%0ALIMIT%20200%0A/P921) by way of a sparql file similar to the ones we already have but was not sure how best to engineer that, so leaving it for another ticket.

Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [x]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

I tested this on a number of pages, including
*/taxon/Q202864/curation (Zika virus)
*/taxon/Q161164/curation (Fraxinus pennsylvanica)

### Checklist
* [X] I have commented my code, particularly in hard-to-understand areas
* [X] My changes generate no new warnings
* [X] I have not used code from external sources without attribution
* [X] I have considered accessibility in my implementation 
  * I have actually considered it but do not know enough about this to make improvements 
* [X] There are no remaining debug statements (print, console.log, ...)
