### PR TITLE
Fix #1870 organization researcher

### DIFF
--- a/scholia/app/templates/organization_employees-and-affiliated.sparql
+++ b/scholia/app/templates/organization_employees-and-affiliated.sparql
@@ -17,10 +17,13 @@ WITH {
     (COUNT(?work) AS ?number_of_works_) ?researcher
   WHERE {
     INCLUDE %researchers
-    OPTIONAL { ?work wdt:P50 ?researcher . }
 
     # No biological pathways; they skew the statistics too much 
     MINUS { ?work wdt:P31 wd:Q4915012 } 
+
+    # This OPTIONAL query should be after the MINUS query, otherwise
+    # researchers might not show if they do not have any papers.
+    OPTIONAL { ?work wdt:P50 ?researcher . }
   } 
   GROUP BY ?researcher
 } AS %researchers_and_number_of_works


### PR DESCRIPTION
For the employees and affiliated panel on the the organization aspect,
researchers having authored no works would not show up in the table.
This patch reorder lines in the SPARQL and this apparently helps.

Fixes #1870

### Description
Change ordering of lines in SPARQL to make researchers with no authored works show up in employee table in the organization aspect.
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

* Test A
* Test B

### Checklist
* [x] I have commented my code, particularly in hard-to-understand areas
* [ ] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered accessibility in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
