### PR TITLE
Update to citation.js 0.5.6 and software-formats 0.5.3

### DIFF
--- a/scholia/app/static/js/citation.js
+++ b/scholia/app/static/js/citation.js
@@ -6,7 +6,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.default = void 0;
 
-var _index = _interopRequireDefault(require("./index"));
+var _index = _interopRequireDefault(require("./index.js"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -28,21 +28,21 @@ const async = function (data, options, callback) {
 
 var _default = async;
 exports.default = _default;
-},{"./index":3}],2:[function(require,module,exports){
+},{"./index.js":3}],2:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.getIds = getIds;
 exports.format = format;
 exports.get = get;
+exports.getIds = getIds;
 
-var _static = require("./static");
+var _static = require("./static.js");
 
-var _output = require("../plugins/output");
+var _output = require("../plugins/output.js");
 
-var _csl = require("../plugins/input/csl");
+var _csl = require("../plugins/input/csl.js");
 
 function getIds() {
   return this.data.map(entry => entry.id);
@@ -111,7 +111,7 @@ function get(options = {}) {
     return result;
   }
 }
-},{"../plugins/input/csl":25,"../plugins/output":33,"./static":8}],3:[function(require,module,exports){
+},{"../plugins/input/csl.js":25,"../plugins/output.js":33,"./static.js":8}],3:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -119,17 +119,17 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.default = void 0;
 
-var log = _interopRequireWildcard(require("./log"));
+var log = _interopRequireWildcard(require("./log.js"));
 
-var options = _interopRequireWildcard(require("./options"));
+var options = _interopRequireWildcard(require("./options.js"));
 
-var set = _interopRequireWildcard(require("./set"));
+var set = _interopRequireWildcard(require("./set.js"));
 
-var sort = _interopRequireWildcard(require("./sort"));
+var sort = _interopRequireWildcard(require("./sort.js"));
 
-var get = _interopRequireWildcard(require("./get"));
+var get = _interopRequireWildcard(require("./get.js"));
 
-var staticMethods = _interopRequireWildcard(require("./static"));
+var staticMethods = _interopRequireWildcard(require("./static.js"));
 
 function _getRequireWildcardCache(nodeInterop) { if (typeof WeakMap !== "function") return null; var cacheBabelInterop = new WeakMap(); var cacheNodeInterop = new WeakMap(); return (_getRequireWildcardCache = function (nodeInterop) { return nodeInterop ? cacheNodeInterop : cacheBabelInterop; })(nodeInterop); }
 
@@ -157,15 +157,15 @@ Cite.prototype[Symbol.iterator] = function* () {
 Object.assign(Cite, staticMethods);
 var _default = Cite;
 exports.default = _default;
-},{"./get":2,"./log":4,"./options":5,"./set":6,"./sort":7,"./static":8}],4:[function(require,module,exports){
+},{"./get.js":2,"./log.js":4,"./options.js":5,"./set.js":6,"./sort.js":7,"./static.js":8}],4:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.save = exports.undo = exports.retrieveLastVersion = exports.retrieveVersion = exports.currentVersion = void 0;
+exports.undo = exports.save = exports.retrieveVersion = exports.retrieveLastVersion = exports.currentVersion = void 0;
 
-var _index = _interopRequireDefault(require("./index"));
+var _index = _interopRequireDefault(require("./index.js"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -206,15 +206,15 @@ const save = function () {
 };
 
 exports.save = save;
-},{"./index":3}],5:[function(require,module,exports){
+},{"./index.js":3}],5:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.defaultOptions = exports.options = void 0;
+exports.options = exports.defaultOptions = void 0;
 
-var _validate = require("./validate");
+var _validate = require("./validate.js");
 
 const defaultOptions = {
   format: 'real',
@@ -236,17 +236,17 @@ const options = function (options, log) {
 };
 
 exports.options = options;
-},{"./validate":9}],6:[function(require,module,exports){
+},{"./validate.js":9}],6:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.reset = exports.setAsync = exports.set = exports.addAsync = exports.add = void 0;
+exports.setAsync = exports.set = exports.reset = exports.addAsync = exports.add = void 0;
 
-var _input = require("../plugins/input/");
+var _index = require("../plugins/input/index.js");
 
-var _fetchId = _interopRequireDefault(require("../util/fetchId"));
+var _fetchId = _interopRequireDefault(require("../util/fetchId.js"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -255,7 +255,7 @@ const add = function (data, options = {}, log = false) {
     this.save();
   }
 
-  this.data.push(...(0, _input.chain)(data, options));
+  this.data.push(...(0, _index.chain)(data, options));
   this.data.filter(entry => !Object.prototype.hasOwnProperty.call(entry, 'id')).forEach(entry => {
     entry.id = (0, _fetchId.default)(this.getIds(), 'temp_id_');
   });
@@ -269,7 +269,7 @@ const addAsync = async function (data, options = {}, log = false) {
     this.save();
   }
 
-  this.data.push(...(await (0, _input.chainAsync)(data, options)));
+  this.data.push(...(await (0, _index.chainAsync)(data, options)));
   this.data.filter(entry => !Object.prototype.hasOwnProperty.call(entry, 'id')).forEach(entry => {
     entry.id = (0, _fetchId.default)(this.getIds(), 'temp_id_');
   });
@@ -311,7 +311,7 @@ const reset = function (log) {
 };
 
 exports.reset = reset;
-},{"../plugins/input/":29,"../util/fetchId":36}],7:[function(require,module,exports){
+},{"../plugins/input/index.js":29,"../util/fetchId.js":36}],7:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -319,7 +319,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.sort = void 0;
 
-var _label = require("../plugin-common/output/label");
+var _label = require("../plugin-common/output/label.js");
 
 var _name = require("@citation-js/name");
 
@@ -379,7 +379,7 @@ const sort = function (method = [], log) {
 };
 
 exports.sort = sort;
-},{"../plugin-common/output/label":20,"@citation-js/name":46}],8:[function(require,module,exports){
+},{"../plugin-common/output/label.js":20,"@citation-js/name":46}],8:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -395,9 +395,9 @@ Object.defineProperty(exports, "async", {
   }
 });
 
-var _async = _interopRequireDefault(require("./async"));
+var _async = _interopRequireDefault(require("./async.js"));
 
-var _validate = require("./validate");
+var _validate = require("./validate.js");
 
 Object.keys(_validate).forEach(function (key) {
   if (key === "default" || key === "__esModule") return;
@@ -412,14 +412,14 @@ Object.keys(_validate).forEach(function (key) {
 });
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-},{"./async":1,"./validate":9}],9:[function(require,module,exports){
+},{"./async.js":1,"./validate.js":9}],9:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.validateOutputOptions = validateOutputOptions;
 exports.validateOptions = validateOptions;
+exports.validateOutputOptions = validateOutputOptions;
 const formats = ['real', 'string'];
 const types = ['json', 'html', 'string', 'rtf'];
 const styles = ['csl', 'bibtex', 'bibtxt', 'citation-*', 'ris', 'ndjson'];
@@ -519,7 +519,7 @@ if (typeof console.Console === 'function') {
 var _default = logger;
 exports.default = _default;
 }).call(this)}).call(this,require('_process'))
-},{"_process":141}],11:[function(require,module,exports){
+},{"_process":133}],11:[function(require,module,exports){
 "use strict";
 
 var plugins = _interopRequireWildcard(require("../plugins"));
@@ -566,17 +566,17 @@ function parse(input) {
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.formats = exports.parsers = exports.ref = void 0;
+exports.ref = exports.parsers = exports.formats = void 0;
 
-var empty = _interopRequireWildcard(require("./empty"));
+var empty = _interopRequireWildcard(require("./empty.js"));
 
-var url = _interopRequireWildcard(require("./url"));
+var url = _interopRequireWildcard(require("./url.js"));
 
-var json = _interopRequireWildcard(require("./json"));
+var json = _interopRequireWildcard(require("./json.js"));
 
-var jquery = _interopRequireWildcard(require("./jquery"));
+var jquery = _interopRequireWildcard(require("./jquery.js"));
 
-var html = _interopRequireWildcard(require("./html"));
+var html = _interopRequireWildcard(require("./html.js"));
 
 function _getRequireWildcardCache(nodeInterop) { if (typeof WeakMap !== "function") return null; var cacheBabelInterop = new WeakMap(); var cacheNodeInterop = new WeakMap(); return (_getRequireWildcardCache = function (nodeInterop) { return nodeInterop ? cacheNodeInterop : cacheBabelInterop; })(nodeInterop); }
 
@@ -653,7 +653,7 @@ const formats = {
   }
 };
 exports.formats = formats;
-},{"./empty":12,"./html":13,"./jquery":15,"./json":16,"./url":17}],15:[function(require,module,exports){
+},{"./empty.js":12,"./html.js":13,"./jquery.js":15,"./json.js":16,"./url.js":17}],15:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -670,9 +670,9 @@ function parse(input) {
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.default = exports.parse = void 0;
+exports.parse = exports.default = void 0;
 
-var _logger = _interopRequireDefault(require("../../logger"));
+var _logger = _interopRequireDefault(require("../../logger.js"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -696,7 +696,7 @@ const parseJSON = function (str) {
 };
 
 exports.default = exports.parse = parseJSON;
-},{"../../logger":10}],17:[function(require,module,exports){
+},{"../../logger.js":10}],17:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -705,18 +705,18 @@ Object.defineProperty(exports, "__esModule", {
 Object.defineProperty(exports, "parse", {
   enumerable: true,
   get: function () {
-    return _util.fetchFile;
+    return _index.fetchFile;
   }
 });
 Object.defineProperty(exports, "parseAsync", {
   enumerable: true,
   get: function () {
-    return _util.fetchFileAsync;
+    return _index.fetchFileAsync;
   }
 });
 
-var _util = require("../../util/");
-},{"../../util/":38}],18:[function(require,module,exports){
+var _index = require("../../util/index.js");
+},{"../../util/index.js":38}],18:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -724,29 +724,29 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.default = void 0;
 
-var _json = _interopRequireDefault(require("./json"));
+var _json = _interopRequireDefault(require("./json.js"));
 
-var _label = _interopRequireDefault(require("./label"));
+var _label = _interopRequireDefault(require("./label.js"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 var _default = Object.assign({}, _json.default, _label.default);
 
 exports.default = _default;
-},{"./json":19,"./label":20}],19:[function(require,module,exports){
+},{"./json.js":19,"./label.js":20}],19:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.getJsonWrapper = getJsonWrapper;
 exports.default = void 0;
+exports.getJsonWrapper = getJsonWrapper;
 
-var plugins = _interopRequireWildcard(require("../../plugins/"));
+var plugins = _interopRequireWildcard(require("../../plugins/index.js"));
 
-var util = _interopRequireWildcard(require("../../util/"));
+var util = _interopRequireWildcard(require("../../util/index.js"));
 
-var _logger = _interopRequireDefault(require("../../logger"));
+var _logger = _interopRequireDefault(require("../../logger.js"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -818,13 +818,13 @@ var _default = {
 
 };
 exports.default = _default;
-},{"../../logger":10,"../../plugins/":23,"../../util/":38}],20:[function(require,module,exports){
+},{"../../logger.js":10,"../../plugins/index.js":23,"../../util/index.js":38}],20:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.default = exports.getLabel = void 0;
+exports.getLabel = exports.default = void 0;
 
 const getLabel = entry => {
   if ('citation-label' in entry) {
@@ -867,7 +867,7 @@ exports.default = _default;
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.list = exports.remove = exports.has = exports.get = exports.add = void 0;
+exports.remove = exports.list = exports.has = exports.get = exports.add = void 0;
 const configs = {};
 
 const add = (ref, config) => {
@@ -899,9 +899,9 @@ exports.list = list;
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.textDict = exports.htmlDict = exports.get = exports.list = exports.has = exports.remove = exports.add = exports.register = void 0;
+exports.textDict = exports.remove = exports.register = exports.list = exports.htmlDict = exports.has = exports.get = exports.add = void 0;
 
-var _register = _interopRequireDefault(require("../util/register"));
+var _register = _interopRequireDefault(require("../util/register.js"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -993,27 +993,27 @@ const textDict = {
   li_end: '\n'
 };
 exports.textDict = textDict;
-},{"../util/register":39}],23:[function(require,module,exports){
+},{"../util/register.js":39}],23:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.config = exports.dict = exports.output = exports.input = exports.list = exports.has = exports.remove = exports.add = void 0;
+exports.remove = exports.output = exports.list = exports.input = exports.has = exports.dict = exports.config = exports.add = void 0;
 
-var input = _interopRequireWildcard(require("./input/"));
+var input = _interopRequireWildcard(require("./input/index.js"));
 
 exports.input = input;
 
-var output = _interopRequireWildcard(require("./output"));
+var output = _interopRequireWildcard(require("./output.js"));
 
 exports.output = output;
 
-var dict = _interopRequireWildcard(require("./dict"));
+var dict = _interopRequireWildcard(require("./dict.js"));
 
 exports.dict = dict;
 
-var config = _interopRequireWildcard(require("./config"));
+var config = _interopRequireWildcard(require("./config.js"));
 
 exports.config = config;
 
@@ -1077,25 +1077,25 @@ exports.has = has;
 const list = () => Object.keys(indices);
 
 exports.list = list;
-},{"./config":21,"./dict":22,"./input/":29,"./output":33}],24:[function(require,module,exports){
+},{"./config.js":21,"./dict.js":22,"./input/index.js":29,"./output.js":33}],24:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.chainLinkAsync = exports.chainAsync = exports.chainLink = exports.chain = void 0;
+exports.chainLinkAsync = exports.chainLink = exports.chainAsync = exports.chain = void 0;
 
-var _deepCopy = _interopRequireDefault(require("../../util/deepCopy"));
+var _deepCopy = _interopRequireDefault(require("../../util/deepCopy.js"));
 
-var _logger = _interopRequireDefault(require("../../logger"));
+var _logger = _interopRequireDefault(require("../../logger.js"));
 
-var _register = require("./register");
+var _register = require("./register.js");
 
-var _type = require("./type");
+var _type = require("./type.js");
 
-var _data = require("./data");
+var _data = require("./data.js");
 
-var _graph = require("./graph");
+var _graph = require("./graph.js");
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -1220,7 +1220,7 @@ const chainLinkAsync = async input => {
 };
 
 exports.chainLinkAsync = chainLinkAsync;
-},{"../../logger":10,"../../util/deepCopy":34,"./data":26,"./graph":28,"./register":31,"./type":32}],25:[function(require,module,exports){
+},{"../../logger.js":10,"../../util/deepCopy.js":34,"./data.js":26,"./graph.js":28,"./register.js":31,"./type.js":32}],25:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -1456,7 +1456,7 @@ const correctField = function (fieldName, value, bestGuessConversions) {
   if (/^_/.test(fieldName)) {
     return value;
   } else if (bestGuessConversions) {
-    if (typeof value === 'string' && fieldType.includes('number') && !isNaN(+value)) {
+    if (typeof value === 'string' && fieldType.includes('number') && !fieldType.includes('string') && !isNaN(+value)) {
       return parseFloat(value);
     } else if (typeof value === 'number' && fieldType.includes('string') && !fieldType.includes('number')) {
       return value.toString();
@@ -1493,9 +1493,9 @@ exports.clean = parseCsl;
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.listDataParser = exports.removeDataParser = exports.hasDataParser = exports.addDataParser = exports.dataAsync = exports.data = void 0;
+exports.removeDataParser = exports.listDataParser = exports.hasDataParser = exports.dataAsync = exports.data = exports.addDataParser = void 0;
 
-var _chain = require("./chain");
+var _chain = require("./chain.js");
 
 const flatten = array => [].concat(...array);
 
@@ -1565,13 +1565,13 @@ exports.removeDataParser = removeDataParser;
 const listDataParser = async => Object.keys(async ? asyncParsers : parsers);
 
 exports.listDataParser = listDataParser;
-},{"./chain":24}],27:[function(require,module,exports){
+},{"./chain.js":24}],27:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.dataTypeOf = exports.typeOf = void 0;
+exports.typeOf = exports.dataTypeOf = void 0;
 
 const typeOf = thing => {
   switch (thing) {
@@ -1650,13 +1650,13 @@ var _exportNames = {
 };
 exports.util = void 0;
 
-var dataType = _interopRequireWildcard(require("./dataType"));
+var dataType = _interopRequireWildcard(require("./dataType.js"));
 
-var graph = _interopRequireWildcard(require("./graph"));
+var graph = _interopRequireWildcard(require("./graph.js"));
 
-var parser = _interopRequireWildcard(require("./parser"));
+var parser = _interopRequireWildcard(require("./parser.js"));
 
-var csl = _interopRequireWildcard(require("./csl"));
+var csl = _interopRequireWildcard(require("./csl.js"));
 
 var _register = require("./register");
 
@@ -1720,15 +1720,15 @@ function _interopRequireWildcard(obj, nodeInterop) { if (!nodeInterop && obj && 
 
 const util = Object.assign({}, dataType, graph, parser, csl);
 exports.util = util;
-},{"./chain":24,"./csl":25,"./data":26,"./dataType":27,"./graph":28,"./parser":30,"./register":31,"./type":32}],30:[function(require,module,exports){
+},{"./chain":24,"./csl.js":25,"./data":26,"./dataType.js":27,"./graph.js":28,"./parser.js":30,"./register":31,"./type":32}],30:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.FormatParser = exports.DataParser = exports.TypeParser = void 0;
+exports.TypeParser = exports.FormatParser = exports.DataParser = void 0;
 
-var _type = require("./type");
+var _type = require("./type.js");
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
@@ -1831,21 +1831,22 @@ class TypeParser {
     const constraints = [].concat(this.data.propertyConstraint || []);
     return constraints.map(({
       props,
-      match = 'every',
+      match,
       value
     }) => {
       props = [].concat(props);
 
       switch (match) {
-        case 'every':
-          return input => props.every(prop => prop in input && (!value || value(input[prop])));
-
         case 'any':
         case 'some':
           return input => props.some(prop => prop in input && (!value || value(input[prop])));
 
         case 'none':
           return input => !props.some(prop => prop in input && (!value || value(input[prop])));
+
+        case 'every':
+        default:
+          return input => props.every(prop => prop in input && (!value || value(input[prop])));
       }
     });
   }
@@ -1975,19 +1976,19 @@ class FormatParser {
 }
 
 exports.FormatParser = FormatParser;
-},{"./type":32}],31:[function(require,module,exports){
+},{"./type.js":32}],31:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.list = exports.has = exports.remove = exports.get = exports.add = void 0;
+exports.remove = exports.list = exports.has = exports.get = exports.add = void 0;
 
-var _parser = require("./parser");
+var _parser = require("./parser.js");
 
-var _type = require("./type");
+var _type = require("./type.js");
 
-var _data = require("./data");
+var _data = require("./data.js");
 
 const formats = {};
 
@@ -2055,17 +2056,17 @@ exports.has = has;
 const list = () => Object.keys(formats);
 
 exports.list = list;
-},{"./data":26,"./parser":30,"./type":32}],32:[function(require,module,exports){
+},{"./data.js":26,"./parser.js":30,"./type.js":32}],32:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.typeMatcher = exports.treeTypeParser = exports.listTypeParser = exports.removeTypeParser = exports.hasTypeParser = exports.addTypeParser = exports.type = void 0;
+exports.typeMatcher = exports.type = exports.treeTypeParser = exports.removeTypeParser = exports.listTypeParser = exports.hasTypeParser = exports.addTypeParser = void 0;
 
-var _logger = _interopRequireDefault(require("../../logger"));
+var _logger = _interopRequireDefault(require("../../logger.js"));
 
-var _dataType = require("./dataType");
+var _dataType = require("./dataType.js");
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -2194,15 +2195,15 @@ const treeTypeParser = () => {
 exports.treeTypeParser = treeTypeParser;
 const typeMatcher = /^(?:@(.+?))(?:\/(?:(.+?)\+)?(?:(.+)))?$/;
 exports.typeMatcher = typeMatcher;
-},{"../../logger":10,"./dataType":27}],33:[function(require,module,exports){
+},{"../../logger.js":10,"./dataType.js":27}],33:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.format = exports.list = exports.has = exports.remove = exports.add = exports.register = void 0;
+exports.remove = exports.register = exports.list = exports.has = exports.format = exports.add = void 0;
 
-var _register = _interopRequireDefault(require("../util/register"));
+var _register = _interopRequireDefault(require("../util/register.js"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -2251,7 +2252,7 @@ const format = (name, data, ...options) => {
 };
 
 exports.format = format;
-},{"../util/register":39}],34:[function(require,module,exports){
+},{"../util/register.js":39}],34:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -2297,23 +2298,23 @@ exports.default = _default;
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+exports.default = void 0;
 exports.fetchFile = fetchFile;
 exports.fetchFileAsync = fetchFileAsync;
 exports.setUserAgent = setUserAgent;
-exports.default = void 0;
 
 var _syncFetch = _interopRequireDefault(require("sync-fetch"));
 
 require("isomorphic-fetch");
 
-var _logger = _interopRequireDefault(require("../logger"));
+var _logger = _interopRequireDefault(require("../logger.js"));
 
-var _package = require("../../package.json");
+var _package = _interopRequireDefault(require("../../package.json"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 const corsEnabled = typeof location !== 'undefined' && typeof document !== 'undefined';
-let userAgent = `Citation.js/${_package.version} Node.js/${process.version}`;
+let userAgent = `Citation.js/${_package.default.version} Node.js/${process.version}`;
 
 function normaliseHeaders(headers) {
   const result = {};
@@ -2409,7 +2410,7 @@ function setUserAgent(newUserAgent) {
 var _default = fetchFile;
 exports.default = _default;
 }).call(this)}).call(this,require('_process'))
-},{"../../package.json":42,"../logger":10,"_process":141,"isomorphic-fetch":114,"sync-fetch":145}],36:[function(require,module,exports){
+},{"../../package.json":42,"../logger.js":10,"_process":133,"isomorphic-fetch":106,"sync-fetch":137}],36:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -2437,7 +2438,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.Grammar = void 0;
 
-var _deepCopy = require("./deepCopy");
+var _deepCopy = require("./deepCopy.js");
 
 class Grammar {
   constructor(rules, state) {
@@ -2489,11 +2490,35 @@ class Grammar {
 }
 
 exports.Grammar = Grammar;
-},{"./deepCopy":34}],38:[function(require,module,exports){
+},{"./deepCopy.js":34}],38:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
+});
+Object.defineProperty(exports, "Grammar", {
+  enumerable: true,
+  get: function () {
+    return _grammar.Grammar;
+  }
+});
+Object.defineProperty(exports, "Register", {
+  enumerable: true,
+  get: function () {
+    return _register.default;
+  }
+});
+Object.defineProperty(exports, "TokenStack", {
+  enumerable: true,
+  get: function () {
+    return _stack.default;
+  }
+});
+Object.defineProperty(exports, "Translator", {
+  enumerable: true,
+  get: function () {
+    return _translator.Translator;
+  }
 });
 Object.defineProperty(exports, "deepCopy", {
   enumerable: true,
@@ -2513,59 +2538,35 @@ Object.defineProperty(exports, "fetchFileAsync", {
     return _fetchFile.fetchFileAsync;
   }
 });
-Object.defineProperty(exports, "setUserAgent", {
-  enumerable: true,
-  get: function () {
-    return _fetchFile.setUserAgent;
-  }
-});
 Object.defineProperty(exports, "fetchId", {
   enumerable: true,
   get: function () {
     return _fetchId.default;
   }
 });
-Object.defineProperty(exports, "TokenStack", {
+Object.defineProperty(exports, "setUserAgent", {
   enumerable: true,
   get: function () {
-    return _stack.default;
-  }
-});
-Object.defineProperty(exports, "Register", {
-  enumerable: true,
-  get: function () {
-    return _register.default;
-  }
-});
-Object.defineProperty(exports, "Grammar", {
-  enumerable: true,
-  get: function () {
-    return _grammar.Grammar;
-  }
-});
-Object.defineProperty(exports, "Translator", {
-  enumerable: true,
-  get: function () {
-    return _translator.Translator;
+    return _fetchFile.setUserAgent;
   }
 });
 
-var _deepCopy = _interopRequireDefault(require("./deepCopy"));
+var _deepCopy = _interopRequireDefault(require("./deepCopy.js"));
 
-var _fetchFile = require("./fetchFile");
+var _fetchFile = require("./fetchFile.js");
 
-var _fetchId = _interopRequireDefault(require("./fetchId"));
+var _fetchId = _interopRequireDefault(require("./fetchId.js"));
 
-var _stack = _interopRequireDefault(require("./stack"));
+var _stack = _interopRequireDefault(require("./stack.js"));
 
-var _register = _interopRequireDefault(require("./register"));
+var _register = _interopRequireDefault(require("./register.js"));
 
-var _grammar = require("./grammar");
+var _grammar = require("./grammar.js");
 
-var _translator = require("./translator");
+var _translator = require("./translator.js");
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-},{"./deepCopy":34,"./fetchFile":35,"./fetchId":36,"./grammar":37,"./register":39,"./stack":40,"./translator":41}],39:[function(require,module,exports){
+},{"./deepCopy.js":34,"./fetchFile.js":35,"./fetchId.js":36,"./grammar.js":37,"./register.js":39,"./stack.js":40,"./translator.js":41}],39:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -2840,8 +2841,14 @@ function createConverter(props, toSource) {
       let outputData = inputProp.map(prop => input[prop]);
 
       if (convert) {
-        const converted = convert.apply(input, outputData);
-        outputData = outputProp.length === 1 ? [converted] : converted;
+        try {
+          const converted = convert.apply(input, outputData);
+          outputData = outputProp.length === 1 ? [converted] : converted;
+        } catch (cause) {
+          throw new Error(`Failed to convert ${inputProp} to ${outputProp}`, {
+            cause
+          });
+        }
       }
 
       outputProp.forEach((prop, index) => {
@@ -2870,83 +2877,47 @@ Translator.CONVERT_TO_SOURCE = Symbol('convert to source');
 Translator.CONVERT_TO_TARGET = Symbol('convert to target');
 },{}],42:[function(require,module,exports){
 module.exports={
-  "_args": [
-    [
-      "@citation-js/core@0.5.1",
-      "/home/egonw/tmp/bundle/bundle-tool"
-    ]
-  ],
-  "_development": true,
-  "_from": "@citation-js/core@0.5.1",
-  "_id": "@citation-js/core@0.5.1",
-  "_inBundle": false,
-  "_integrity": "sha512-2t4qcDJ/egb+PodvjaZUA6sm3j4mfx8YQV+duB19e/kcuNvEZ+trQrqWvFUp4lPolHF/YufEs81gSs2N3Dc5xA==",
-  "_location": "/@citation-js/core",
-  "_phantomChildren": {},
-  "_requested": {
-    "type": "version",
-    "registry": true,
-    "raw": "@citation-js/core@0.5.1",
-    "name": "@citation-js/core",
-    "escapedName": "@citation-js%2fcore",
-    "scope": "@citation-js",
-    "rawSpec": "0.5.1",
-    "saveSpec": null,
-    "fetchSpec": "0.5.1"
-  },
-  "_requiredBy": [
-    "#DEV:/"
-  ],
-  "_resolved": "https://registry.npmjs.org/@citation-js/core/-/core-0.5.1.tgz",
-  "_spec": "0.5.1",
-  "_where": "/home/egonw/tmp/bundle/bundle-tool",
-  "author": {
-    "name": "Lars Willighagen",
-    "email": "lars.willighagen@gmail.com"
-  },
-  "bugs": {
-    "url": "https://github.com/citation-js/citation-js/issues"
-  },
-  "dependencies": {
-    "@citation-js/date": "^0.4.4",
-    "@citation-js/name": "^0.4.2",
-    "isomorphic-fetch": "^3.0.0",
-    "sync-fetch": "^0.2.0"
-  },
+  "name": "@citation-js/core",
+  "version": "0.5.4",
   "description": "Convert different bibliographic metadata sources",
-  "devDependencies": {
-    "@babel/plugin-proposal-class-properties": "^7.12.1"
-  },
-  "directories": {
-    "lib": "src",
-    "test": "__tests__"
-  },
-  "engines": {
-    "node": ">=8"
-  },
-  "files": [
-    "lib",
-    "lib-mjs"
-  ],
-  "gitHead": "3f3eee0813c7d578a454c34e402fa342d0693cfa",
-  "homepage": "https://citation.js.org/",
   "keywords": [
     "citation-js",
     "citation",
     "bibliography"
   ],
+  "author": "Lars Willighagen <lars.willighagen@gmail.com>",
   "license": "MIT",
   "main": "lib/index.js",
   "module": "lib-mjs/index.js",
-  "name": "@citation-js/core",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/citation-js/citation-js/tree/master/packages/core"
+  "directories": {
+    "lib": "src",
+    "test": "__tests__"
   },
+  "homepage": "https://citation.js.org/",
+  "repository": "https://github.com/citation-js/citation-js/tree/master/packages/core",
+  "bugs": {
+    "url": "https://github.com/citation-js/citation-js/issues"
+  },
+  "engines": {
+    "node": ">=10"
+  },
+  "files": [
+    "lib",
+    "lib-mjs"
+  ],
   "scripts": {
     "test": "mocha -c -R dot test/*.spec.js"
   },
-  "version": "0.5.1"
+  "dependencies": {
+    "@citation-js/date": "^0.5.0",
+    "@citation-js/name": "^0.4.2",
+    "isomorphic-fetch": "^3.0.0",
+    "sync-fetch": "^0.3.0"
+  },
+  "devDependencies": {
+    "@babel/plugin-proposal-class-properties": "^7.12.1"
+  },
+  "gitHead": "bd67972fd6078b646d4aac84a5fda9bdd9433122"
 }
 
 },{}],43:[function(require,module,exports){
@@ -2955,16 +2926,16 @@ module.exports={
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-Object.defineProperty(exports, "parse", {
-  enumerable: true,
-  get: function get() {
-    return _input.default;
-  }
-});
 Object.defineProperty(exports, "format", {
   enumerable: true,
   get: function get() {
     return _output.default;
+  }
+});
+Object.defineProperty(exports, "parse", {
+  enumerable: true,
+  get: function get() {
+    return _input.default;
   }
 });
 
@@ -2981,11 +2952,15 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.default = void 0;
 
-function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _nonIterableRest(); }
+function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest(); }
 
-function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance"); }
+function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
 
-function _iterableToArrayLimit(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
+
+function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+
+function _iterableToArrayLimit(arr, i) { var _i = arr == null ? null : typeof Symbol !== "undefined" && arr[Symbol.iterator] || arr["@@iterator"]; if (_i == null) return; var _arr = []; var _n = true; var _d = false; var _s, _e; try { for (_i = _i.call(arr); !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
 
 function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
@@ -3003,18 +2978,22 @@ const monthMap = {
   nov: 11,
   dec: 12
 };
+const dateRangeDelimiters = / (?:to|[-/]) | ?(?:--|[–—]) ?/;
+const dateRangePattern = /^(\d{4}-\d{2}-\d{2})\/(\d{4}-\d{2}-\d{2})$/;
 
-const getMonth = monthName => monthMap[monthName.toLowerCase().slice(0, 3)];
+function getMonth(monthName) {
+  return monthMap[monthName.toLowerCase().slice(0, 3)];
+}
 
-const parseEpoch = function parseEpoch(date) {
-  let epoch = new Date(date);
+function parseEpoch(date) {
+  const epoch = new Date(date);
 
   if (typeof date === 'number' && !isNaN(epoch.valueOf())) {
     return [epoch.getFullYear(), epoch.getMonth() + 1, epoch.getDate()];
   } else {
     return null;
   }
-};
+}
 
 const parseIso8601 = function parseIso8601(date) {
   const pattern = /^(\d{4}|[-+]\d{6,})-(\d{2})(?:-(\d{2}))?/;
@@ -3023,11 +3002,11 @@ const parseIso8601 = function parseIso8601(date) {
     return null;
   }
 
-  let _date$match = date.match(pattern),
-      _date$match2 = _slicedToArray(_date$match, 4),
-      year = _date$match2[1],
-      month = _date$match2[2],
-      day = _date$match2[3];
+  const _date$match = date.match(pattern),
+        _date$match2 = _slicedToArray(_date$match, 4),
+        year = _date$match2[1],
+        month = _date$match2[2],
+        day = _date$match2[3];
 
   if (!+month) {
     return [year];
@@ -3060,29 +3039,29 @@ const parseRfc2822 = function parseRfc2822(date) {
   return [year, month, day];
 };
 
-const parseAmericanDay = function parseAmericanDay(date) {
+function parseAmericanDay(date) {
   const pattern = /^(\d{1,2})\/(\d{1,2})\/(\d{2}(?:\d{2})?)/;
 
   if (typeof date !== 'string' || !pattern.test(date)) {
     return null;
   }
 
-  let _date$match5 = date.match(pattern),
-      _date$match6 = _slicedToArray(_date$match5, 4),
-      month = _date$match6[1],
-      day = _date$match6[2],
-      year = _date$match6[3];
+  const _date$match5 = date.match(pattern),
+        _date$match6 = _slicedToArray(_date$match5, 4),
+        month = _date$match6[1],
+        day = _date$match6[2],
+        year = _date$match6[3];
 
-  let check = new Date(year, month, day);
+  const check = new Date(year, month, day);
 
   if (check.getMonth() === parseInt(month)) {
     return [year, month, day];
   } else {
     return null;
   }
-};
+}
 
-const parseDay = function parseDay(date) {
+function parseDay(date) {
   const pattern = /^(\d{1,2})[ .\-/](\d{1,2}|[a-z]{3,10})[ .\-/](-?\d+)/i;
   const reversePattern = /^(-?\d+)[ .\-/](\d{1,2}|[a-z]{3,10})[ .\-/](\d{1,2})/i;
   let year;
@@ -3118,13 +3097,13 @@ const parseDay = function parseDay(date) {
   }
 
   return [year, month, day];
-};
+}
 
-const parseMonth = function parseMonth(date) {
+function parseMonth(date) {
   const pattern = /^([a-z]{3,10}|-?\d+)[^\w-]+([a-z]{3,10}|-?\d+)$/i;
 
   if (typeof date === 'string' && pattern.test(date)) {
-    let values = date.match(pattern).slice(1, 3);
+    const values = date.match(pattern).slice(1, 3);
     let month;
 
     if (getMonth(values[1])) {
@@ -3141,35 +3120,71 @@ const parseMonth = function parseMonth(date) {
       month = values.shift();
     }
 
-    let year = values.pop();
+    const year = values.pop();
     return [year, month];
   } else {
     return null;
   }
-};
+}
 
-const parseYear = function parseYear(date) {
-  if (typeof date === 'string' && /^-?\d+$/.test(date)) {
+function parseYear(date) {
+  if (typeof date !== 'string') {
+    return null;
+  }
+
+  const adBc = date.match(/^(\d+) ?(a\.?d\.?|b\.?c\.?)$/i);
+
+  if (adBc) {
+    const _adBc$slice = adBc.slice(1),
+          _adBc$slice2 = _slicedToArray(_adBc$slice, 2),
+          date = _adBc$slice2[0],
+          suffix = _adBc$slice2[1];
+
+    return [date * (suffix.toLowerCase()[0] === 'a' ? 1 : -1)];
+  } else if (/^-?\d+$/.test(date)) {
     return [date];
   } else {
     return null;
   }
-};
+}
 
-const parseDate = function parseDate(value) {
-  let dateParts = parseEpoch(value) || parseIso8601(value) || parseRfc2822(value) || parseAmericanDay(value) || parseDay(value) || parseMonth(value) || parseYear(value);
+function parseDateParts(value) {
+  const dateParts = parseEpoch(value) || parseIso8601(value) || parseRfc2822(value) || parseAmericanDay(value) || parseDay(value) || parseMonth(value) || parseYear(value);
+  return dateParts && dateParts.map(string => parseInt(string));
+}
 
-  if (dateParts) {
-    dateParts = dateParts.map(string => parseInt(string));
+function splitDateRange(range) {
+  if (dateRangePattern.test(range)) {
+    return range.match(dateRangePattern).slice(1, 3);
+  } else {
+    return range.split(dateRangeDelimiters);
+  }
+}
+
+function parseDate(rangeStart, rangeEnd) {
+  const range = [];
+  const rangeStartAsRange = typeof rangeStart === 'string' && splitDateRange(rangeStart);
+
+  if (rangeEnd) {
+    range.push(rangeStart, rangeEnd);
+  } else if (rangeStartAsRange && rangeStartAsRange.length === 2) {
+    range.push(...rangeStartAsRange);
+  } else {
+    range.push(rangeStart);
+  }
+
+  const dateParts = range.map(parseDateParts);
+
+  if (dateParts.filter(Boolean).length === range.length) {
     return {
-      'date-parts': [dateParts]
+      'date-parts': dateParts
     };
   } else {
     return {
-      raw: value
+      raw: rangeEnd ? range.join('/') : rangeStart
     };
   }
-};
+}
 
 var _default = parseDate;
 exports.default = _default;
@@ -3198,7 +3213,7 @@ const getDate = function getDate(date, delimiter = '-') {
     return date.raw;
   }
 
-  let dateParts = date['date-parts'][0].map(part => part.toString());
+  const dateParts = date['date-parts'][0].map(part => part.toString());
 
   switch (dateParts.length) {
     case 3:
@@ -3218,8 +3233,30 @@ const getDate = function getDate(date, delimiter = '-') {
 var _default = getDate;
 exports.default = _default;
 },{}],46:[function(require,module,exports){
-arguments[4][43][0].apply(exports,arguments)
-},{"./input":47,"./output":48,"dup":43}],47:[function(require,module,exports){
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+Object.defineProperty(exports, "parse", {
+  enumerable: true,
+  get: function get() {
+    return _input.default;
+  }
+});
+Object.defineProperty(exports, "format", {
+  enumerable: true,
+  get: function get() {
+    return _output.default;
+  }
+});
+
+var _input = _interopRequireDefault(require("./input"));
+
+var _output = _interopRequireDefault(require("./output"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+},{"./input":47,"./output":48}],47:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -3354,21 +3391,23 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.default = void 0;
 
-var biblatex = _interopRequireWildcard(require("./mapping/biblatexTypes"));
+var _biblatexTypes = _interopRequireDefault(require("./mapping/biblatexTypes.json"));
 
-var bibtex = _interopRequireWildcard(require("./mapping/bibtexTypes"));
+var _bibtexTypes = _interopRequireDefault(require("./mapping/bibtexTypes.json"));
 
-var constants = _interopRequireWildcard(require("./input/constants"));
+var constants = _interopRequireWildcard(require("./input/constants.js"));
 
 function _getRequireWildcardCache(nodeInterop) { if (typeof WeakMap !== "function") return null; var cacheBabelInterop = new WeakMap(); var cacheNodeInterop = new WeakMap(); return (_getRequireWildcardCache = function (nodeInterop) { return nodeInterop ? cacheNodeInterop : cacheBabelInterop; })(nodeInterop); }
 
 function _interopRequireWildcard(obj, nodeInterop) { if (!nodeInterop && obj && obj.__esModule) { return obj; } if (obj === null || typeof obj !== "object" && typeof obj !== "function") { return { default: obj }; } var cache = _getRequireWildcardCache(nodeInterop); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (key !== "default" && Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj.default = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
 
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
 var _default = {
   constants,
   types: {
-    biblatex,
-    bibtex
+    biblatex: _biblatexTypes.default,
+    bibtex: _bibtexTypes.default
   },
   parse: {
     biblatex: true,
@@ -3380,25 +3419,25 @@ var _default = {
   }
 };
 exports.default = _default;
-},{"./input/constants":52,"./mapping/biblatexTypes":62,"./mapping/bibtexTypes":64}],50:[function(require,module,exports){
+},{"./input/constants.js":52,"./mapping/biblatexTypes.json":62,"./mapping/bibtexTypes.json":64}],50:[function(require,module,exports){
 "use strict";
 
 var _core = require("@citation-js/core");
 
-var _input = require("./input/");
+var _index = require("./input/index.js");
 
-var _config = _interopRequireDefault(require("./config"));
+var _config = _interopRequireDefault(require("./config.js"));
 
-var _output = _interopRequireDefault(require("./output/"));
+var _index2 = _interopRequireDefault(require("./output/index.js"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-_core.plugins.add(_input.ref, {
-  input: _input.formats,
-  output: _output.default,
+_core.plugins.add(_index.ref, {
+  input: _index.formats,
+  output: _index2.default,
   config: _config.default
 });
-},{"./config":49,"./input/":56,"./output/":70,"@citation-js/core":"citation-js"}],51:[function(require,module,exports){
+},{"./config.js":49,"./input/index.js":56,"./output/index.js":70,"@citation-js/core":"citation-js"}],51:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -3452,40 +3491,24 @@ exports.text = exports.parse = parseBibTxt;
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-Object.defineProperty(exports, "required", {
-  enumerable: true,
-  get: function () {
-    return _required.default;
-  }
-});
-Object.defineProperty(exports, "fieldTypes", {
-  enumerable: true,
-  get: function () {
-    return _fieldTypes.default;
-  }
-});
-Object.defineProperty(exports, "diacritics", {
-  enumerable: true,
-  get: function () {
-    return _unicode.diacritics;
-  }
-});
-Object.defineProperty(exports, "commands", {
-  enumerable: true,
-  get: function () {
-    return _unicode.commands;
-  }
-});
-exports.sentenceCaseLanguages = exports.mathScripts = exports.mathScriptFormatting = exports.ligatures = exports.ligaturePattern = exports.argumentCommands = exports.formatting = exports.formattingCommands = exports.formattingEnvs = exports.defaultStrings = void 0;
+exports.sentenceCaseLanguages = exports.required = exports.mathScripts = exports.mathScriptFormatting = exports.ligatures = exports.ligaturePattern = exports.formattingEnvs = exports.formattingCommands = exports.formatting = exports.fieldTypes = exports.diacritics = exports.defaultStrings = exports.commands = exports.argumentCommands = void 0;
 
-var _required = _interopRequireDefault(require("./required.json"));
+var _required2 = _interopRequireDefault(require("./required.json"));
 
-var _fieldTypes = _interopRequireDefault(require("./fieldTypes.json"));
+var _fieldTypes2 = _interopRequireDefault(require("./fieldTypes.json"));
 
-var _unicode = require("./unicode.json");
+var _unicode = _interopRequireDefault(require("./unicode.json"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
+const required = _required2.default;
+exports.required = required;
+const fieldTypes = _fieldTypes2.default;
+exports.fieldTypes = fieldTypes;
+const diacritics = _unicode.default.diacritics;
+exports.diacritics = diacritics;
+const commands = _unicode.default.commands;
+exports.commands = commands;
 const defaultStrings = {
   jan: '01',
   feb: '02',
@@ -3663,13 +3686,13 @@ Object.defineProperty(exports, "__esModule", {
 exports.parse = parse;
 exports.parseBibtex = parseBibtex;
 
-var _config = _interopRequireDefault(require("../config"));
+var _config = _interopRequireDefault(require("../config.js"));
 
-var _mapping = require("../mapping");
+var _index = require("../mapping/index.js");
 
-var _value = require("./value");
+var _value = require("./value.js");
 
-var _constants = require("./constants");
+var _constants = require("./constants.js");
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -3720,6 +3743,11 @@ function parseEntryValues(entry) {
 
   for (const property in entry.properties) {
     const value = entry.properties[property];
+
+    if (value === '') {
+      continue;
+    }
+
     output[property] = (0, _value.parse)(value + '', property, output.language);
   }
 
@@ -3733,7 +3761,7 @@ function parse(entries) {
     validate(entries, _constants.required.biblatex);
   }
 
-  return (0, _mapping.parse)(entries.map(parseEntryValues));
+  return (0, _index.parse)(entries.map(parseEntryValues));
 }
 
 function parseBibtex(entries) {
@@ -3741,9 +3769,9 @@ function parseBibtex(entries) {
     validate(entries, _constants.required.bibtex);
   }
 
-  return (0, _mapping.parseBibtex)(entries.map(parseEntryValues));
+  return (0, _index.parseBibtex)(entries.map(parseEntryValues));
 }
-},{"../config":49,"../mapping":65,"./constants":52,"./value":60}],54:[function(require,module,exports){
+},{"../config.js":49,"../mapping/index.js":65,"./constants.js":52,"./value.js":60}],54:[function(require,module,exports){
 module.exports={
   "abstract": ["field", "literal"],
   "addendum": ["field", "literal"],
@@ -3902,14 +3930,14 @@ module.exports={
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.parse = parse;
 exports.bibtexGrammar = void 0;
+exports.parse = parse;
 
 var _core = require("@citation-js/core");
 
 var _moo = _interopRequireDefault(require("moo"));
 
-var _constants = require("./constants");
+var _constants = require("./constants.js");
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -4178,19 +4206,19 @@ exports.bibtexGrammar = bibtexGrammar;
 function parse(text) {
   return bibtexGrammar.parse(lexer.reset(text));
 }
-},{"./constants":52,"@citation-js/core":"citation-js","moo":140}],56:[function(require,module,exports){
+},{"./constants.js":52,"@citation-js/core":"citation-js","moo":132}],56:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.formats = exports.ref = void 0;
+exports.ref = exports.formats = void 0;
 
-var _file = require("./file");
+var _file = require("./file.js");
 
-var _bibtxt = require("./bibtxt");
+var _bibtxt = require("./bibtxt.js");
 
-var _entries = require("./entries");
+var _entries = require("./entries.js");
 
 const ref = '@bibtex';
 exports.ref = ref;
@@ -4242,14 +4270,14 @@ const formats = {
   }
 };
 exports.formats = formats;
-},{"./bibtxt":51,"./entries":53,"./file":55}],57:[function(require,module,exports){
+},{"./bibtxt.js":51,"./entries.js":53,"./file.js":55}],57:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.getStringCase = getStringCase;
 exports.formatNameParts = formatNameParts;
+exports.getStringCase = getStringCase;
 exports.orderNameParts = orderNameParts;
 exports.orderNamePieces = orderNamePieces;
 
@@ -4384,11 +4412,11 @@ var _core = require("@citation-js/core");
 
 var _moo = _interopRequireDefault(require("moo"));
 
-var _config = _interopRequireDefault(require("../config"));
+var _config = _interopRequireDefault(require("../config.js"));
 
-var constants = _interopRequireWildcard(require("./constants"));
+var constants = _interopRequireWildcard(require("./constants.js"));
 
-var _name = require("./name");
+var _name = require("./name.js");
 
 function _getRequireWildcardCache(nodeInterop) { if (typeof WeakMap !== "function") return null; var cacheBabelInterop = new WeakMap(); var cacheNodeInterop = new WeakMap(); return (_getRequireWildcardCache = function (nodeInterop) { return nodeInterop ? cacheNodeInterop : cacheBabelInterop; })(nodeInterop); }
 
@@ -4402,13 +4430,14 @@ function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { va
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
+const commandKeywords = {
+  '\\begin': 'commandBegin',
+  '\\end': 'commandEnd'
+};
 const text = {
   command: {
     match: /\\(?:[a-zA-Z]+|.) */,
-    type: _moo.default.keywords({
-      commandBegin: '\\begin',
-      commandEnd: '\\end'
-    }),
+    type: command => commandKeywords[command],
     value: s => s.slice(1).trim()
   },
   lbrace: {
@@ -4898,7 +4927,7 @@ function parse(text, field, languages = []) {
     col: 0
   }), getMainRule(fieldType, languages));
 }
-},{"../config":49,"./constants":52,"./name":57,"@citation-js/core":"citation-js","moo":140}],61:[function(require,module,exports){
+},{"../config.js":49,"./constants.js":52,"./name.js":57,"@citation-js/core":"citation-js","moo":132}],61:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -4910,9 +4939,9 @@ var _core = require("@citation-js/core");
 
 var _date = require("@citation-js/date");
 
-var _biblatexTypes = _interopRequireDefault(require("./biblatexTypes"));
+var _biblatexTypes = _interopRequireDefault(require("./biblatexTypes.json"));
 
-var _shared = require("./shared");
+var _shared = require("./shared.js");
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -5224,7 +5253,7 @@ var _default = new _core.util.Translator([...aliases, ...nonSpec, {
   target: 'issued',
   convert: _shared.Converters.DATE
 }, {
-  source: ['year', 'month'],
+  source: ['year', 'month', 'day'],
   target: 'issued',
   convert: _shared.Converters.YEAR_MONTH,
   when: {
@@ -5433,7 +5462,7 @@ var _default = new _core.util.Translator([...aliases, ...nonSpec, {
 }]);
 
 exports.default = _default;
-},{"./biblatexTypes":62,"./shared":66,"@citation-js/core":"citation-js","@citation-js/date":43}],62:[function(require,module,exports){
+},{"./biblatexTypes.json":62,"./shared.js":66,"@citation-js/core":"citation-js","@citation-js/date":43}],62:[function(require,module,exports){
 module.exports={
   "source": {
     "article": "article-journal",
@@ -5526,9 +5555,9 @@ var _core = require("@citation-js/core");
 
 var _date = require("@citation-js/date");
 
-var _bibtexTypes = _interopRequireDefault(require("./bibtexTypes"));
+var _bibtexTypes = _interopRequireDefault(require("./bibtexTypes.json"));
 
-var _shared = require("./shared");
+var _shared = require("./shared.js");
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -5621,7 +5650,7 @@ var _default = new _core.util.Translator([{
     }
   }
 }, {
-  source: ['year', 'month'],
+  source: ['year', 'month', 'day'],
   target: 'issued',
   convert: _shared.Converters.YEAR_MONTH
 }, {
@@ -5776,7 +5805,7 @@ var _default = new _core.util.Translator([{
 }]);
 
 exports.default = _default;
-},{"./bibtexTypes":64,"./shared":66,"@citation-js/core":"citation-js","@citation-js/date":43}],64:[function(require,module,exports){
+},{"./bibtexTypes.json":64,"./shared.js":66,"@citation-js/core":"citation-js","@citation-js/date":43}],64:[function(require,module,exports){
 module.exports={
   "source": {
     "article": "article-journal",
@@ -5813,16 +5842,16 @@ module.exports={
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.parseBibtex = parseBibtex;
+exports.format = format;
 exports.formatBibtex = formatBibtex;
 exports.parse = parse;
-exports.format = format;
+exports.parseBibtex = parseBibtex;
 
-var _shared = require("./shared");
+var _shared = require("./shared.js");
 
-var _biblatex = _interopRequireDefault(require("./biblatex"));
+var _biblatex = _interopRequireDefault(require("./biblatex.js"));
 
-var _bibtex = _interopRequireDefault(require("./bibtex"));
+var _bibtex = _interopRequireDefault(require("./bibtex.js"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -5903,20 +5932,20 @@ function parse(input) {
 function format(input) {
   return _format(input, _biblatex.default);
 }
-},{"./biblatex":61,"./bibtex":63,"./shared":66}],66:[function(require,module,exports){
+},{"./biblatex.js":61,"./bibtex.js":63,"./shared.js":66}],66:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+exports.TYPE_KEYS = exports.TYPE = exports.STANDARD_NUMBERS_PATTERN = exports.MONTHS = exports.LABEL = exports.Converters = void 0;
+exports.formatLabel = formatLabel;
 exports.parseDate = parseDate;
 exports.parseMonth = parseMonth;
-exports.formatLabel = formatLabel;
-exports.Converters = exports.STANDARD_NUMBERS_PATTERN = exports.TYPE_KEYS = exports.MONTHS = exports.LABEL = exports.TYPE = void 0;
 
 var _core = require("@citation-js/core");
 
-var _config = _interopRequireDefault(require("../config"));
+var _config = _interopRequireDefault(require("../config.js"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -6108,10 +6137,14 @@ const Converters = {
 
   },
   YEAR_MONTH: {
-    toTarget(year, month) {
+    toTarget(year, month, day) {
       if (isNaN(+year)) {
         return {
           literal: year
+        };
+      } else if (!isNaN(+day) && !isNaN(+month)) {
+        return {
+          'date-parts': [[+year, +month, +day]]
         };
       } else {
         return {
@@ -6124,6 +6157,8 @@ const Converters = {
       if ('date-parts' in date) {
         const [year, month, day] = date['date-parts'][0];
         return [year.toString(), month ? day ? `${months[month - 1]} ${day}` : month : undefined];
+      } else {
+        return [];
       }
     }
 
@@ -6164,7 +6199,15 @@ const Converters = {
     },
 
     toSource(id, label, author, issued, suffix, title) {
-      const safeId = id && id.replace(unsafeChars, '') || 'undefined';
+      let safeId;
+
+      if (id === null) {
+        safeId = 'null';
+      } else if (id === undefined) {
+        safeId = 'undefined';
+      } else {
+        safeId = id.toString().replace(unsafeChars, '');
+      }
 
       if (_config.default.format.useIdAsLabel) {
         return safeId;
@@ -6223,7 +6266,7 @@ const Converters = {
   }
 };
 exports.Converters = Converters;
-},{"../config":49,"@citation-js/core":"citation-js"}],67:[function(require,module,exports){
+},{"../config.js":49,"@citation-js/core":"citation-js"}],67:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -6274,9 +6317,9 @@ Object.defineProperty(exports, "__esModule", {
 exports.format = format;
 exports.formatBibtex = formatBibtex;
 
-var _mapping = require("../mapping");
+var _index = require("../mapping/index.js");
 
-var _value = require("./value");
+var _value = require("./value.js");
 
 function formatEntryValues({
   type,
@@ -6298,13 +6341,13 @@ function formatEntryValues({
 }
 
 function format(entries) {
-  return (0, _mapping.format)(entries).map(formatEntryValues);
+  return (0, _index.format)(entries).map(formatEntryValues);
 }
 
 function formatBibtex(entries) {
-  return (0, _mapping.formatBibtex)(entries).map(formatEntryValues);
+  return (0, _index.formatBibtex)(entries).map(formatEntryValues);
 }
-},{"../mapping":65,"./value":71}],70:[function(require,module,exports){
+},{"../mapping/index.js":65,"./value.js":71}],70:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -6314,11 +6357,11 @@ exports.default = void 0;
 
 var _core = require("@citation-js/core");
 
-var _entries = require("./entries");
+var _entries = require("./entries.js");
 
-var _bibtex = require("./bibtex");
+var _bibtex = require("./bibtex.js");
 
-var _bibtxt = require("./bibtxt");
+var _bibtxt = require("./bibtxt.js");
 
 const factory = function (mapper, formatter) {
   return function (data, opts = {}) {
@@ -6344,7 +6387,7 @@ var _default = {
   bibtxt: factory(_entries.formatBibtex, _bibtxt.format)
 };
 exports.default = _default;
-},{"./bibtex":67,"./bibtxt":68,"./entries":69,"@citation-js/core":"citation-js"}],71:[function(require,module,exports){
+},{"./bibtex.js":67,"./bibtxt.js":68,"./entries.js":69,"@citation-js/core":"citation-js"}],71:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -6352,7 +6395,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.format = format;
 
-var _constants = require("../input/constants");
+var _constants = require("../input/constants.js");
 
 const unicode = {};
 
@@ -6477,17 +6520,18 @@ function format(field, value) {
     return formatSingleValue(value, valueType);
   }
 }
-},{"../input/constants":52}],72:[function(require,module,exports){
+},{"../input/constants.js":52}],72:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.parseAsync = exports.parse = void 0;
-
-var _json = _interopRequireDefault(require("./json"));
+exports.parse = parseDoiApi;
+exports.parseAsync = parseDoiApiAsync;
 
 var _core = require("@citation-js/core");
+
+var _json = _interopRequireDefault(require("./json.js"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -6498,58 +6542,54 @@ const apiOptions = {
   }
 };
 
-const fetchDoiApiAsync = async function (url) {
+async function fetchDoiApiAsync(url) {
   const result = await _core.util.fetchFileAsync(url, apiOptions);
   return result === '[]' ? {} : JSON.parse(result);
-};
+}
 
-const parseDoiApiAsync = async function (data) {
+async function parseDoiApiAsync(data) {
   const doiJsonList = await Promise.all([].concat(data).map(fetchDoiApiAsync));
   return doiJsonList.map(_json.default);
-};
+}
 
-exports.parseAsync = parseDoiApiAsync;
-
-const fetchDoiApi = function (url) {
+function fetchDoiApi(url) {
   const result = _core.util.fetchFile(url, apiOptions);
 
   return result === '[]' ? {} : JSON.parse(result);
-};
+}
 
-const parseDoiApi = data => [].concat(data).map(fetchDoiApi).map(_json.default);
-
-exports.parse = parseDoiApi;
-},{"./json":75,"@citation-js/core":"citation-js"}],73:[function(require,module,exports){
+function parseDoiApi(data) {
+  return [].concat(data).map(fetchDoiApi).map(_json.default);
+}
+},{"./json.js":75,"@citation-js/core":"citation-js"}],73:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.default = exports.parse = void 0;
+exports.default = exports.parse = parseDoi;
 
-const parseDoi = data => {
+function parseDoi(data) {
   const list = Array.isArray(data) ? data : data.trim().split(/(?:\s+)/g);
   return list.map(doi => `https://doi.org/${doi}`);
-};
-
-exports.default = exports.parse = parseDoi;
+}
 },{}],74:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.formats = exports.parsers = exports.ref = void 0;
+exports.ref = exports.parsers = exports.formats = void 0;
 
 var _core = require("@citation-js/core");
 
-var id = _interopRequireWildcard(require("./id"));
+var id = _interopRequireWildcard(require("./id.js"));
 
-var api = _interopRequireWildcard(require("./api"));
+var api = _interopRequireWildcard(require("./api.js"));
 
-var json = _interopRequireWildcard(require("./json"));
+var json = _interopRequireWildcard(require("./json.js"));
 
-var type = _interopRequireWildcard(require("./type"));
+var type = _interopRequireWildcard(require("./type.js"));
 
 function _getRequireWildcardCache(nodeInterop) { if (typeof WeakMap !== "function") return null; var cacheBabelInterop = new WeakMap(); var cacheNodeInterop = new WeakMap(); return (_getRequireWildcardCache = function (nodeInterop) { return nodeInterop ? cacheNodeInterop : cacheBabelInterop; })(nodeInterop); }
 
@@ -6604,21 +6644,21 @@ exports.formats = formats;
 _core.plugins.add(ref, {
   input: formats
 });
-},{"./api":72,"./id":73,"./json":75,"./type":76,"@citation-js/core":"citation-js"}],75:[function(require,module,exports){
+},{"./api.js":72,"./id.js":73,"./json.js":75,"./type.js":76,"@citation-js/core":"citation-js"}],75:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.default = exports.parse = void 0;
+exports.default = exports.parse = parseDoiJson;
 
-var _type = _interopRequireDefault(require("./type"));
+var _type = _interopRequireDefault(require("./type.js"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-const parseDoiJson = function (data) {
+function parseDoiJson(data) {
   const res = {
-    type: (0, _type.default)(data.type)
+    type: (0, _type.default)(data.type, data)
   };
   const dateFields = ['submitted', 'issued', 'event-date', 'original-date', 'container', 'accessed'];
   dateFields.forEach(field => {
@@ -6629,26 +6669,28 @@ const parseDoiJson = function (data) {
     }
   });
   return Object.assign({}, data, res);
-};
-
-exports.default = exports.parse = parseDoiJson;
-},{"./type":76}],76:[function(require,module,exports){
+}
+},{"./type.js":76}],76:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.default = exports.parse = void 0;
-const varDoiTypes = {
+exports.default = exports.parse = fetchDoiType;
+const doiTypes = {
   'journal-article': 'article-journal',
   'book-chapter': 'chapter',
   'posted-content': 'manuscript',
   'proceedings-article': 'paper-conference'
 };
 
-const fetchDoiType = value => varDoiTypes[value] || value;
+function fetchDoiType(value, data) {
+  if (value === 'posted-content' && data.subtype === 'preprint') {
+    return 'article';
+  }
 
-exports.default = exports.parse = fetchDoiType;
+  return doiTypes[value] || value;
+}
 },{}],77:[function(require,module,exports){
 "use strict";
 
@@ -6791,7 +6833,7 @@ function format(records) {
 
 const GOOGLE_BOOKS_API_VERSION = 'v1';
 exports.GOOGLE_BOOKS_API_VERSION = GOOGLE_BOOKS_API_VERSION;
-},{"@citation-js/core":"citation-js","@citation-js/date":81,"@citation-js/name":46}],78:[function(require,module,exports){
+},{"@citation-js/core":"citation-js","@citation-js/date":43,"@citation-js/name":46}],78:[function(require,module,exports){
 "use strict";
 
 var _core = require("@citation-js/core");
@@ -7123,290 +7165,9 @@ function format(records) {
 
   return output;
 }
-},{"@citation-js/core":"citation-js","@citation-js/date":81,"@citation-js/name":46}],81:[function(require,module,exports){
-arguments[4][43][0].apply(exports,arguments)
-},{"./input":82,"./output":83,"dup":43}],82:[function(require,module,exports){
-"use strict";
-
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-exports.default = void 0;
-
-function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest(); }
-
-function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
-
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
-
-function _iterableToArrayLimit(arr, i) { var _i = arr && (typeof Symbol !== "undefined" && arr[Symbol.iterator] || arr["@@iterator"]); if (_i == null) return; var _arr = []; var _n = true; var _d = false; var _s, _e; try { for (_i = _i.call(arr); !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
-
-function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
-
-const monthMap = {
-  jan: 1,
-  feb: 2,
-  mar: 3,
-  apr: 4,
-  may: 5,
-  jun: 6,
-  jul: 7,
-  aug: 8,
-  sep: 9,
-  oct: 10,
-  nov: 11,
-  dec: 12
-};
-const dateRangeDelimiters = / (?:to|[-/]) | ?(?:--|[–—]) ?|(?<=\d{4}-\d{2}-\d{2})\/(?=\d{4}-\d{2}-\d{2})/;
-
-function getMonth(monthName) {
-  return monthMap[monthName.toLowerCase().slice(0, 3)];
-}
-
-function parseEpoch(date) {
-  const epoch = new Date(date);
-
-  if (typeof date === 'number' && !isNaN(epoch.valueOf())) {
-    return [epoch.getFullYear(), epoch.getMonth() + 1, epoch.getDate()];
-  } else {
-    return null;
-  }
-}
-
-const parseIso8601 = function parseIso8601(date) {
-  const pattern = /^(\d{4}|[-+]\d{6,})-(\d{2})(?:-(\d{2}))?/;
-
-  if (typeof date !== 'string' || !pattern.test(date)) {
-    return null;
-  }
-
-  const _date$match = date.match(pattern),
-        _date$match2 = _slicedToArray(_date$match, 4),
-        year = _date$match2[1],
-        month = _date$match2[2],
-        day = _date$match2[3];
-
-  if (!+month) {
-    return [year];
-  } else if (!+day) {
-    return [year, month];
-  } else {
-    return [year, month, day];
-  }
-};
-
-const parseRfc2822 = function parseRfc2822(date) {
-  const pattern = /^(?:[a-z]{3},\s*)?(\d{1,2}) ([a-z]{3}) (\d{4,})/i;
-
-  if (typeof date !== 'string' || !pattern.test(date)) {
-    return null;
-  }
-
-  let _date$match3 = date.match(pattern),
-      _date$match4 = _slicedToArray(_date$match3, 4),
-      day = _date$match4[1],
-      month = _date$match4[2],
-      year = _date$match4[3];
-
-  month = getMonth(month);
-
-  if (!month) {
-    return null;
-  }
-
-  return [year, month, day];
-};
-
-function parseAmericanDay(date) {
-  const pattern = /^(\d{1,2})\/(\d{1,2})\/(\d{2}(?:\d{2})?)/;
-
-  if (typeof date !== 'string' || !pattern.test(date)) {
-    return null;
-  }
-
-  const _date$match5 = date.match(pattern),
-        _date$match6 = _slicedToArray(_date$match5, 4),
-        month = _date$match6[1],
-        day = _date$match6[2],
-        year = _date$match6[3];
-
-  const check = new Date(year, month, day);
-
-  if (check.getMonth() === parseInt(month)) {
-    return [year, month, day];
-  } else {
-    return null;
-  }
-}
-
-function parseDay(date) {
-  const pattern = /^(\d{1,2})[ .\-/](\d{1,2}|[a-z]{3,10})[ .\-/](-?\d+)/i;
-  const reversePattern = /^(-?\d+)[ .\-/](\d{1,2}|[a-z]{3,10})[ .\-/](\d{1,2})/i;
-  let year;
-  let month;
-  let day;
-
-  if (typeof date !== 'string') {
-    return null;
-  } else if (pattern.test(date)) {
-    var _date$match7 = date.match(pattern);
-
-    var _date$match8 = _slicedToArray(_date$match7, 4);
-
-    day = _date$match8[1];
-    month = _date$match8[2];
-    year = _date$match8[3];
-  } else if (reversePattern.test(date)) {
-    var _date$match9 = date.match(reversePattern);
-
-    var _date$match10 = _slicedToArray(_date$match9, 4);
-
-    year = _date$match10[1];
-    month = _date$match10[2];
-    day = _date$match10[3];
-  } else {
-    return null;
-  }
-
-  if (getMonth(month)) {
-    month = getMonth(month);
-  } else if (isNaN(month)) {
-    return null;
-  }
-
-  return [year, month, day];
-}
-
-function parseMonth(date) {
-  const pattern = /^([a-z]{3,10}|-?\d+)[^\w-]+([a-z]{3,10}|-?\d+)$/i;
-
-  if (typeof date === 'string' && pattern.test(date)) {
-    const values = date.match(pattern).slice(1, 3);
-    let month;
-
-    if (getMonth(values[1])) {
-      month = getMonth(values.pop());
-    } else if (getMonth(values[0])) {
-      month = getMonth(values.shift());
-    } else if (values.some(isNaN) || values.every(value => +value < 0)) {
-      return null;
-    } else if (+values[0] < 0) {
-      month = values.pop();
-    } else if (+values[0] > +values[1] && +values[1] > 0) {
-      month = values.pop();
-    } else {
-      month = values.shift();
-    }
-
-    const year = values.pop();
-    return [year, month];
-  } else {
-    return null;
-  }
-}
-
-function parseYear(date) {
-  if (typeof date !== 'string') {
-    return null;
-  }
-
-  const adBc = date.match(/^(\d+) ?(a\.?d\.?|b\.?c\.?)$/i);
-
-  if (adBc) {
-    const _adBc$slice = adBc.slice(1),
-          _adBc$slice2 = _slicedToArray(_adBc$slice, 2),
-          date = _adBc$slice2[0],
-          suffix = _adBc$slice2[1];
-
-    return [date * (suffix.toLowerCase()[0] === 'a' ? 1 : -1)];
-  } else if (/^-?\d+$/.test(date)) {
-    return [date];
-  } else {
-    return null;
-  }
-}
-
-function parseDateParts(value) {
-  const dateParts = parseEpoch(value) || parseIso8601(value) || parseRfc2822(value) || parseAmericanDay(value) || parseDay(value) || parseMonth(value) || parseYear(value);
-  return dateParts && dateParts.map(string => parseInt(string));
-}
-
-function parseDate(rangeStart, rangeEnd) {
-  const range = [];
-  const rangeStartAsRange = typeof rangeStart === 'string' && rangeStart.split(dateRangeDelimiters);
-
-  if (rangeEnd) {
-    range.push(rangeStart, rangeEnd);
-  } else if (rangeStartAsRange && rangeStartAsRange.length === 2) {
-    range.push(...rangeStartAsRange);
-  } else {
-    range.push(rangeStart);
-  }
-
-  const dateParts = range.map(parseDateParts);
-
-  if (dateParts.filter(Boolean).length === range.length) {
-    return {
-      'date-parts': dateParts
-    };
-  } else {
-    return {
-      raw: rangeEnd ? range.join('/') : rangeStart
-    };
-  }
-}
-
-var _default = parseDate;
-exports.default = _default;
-},{}],83:[function(require,module,exports){
-"use strict";
-
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-exports.default = void 0;
-
-function padStart(str, len, chr) {
-  if (str.length >= len) {
-    return str;
-  }
-
-  while (str.length < len) {
-    str = chr + str;
-  }
-
-  return str.slice(-len);
-}
-
-const getDate = function getDate(date, delimiter = '-') {
-  if (!date['date-parts']) {
-    return date.raw;
-  }
-
-  const dateParts = date['date-parts'][0].map(part => part.toString());
-
-  switch (dateParts.length) {
-    case 3:
-      dateParts[2] = padStart(dateParts[2], 2, '0');
-
-    case 2:
-      dateParts[1] = padStart(dateParts[1], 2, '0');
-
-    case 1:
-      dateParts[0] = padStart(dateParts[0], 4, '0');
-      break;
-  }
-
-  return dateParts.join(delimiter);
-};
-
-var _default = getDate;
-exports.default = _default;
-},{}],84:[function(require,module,exports){
+},{"@citation-js/core":"citation-js","@citation-js/date":43,"@citation-js/name":46}],81:[function(require,module,exports){
 arguments[4][78][0].apply(exports,arguments)
-},{"./input":85,"@citation-js/core":"citation-js","dup":78}],85:[function(require,module,exports){
+},{"./input":82,"@citation-js/core":"citation-js","dup":78}],82:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -7451,7 +7212,7 @@ const formats = {
   }
 };
 exports.formats = formats;
-},{"@citation-js/core":"citation-js"}],86:[function(require,module,exports){
+},{"@citation-js/core":"citation-js"}],83:[function(require,module,exports){
 "use strict";
 
 var _core = require("@citation-js/core");
@@ -7465,7 +7226,7 @@ const ref = '@quickstatements';
 _core.plugins.add(ref, {
   output: _output.default
 });
-},{"./output":87,"@citation-js/core":"citation-js"}],87:[function(require,module,exports){
+},{"./output":84,"@citation-js/core":"citation-js"}],84:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -7740,13 +7501,7 @@ var _default = {
 
 };
 exports.default = _default;
-},{"@citation-js/core":"citation-js","@citation-js/date":88,"@citation-js/name":46,"wikidata-sdk":176}],88:[function(require,module,exports){
-arguments[4][43][0].apply(exports,arguments)
-},{"./input":89,"./output":90,"dup":43}],89:[function(require,module,exports){
-arguments[4][82][0].apply(exports,arguments)
-},{"dup":82}],90:[function(require,module,exports){
-arguments[4][83][0].apply(exports,arguments)
-},{"dup":83}],91:[function(require,module,exports){
+},{"@citation-js/core":"citation-js","@citation-js/date":43,"@citation-js/name":46,"wikidata-sdk":168}],85:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -7778,23 +7533,23 @@ const CFF_SCHEMA = _jsYaml.default.DEFAULT_SCHEMA.extend({
 });
 
 exports.CFF_SCHEMA = CFF_SCHEMA;
-},{"js-yaml":115}],92:[function(require,module,exports){
+},{"js-yaml":107}],86:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.parse = parse;
-exports.format = format;
 exports.CFF_VERSION = void 0;
+exports.format = format;
+exports.parse = parse;
 
 var _core = require("@citation-js/core");
 
 var _date = require("@citation-js/date");
 
-function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) { symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); } keys.push.apply(keys, symbols); } return keys; }
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); enumerableOnly && (symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; })), keys.push.apply(keys, symbols); } return keys; }
 
-function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = null != arguments[i] ? arguments[i] : {}; i % 2 ? ownKeys(Object(source), !0).forEach(function (key) { _defineProperty(target, key, source[key]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)) : ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } return target; }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
@@ -8384,12 +8139,12 @@ const REF_PROPS = [...MAIN_PROPS, {
   target: 'page',
   convert: {
     toTarget(start, end) {
-      return `${start}-${end}`;
+      return end ? `${start}-${end}` : start;
     },
 
     toSource(page) {
       const [start, end] = page.split('-');
-      return [start, end];
+      return end ? [start, end] : [start];
     }
 
   }
@@ -8451,16 +8206,16 @@ function format(input, {
 
 const CFF_VERSION = '1.1.0';
 exports.CFF_VERSION = CFF_VERSION;
-},{"@citation-js/core":"citation-js","@citation-js/date":97}],93:[function(require,module,exports){
+},{"@citation-js/core":"citation-js","@citation-js/date":43}],87:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.json = json;
 exports.api = api;
-exports.url = url;
 exports.config = void 0;
+exports.json = json;
+exports.url = url;
 
 var _core = require("@citation-js/core");
 
@@ -8550,7 +8305,7 @@ function url(input) {
   const [, user, repo] = input.match(/^https?:\/\/github.com\/([^/]+)\/([^/]+)/);
   return `https://api.github.com/repos/${user}/${repo}`;
 }
-},{"@citation-js/core":"citation-js","@citation-js/date":97,"@citation-js/name":46}],94:[function(require,module,exports){
+},{"@citation-js/core":"citation-js","@citation-js/date":43,"@citation-js/name":46}],88:[function(require,module,exports){
 "use strict";
 
 var _core = require("@citation-js/core");
@@ -8634,7 +8389,7 @@ _core.plugins.add('@github', {
     '@github/url': {
       parseType: {
         dataType: 'String',
-        predicate: /^https?:\/\/github.com\/[^/]+\//,
+        predicate: /^https?:\/\/github\.com\/[^/]+\//,
         extends: '@else/url'
       },
       parse: gh.url
@@ -8642,7 +8397,7 @@ _core.plugins.add('@github', {
     '@github/api': {
       parseType: {
         dataType: 'String',
-        predicate: /^https?:\/\/api.github.com\/repos\/[^/]+\//,
+        predicate: /^https?:\/\/api\.github\.com\/repos\/[^/]+\//,
         extends: '@else/url'
       },
       parseAsync: gh.api
@@ -8654,7 +8409,7 @@ _core.plugins.add('@github', {
           props: 'url',
 
           value(url) {
-            return /^https?:\/\/api.github.com\/repos\/[^/]+\//.test(url);
+            return /^https?:\/\/api\.github\.com\/repos\/[^/]+\//.test(url);
           }
 
         }
@@ -8677,7 +8432,7 @@ _core.plugins.add('@npm', {
     '@npm/api': {
       parseType: {
         dataType: 'String',
-        predicate: /^https?:\/\/registry.npmjs.org\//,
+        predicate: /^https?:\/\/registry\.npmjs\.org\//,
         extends: '@else/url'
       },
       parseAsync: npm.api
@@ -8730,14 +8485,14 @@ _core.plugins.add('@zenodo', {
 
   }
 });
-},{"./cff":92,"./cff-yaml":91,"./gh":93,"./npm":95,"./zenodo":96,"@citation-js/core":"citation-js","js-yaml":115}],95:[function(require,module,exports){
+},{"./cff":86,"./cff-yaml":85,"./gh":87,"./npm":89,"./zenodo":90,"@citation-js/core":"citation-js","js-yaml":107}],89:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.json = json;
 exports.api = api;
+exports.json = json;
 exports.url = url;
 
 var _core = require("@citation-js/core");
@@ -8792,15 +8547,15 @@ function url(input) {
   const [, pkg] = input.match(/((@[^/]+\/)?[^/]+)$/);
   return `https://registry.npmjs.org/${pkg}`;
 }
-},{"@citation-js/core":"citation-js","@citation-js/date":97,"@citation-js/name":46}],96:[function(require,module,exports){
+},{"@citation-js/core":"citation-js","@citation-js/date":43,"@citation-js/name":46}],90:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.parse = parse;
-exports.format = format;
 exports.VERSION = void 0;
+exports.format = format;
+exports.parse = parse;
 
 var _core = require("@citation-js/core");
 
@@ -8808,9 +8563,9 @@ var _name = require("@citation-js/name");
 
 var _date = require("@citation-js/date");
 
-function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) { symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); } keys.push.apply(keys, symbols); } return keys; }
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); enumerableOnly && (symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; })), keys.push.apply(keys, symbols); } return keys; }
 
-function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = null != arguments[i] ? arguments[i] : {}; i % 2 ? ownKeys(Object(source), !0).forEach(function (key) { _defineProperty(target, key, source[key]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)) : ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } return target; }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
@@ -9128,13 +8883,7 @@ function format(input) {
 
 const VERSION = '1.0.0';
 exports.VERSION = VERSION;
-},{"@citation-js/core":"citation-js","@citation-js/date":97,"@citation-js/name":46}],97:[function(require,module,exports){
-arguments[4][43][0].apply(exports,arguments)
-},{"./input":98,"./output":99,"dup":43}],98:[function(require,module,exports){
-arguments[4][82][0].apply(exports,arguments)
-},{"dup":82}],99:[function(require,module,exports){
-arguments[4][83][0].apply(exports,arguments)
-},{"dup":83}],100:[function(require,module,exports){
+},{"@citation-js/core":"citation-js","@citation-js/date":43,"@citation-js/name":46}],91:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -9157,28 +8906,32 @@ function parse(urls) {
 function parseAsync(urls) {
   return Promise.all([].concat(urls).map(fetchFileAsync));
 }
-},{"@citation-js/core":"citation-js"}],101:[function(require,module,exports){
+},{"@citation-js/core":"citation-js"}],92:[function(require,module,exports){
 module.exports={
   "langs": ["en"]
 }
 
-},{}],102:[function(require,module,exports){
+},{}],93:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.parseEntity = parseEntity;
-exports.parseAsync = exports.parseEntitiesAsync = parseEntitiesAsync;
 exports.default = exports.parse = exports.parseEntities = parseEntities;
+exports.parseAsync = exports.parseEntitiesAsync = parseEntitiesAsync;
+exports.parseEntity = parseEntity;
 
 var _core = require("@citation-js/core");
 
-var response = _interopRequireWildcard(require("./response"));
+var response = _interopRequireWildcard(require("./response.js"));
 
-var _prop = require("./prop");
+var _prop = require("./prop.js");
 
-var _props = require("./props");
+var _props = _interopRequireDefault(require("./props.json"));
+
+var _ignoredProps = _interopRequireDefault(require("./ignoredProps.json"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _getRequireWildcardCache(nodeInterop) { if (typeof WeakMap !== "function") return null; var cacheBabelInterop = new WeakMap(); var cacheNodeInterop = new WeakMap(); return (_getRequireWildcardCache = function (nodeInterop) { return nodeInterop ? cacheNodeInterop : cacheBabelInterop; })(nodeInterop); }
 
@@ -9223,8 +8976,8 @@ function parseEntity(entity) {
   };
   const unkown = new Set(Object.keys(entity.claims));
 
-  for (const prop in _props.props) {
-    const input = prepareValue(_props.props[prop], entity, unkown);
+  for (const prop in _props.default) {
+    const input = prepareValue(_props.default[prop], entity, unkown);
 
     if (input) {
       const output = (0, _prop.parseProp)(prop, input, entity);
@@ -9236,7 +8989,7 @@ function parseEntity(entity) {
   }
 
   for (const prop of unkown) {
-    if (prop in _props.ignoredProps) {
+    if (prop in _ignoredProps.default) {
       continue;
     }
 
@@ -9277,17 +9030,17 @@ function parseEntities({
 }) {
   return response.parse(entities).map(parseEntity);
 }
-},{"./prop":105,"./props":106,"./response":107,"@citation-js/core":"citation-js"}],103:[function(require,module,exports){
+},{"./ignoredProps.json":95,"./prop.js":97,"./props.json":98,"./response.js":99,"@citation-js/core":"citation-js"}],94:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.default = exports.parse = void 0;
+exports.parse = exports.default = void 0;
 
 var _wikidataSdk = _interopRequireDefault(require("wikidata-sdk"));
 
-var _config = _interopRequireDefault(require("./config"));
+var _config = _interopRequireDefault(require("./config.json"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -9297,27 +9050,35 @@ const parseWikidata = function (data, langs) {
 };
 
 exports.default = exports.parse = parseWikidata;
-},{"./config":101,"wikidata-sdk":176}],104:[function(require,module,exports){
+},{"./config.json":92,"wikidata-sdk":168}],95:[function(require,module,exports){
+module.exports={
+  "P2860": "Cites",
+  "P921": "Main subject",
+  "P3181": "OpenCitations bibliographic resource ID",
+  "P364": "Original language of work"
+}
+
+},{}],96:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.formats = exports.parsers = exports.ref = void 0;
+exports.ref = exports.parsers = exports.formats = void 0;
 
 var _core = require("@citation-js/core");
 
-var id = _interopRequireWildcard(require("./id"));
+var id = _interopRequireWildcard(require("./id.js"));
 
-var entity = _interopRequireWildcard(require("./entity"));
+var entity = _interopRequireWildcard(require("./entity.js"));
 
-var prop = _interopRequireWildcard(require("./prop"));
+var prop = _interopRequireWildcard(require("./prop.js"));
 
-var url = _interopRequireWildcard(require("./url"));
+var url = _interopRequireWildcard(require("./url.js"));
 
-var api = _interopRequireWildcard(require("./api"));
+var api = _interopRequireWildcard(require("./api.js"));
 
-var _config = _interopRequireDefault(require("./config"));
+var _config = _interopRequireDefault(require("./config.json"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -9426,15 +9187,15 @@ _core.plugins.add(ref, {
   input: formats,
   config: _config.default
 });
-},{"./api":100,"./config":101,"./entity":102,"./id":103,"./prop":105,"./url":109,"@citation-js/core":"citation-js"}],105:[function(require,module,exports){
+},{"./api.js":91,"./config.json":92,"./entity.js":93,"./id.js":94,"./prop.js":97,"./url.js":101,"@citation-js/core":"citation-js"}],97:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+exports.getLabel = getLabel;
 exports.default = exports.parse = exports.parseProp = parseProp;
 exports.parseType = parseType;
-exports.getLabel = getLabel;
 
 var _core = require("@citation-js/core");
 
@@ -9442,9 +9203,9 @@ var _name = require("@citation-js/name");
 
 var _date = require("@citation-js/date");
 
-var _config = _interopRequireDefault(require("./config"));
+var _config = _interopRequireDefault(require("./config.json"));
 
-var _types = _interopRequireDefault(require("./types"));
+var _types = _interopRequireDefault(require("./types.json"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -9570,148 +9331,140 @@ function getLabel(entity) {
 
   return entity.labels[lang];
 }
-},{"./config":101,"./types":108,"@citation-js/core":"citation-js","@citation-js/date":43,"@citation-js/name":46}],106:[function(require,module,exports){
+},{"./config.json":92,"./types.json":100,"@citation-js/core":"citation-js","@citation-js/date":43,"@citation-js/name":46}],98:[function(require,module,exports){
 module.exports={
-  "props": {
-    "author": {
-      "values": "all",
-      "props": ["P50", "P2093"]
-    },
-    "composer": {
-      "values": "all",
-      "props": ["P86"]
-    },
-
-    "collection-editor": {
-      "values": "all",
-      "props": ["P179.P98"]
-    },
-    "collection-number": {
-      "values": "all",
-      "props": ["P179"]
-    },
-    "collection-title": "P179",
-
-    "container-author": {
-      "values": "all",
-      "props": ["P1433.P50", "P1433.P2093", "P361.P50", "P361.P2093"]
-    },
-    "container-title": { "values": "any", "props": ["P1433", "P361"] },
-    "container-title-short": { "values": "any", "props": ["P1433.P1813", "P1433.P1160"] },
-
-    "director": {
-      "values": "all",
-      "props": ["P57"]
-    },
-    "DOI": "P356",
-    "edition": "P393",
-    "editor": {
-      "values": "all",
-      "props": ["P98"]
-    },
-
-    "event": "P1433.P4745",
-    "event-date": {
-      "values": "all",
-      "props": ["P1433.P4745.P580", "P1433.P4745.P582"]
-    },
-    "event-place": "P1433.P4745.P276",
-
-    "illustrator": {
-      "values": "all",
-      "props": ["P110"]
-    },
-    "ISBN": {
-      "values": "any",
-      "props": ["P212", "P957"]
-    },
-    "ISSN": "P1433.P236",
-    "issue": "P433",
-    "issued": "P577",
-    "journalAbbreviation": { "values": "any", "props": ["P1433.P1813", "P1433.P1160"] },
-    "keyword": {
-      "values": "all",
-      "props": ["P921"]
-    },
-    "language": {
-      "values": "any",
-      "props": ["P407.P218", "P364.P218"]
-    },
-    "medium": { "values": "any", "props": ["P437", "P186"] },
-    "number-of-pages": "P1104",
-    "number-of-volumes": {
-      "values": "all",
-      "props": ["P179.P527"]
-    },
-
-    "original-author": {
-      "values": "all",
-      "props": ["P629.P50", "P629.P2093"]
-    },
-    "original-date": "P629.P577",
-    "original-publisher": "P629.P123",
-    "original-publisher-place": {
-      "values": "any",
-      "props": ["P629.P123.P740", "P629.P123.P159"]
-    },
-    "original-title": "P629.P1476",
-
-    "page": "P304",
-    "PMID": "P698",
-    "PMCID": "P932",
-
-    "publisher": "P123",
-    "publisher-place": { "values": "any", "props": ["P123.P740", "P123.P159"]},
-
-    "recipient": {
-      "values": "all",
-      "props": ["P1817"]
-    },
-
-    "reviewed-title": "P921.P1476",
-    "reviewed-author": {
-      "values": "all",
-      "props": ["P921.P50", "P921.P2093"]
-    },
-
-    "scale": "P1752",
-    "title": "P1476",
-    "translator": {
-      "values": "all",
-      "props": ["P655"]
-    },
-    "type": "P31",
-    "version": "P348",
-    "volume": "P478",
-    "URL": {
-      "values": "any",
-      "props": ["P856", "P953", "P973", "P2699"]
-    }
+  "author": {
+    "values": "all",
+    "props": ["P50", "P2093"]
   },
-  "ignoredProps": {
-    "P2860": "Cites",
-    "P921": "Main subject",
-    "P3181": "OpenCitations bibliographic resource ID",
-    "P364": "Original language of work"
+  "composer": {
+    "values": "all",
+    "props": ["P86"]
+  },
+
+  "collection-editor": {
+    "values": "all",
+    "props": ["P179.P98"]
+  },
+  "collection-number": {
+    "values": "all",
+    "props": ["P179"]
+  },
+  "collection-title": "P179",
+
+  "container-author": {
+    "values": "all",
+    "props": ["P1433.P50", "P1433.P2093", "P361.P50", "P361.P2093"]
+  },
+  "container-title": { "values": "any", "props": ["P1433", "P361"] },
+  "container-title-short": { "values": "any", "props": ["P1433.P1813", "P1433.P1160"] },
+
+  "director": {
+    "values": "all",
+    "props": ["P57"]
+  },
+  "DOI": "P356",
+  "edition": "P393",
+  "editor": {
+    "values": "all",
+    "props": ["P98"]
+  },
+
+  "event": "P1433.P4745",
+  "event-date": {
+    "values": "all",
+    "props": ["P1433.P4745.P580", "P1433.P4745.P582"]
+  },
+  "event-place": "P1433.P4745.P276",
+
+  "illustrator": {
+    "values": "all",
+    "props": ["P110"]
+  },
+  "ISBN": {
+    "values": "any",
+    "props": ["P212", "P957"]
+  },
+  "ISSN": "P1433.P236",
+  "issue": "P433",
+  "issued": "P577",
+  "journalAbbreviation": { "values": "any", "props": ["P1433.P1813", "P1433.P1160"] },
+  "keyword": {
+    "values": "all",
+    "props": ["P921"]
+  },
+  "language": {
+    "values": "any",
+    "props": ["P407.P218", "P364.P218"]
+  },
+  "medium": { "values": "any", "props": ["P437", "P186"] },
+  "number-of-pages": "P1104",
+  "number-of-volumes": {
+    "values": "all",
+    "props": ["P179.P527"]
+  },
+
+  "original-author": {
+    "values": "all",
+    "props": ["P629.P50", "P629.P2093"]
+  },
+  "original-date": "P629.P577",
+  "original-publisher": "P629.P123",
+  "original-publisher-place": {
+    "values": "any",
+    "props": ["P629.P123.P740", "P629.P123.P159"]
+  },
+  "original-title": "P629.P1476",
+
+  "page": "P304",
+  "PMID": "P698",
+  "PMCID": "P932",
+
+  "publisher": "P123",
+  "publisher-place": { "values": "any", "props": ["P123.P740", "P123.P159"]},
+
+  "recipient": {
+    "values": "all",
+    "props": ["P1817"]
+  },
+
+  "reviewed-title": "P921.P1476",
+  "reviewed-author": {
+    "values": "all",
+    "props": ["P921.P50", "P921.P2093"]
+  },
+
+  "scale": "P1752",
+  "title": "P1476",
+  "translator": {
+    "values": "all",
+    "props": ["P655"]
+  },
+  "type": "P31",
+  "version": "P348",
+  "volume": "P478",
+  "URL": {
+    "values": "any",
+    "props": ["P856", "P953", "P973", "P2699"]
   }
 }
 
-},{}],107:[function(require,module,exports){
+},{}],99:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.fillCache = fillCache;
-exports.parse = parse;
 exports.fillCacheAsync = fillCacheAsync;
+exports.parse = parse;
 exports.parseAsync = parseAsync;
 
 var _wikidataSdk = require("wikidata-sdk");
 
-var _api = require("./api");
+var _api = require("./api.js");
 
-var _id = require("./id");
+var _id = require("./id.js");
 
 const SIMPLIFY_OPTS = {
   keepQualifiers: true,
@@ -9792,14 +9545,14 @@ function completeResponse(entities, old) {
 
   const ids = [];
 
-  for (var id of old) {
-    var entity = entities[id];
+  for (const id of old) {
+    const entity = entities[id];
 
     if (!entity._needed) {
       continue;
     }
 
-    for (var prop in entity.claims) {
+    for (const prop in entity.claims) {
       if (prop in entity._needed) {
         for (const claim of entity.claims[prop]) {
           if (claim.value && claim.value.id) {
@@ -9887,10 +9640,10 @@ async function parseAsync(entities) {
   const cache = await fillCacheAsync(entities);
   return finalizeItems(entities, cache);
 }
-},{"./api":100,"./id":103,"wikidata-sdk":176}],108:[function(require,module,exports){
+},{"./api.js":91,"./id.js":94,"wikidata-sdk":168}],100:[function(require,module,exports){
 module.exports={"Q191067":"article","Q1266946":"thesis","Q187685":"thesis","Q265158":"review","Q1172284":"dataset","Q2352616":"dataset","Q367035":"dataset","Q4006":"map","Q133792":"map","Q842617":"map","Q1425895":"map","Q2334719":"legal_case","Q36774":"webpage","Q15474042":"webpage","Q58494026":"webpage","Q17379835":"webpage","Q17442446":"webpage","Q21281405":"webpage","Q16222597":"webpage","Q653848":"map","Q21944833":"map","Q11424":"motion_picture","Q157443":"motion_picture","Q571":"book","Q87167":"manuscript","Q131569":"treaty","Q216665":"book","Q686822":"bill","Q10870555":"report","Q3099732":"report","Q252550":"treaty","Q3536928":"treaty","Q5707594":"article-newspaper","Q59908":"article","Q1164267":"book","Q18011172":"motion_picture","Q19389637":"article","Q11578774":"broadcast","Q15416":"broadcast","Q1555508":"broadcast","Q26260507":"broadcast","Q580922":"article","Q651270":"article","Q759838":"article","Q1580166":"entry-dictionary","Q1809676":"article","Q2106255":"article","Q1004391":"report","Q2438528":"article","Q6646525":"article","Q7216866":"post","Q7318358":"article","Q7582241":"article","Q10389811":"entry","Q13442814":"article-journal","Q17518557":"article","Q19917774":"article","Q30070590":"article-magazine","Q37974534":"article","Q637866":"review-book","Q5196473":"review","Q5251247":"review","Q42350535":"article","Q51282711":"thesis","Q51282766":"thesis","Q51282798":"thesis","Q51282875":"thesis","Q51282918":"thesis","Q51282969":"thesis","Q51282999":"thesis","Q51283026":"thesis","Q51283053":"thesis","Q51283145":"thesis","Q51283327":"thesis","Q55399605":"thesis","Q58010711":"article","Q60559362":"article","Q480498":"legal_case","Q697327":"legal_case","Q1469824":"dataset","Q2055205":"legal_case","Q162827":"map","Q460214":"map","Q2259701":"map","Q253623":"patent","Q22909582":"review","Q1172480":"dataset","Q45941145":"dataset","Q56515249":"review","Q61992233":"review","Q16968990":"book","Q21191270":"broadcast","Q26225677":"motion_picture","Q56753859":"map","Q57933693":"book","Q2823677":"legal_case","Q2865639":"legal_case","Q7307130":"legal_case","Q8016240":"legal_case","Q11827307":"legal_case","Q16738832":"legal_case","Q18146819":"legal_case","Q18536127":"legal_case","Q20917517":"legal_case","Q7366":"song","Q7302866":"song","Q25203386":"song","Q30637971":"legal_case","Q52768654":"map","Q56123235":"song","Q56612794":"song","Q60566516":"song","Q60809954":"song","Q61221204":"legal_case","Q24634210":"broadcast","Q61855877":"broadcast","Q1006160":"dataset","Q1980247":"chapter","Q19692072":"legal_case","Q23927052":"paper-conference","Q178651":"interview","Q861911":"speech","Q216526":"map","Q2940514":"map","Q3391101":"map","Q55089312":"dataset","Q56704157":"legal_case","Q26205359":"webpage","Q28326484":"webpage","Q28326490":"webpage","Q57312861":"webpage","Q106833":"book","Q128093":"book","Q20540385":"book","Q7433672":"book","Q193495":"book","Q3831846":"book","Q203490":"book","Q254554":"book","Q448980":"book","Q604219":"book","Q605076":"book","Q642946":"book","Q48498":"manuscript","Q727715":"book","Q747381":"book","Q855753":"book","Q890239":"book","Q913554":"book","Q918038":"book","Q922203":"book","Q944359":"book","Q1009641":"book","Q1631107":"dataset","Q26876682":"dataset","Q47114558":"dataset","Q1050259":"book","Q1062404":"book","Q1106827":"book","Q1173065":"book","Q1184488":"book","Q1238720":"book","Q1414013":"book","Q1415108":"book","Q162206":"map","Q191072":"map","Q320228":"map","Q352416":"map","Q441903":"map","Q573980":"map","Q602481":"map","Q715789":"map","Q728502":"map","Q1403728":"map","Q1410020":"map","Q1496857":"book","Q1528894":"book","Q1609706":"book","Q1616547":"book","Q1650727":"book","Q1760610":"book","Q1785330":"book","Q1870591":"book","Q1883939":"book","Q1977520":"book","Q1986787":"book","Q2069066":"book","Q2072218":"book","Q2104296":"book","Q2122442":"book","Q2128336":"book","Q2135225":"book","Q2208044":"book","Q2314679":"book","Q2331348":"book","Q2363145":"book","Q2374324":"book","Q2377289":"book","Q2396513":"book","Q2514954":"book","Q2537127":"book","Q2787237":"book","Q2831984":"book","Q3045706":"book","Q3831821":"book","Q3831847":"book","Q3915339":"book","Q4067007":"book","Q4224691":"book","Q4515179":"book","Q4677625":"book","Q4686085":"book","Q4931288":"book","Q5073531":"book","Q5093328":"book","Q5159310":"book","Q6675210":"book","Q8275050":"book","Q10666342":"book","Q11396303":"book","Q11750596":"book","Q12308638":"book","Q12410152":"book","Q12731131":"book","Q13137339":"book","Q13430107":"book","Q13636757":"book","Q13751595":"book","Q16046027":"book","Q16385949":"book","Q16507688":"book","Q16736578":"book","Q17134316":"book","Q21598767":"book","Q21662746":"book","Q22988237":"book","Q25679217":"book","Q12912091":"motion_picture","Q1453402":"map","Q1502030":"map","Q1664468":"map","Q1783108":"map","Q1787111":"dataset","Q1875628":"map","Q2089517":"map","Q2127425":"map","Q2353983":"map","Q2368091":"map","Q2426254":"map","Q2470969":"map","Q2471702":"map","Q2620815":"map","Q2656361":"map","Q2940478":"map","Q3509676":"map","Q3515498":"map","Q4505959":"map","Q4845530":"map","Q26267321":"book","Q26271823":"book","Q27560760":"book","Q29154430":"book","Q29586870":"book","Q31946409":"book","Q38143661":"book","Q52005090":"book","Q52153485":"book","Q55610842":"book","Q56552233":"book","Q57790812":"book","Q58142059":"book","Q58211632":"book","Q58807269":"book","Q60226001":"book","Q60475414":"book","Q60475468":"book","Q60627667":"book","Q61696018":"book","Q5047387":"map","Q5177325":"map","Q5434353":"map","Q6017843":"map","Q6664848":"map","Q7104865":"map","Q10544122":"map","Q11426259":"map","Q11618908":"map","Q14321585":"map","Q15877105":"map","Q17047956":"map","Q21935483":"map","Q22125384":"map","Q59457513":"map","Q60054914":"map","Q846662":"broadcast","Q5778924":"motion_picture","Q8513":"dataset","Q178376":"dataset","Q1675302":"map","Q267628":"article","Q871232":"article","Q3694604":"article","Q3719255":"article","Q19375673":"article","Q442919":"interview","Q850171":"interview","Q1384479":"interview","Q1477475":"interview","Q1067324":"motion_picture","Q1941707":"motion_picture","Q3055290":"interview","Q3055291":"interview","Q450873":"patent","Q681875":"patent","Q913351":"patent","Q5465504":"patent","Q2049275":"manuscript","Q213924":"manuscript","Q274076":"manuscript","Q597695":"manuscript","Q720106":"manuscript","Q865595":"manuscript","Q1067768":"manuscript","Q1266076":"manuscript","Q2209578":"manuscript","Q2217259":"manuscript","Q2531964":"manuscript","Q2816501":"manuscript","Q19787436":"patent","Q19787437":"patent","Q35639987":"patent","Q43305660":"patent","Q59818481":"dataset","Q1949797":"legal_case","Q18918145":"article-journal","Q2782326":"article-journal","Q3149408":"legal_case","Q18342738":"speech","Q3228788":"speech","Q3731370":"legal_case","Q17123524":"book","Q336144":"motion_picture","Q867242":"book","Q1093720":"treaty","Q193170":"treaty","Q625298":"treaty","Q837144":"treaty","Q864737":"treaty","Q931855":"treaty","Q1242841":"treaty","Q1414340":"treaty","Q1414472":"treaty","Q1498487":"treaty","Q1646218":"treaty","Q1671773":"treaty","Q1711115":"treaty","Q2290707":"treaty","Q2300991":"treaty","Q2465017":"treaty","Q3125472":"manuscript","Q3220177":"manuscript","Q3240926":"manuscript","Q3252544":"manuscript","Q3560324":"manuscript","Q3749265":"manuscript","Q3824506":"treaty","Q3960554":"manuscript","Q4426710":"treaty","Q4475654":"manuscript","Q4872029":"treaty","Q4985043":"treaty","Q7012086":"manuscript","Q7452368":"manuscript","Q9026959":"manuscript","Q11613006":"manuscript","Q13430250":"manuscript","Q17143154":"manuscript","Q21089188":"manuscript","Q22669850":"manuscript","Q22948347":"manuscript","Q25351420":"manuscript","Q31078443":"manuscript","Q33308141":"manuscript","Q11122":"treaty","Q451584":"legal_case","Q876477":"bill","Q1006544":"bill","Q1288220":"legal_case","Q2206565":"legal_case","Q2783852":"legal_case","Q5500839":"legal_case","Q7246224":"bill","Q7257705":"bill","Q7885007":"bill","Q859161":"dataset","Q1650567":"webpage","Q11439":"webpage","Q16602140":"bill","Q16821677":"bill","Q28457660":"bill","Q2261569":"webpage","Q2641220":"webpage","Q2737701":"webpage","Q14204246":"webpage","Q21025364":"webpage","Q23691297":"webpage","Q58040463":"webpage","Q44873079":"interview","Q4202018":"interview","Q4317093":"interview","Q7256239":"interview","Q7625207":"interview","Q8776455":"interview","Q45933791":"interview","Q60723716":"interview","Q6908053":"treaty","Q6934728":"treaty","Q6944158":"treaty","Q9160460":"treaty","Q9557810":"treaty","Q11455760":"treaty","Q11637357":"treaty","Q16567729":"treaty","Q19357149":"book","Q184528":"speech","Q203737":"speech","Q261197":"speech","Q554211":"speech","Q749054":"speech","Q787020":"speech","Q805093":"speech","Q960189":"speech","Q1346967":"speech","Q1840948":"speech","Q1980740":"speech","Q2183050":"speech","Q2895132":"speech","Q3030189":"speech","Q3040417":"speech","Q4329077":"speech","Q4388316":"speech","Q5152362":"speech","Q200092":"motion_picture","Q224700":"motion_picture","Q248583":"motion_picture","Q457832":"motion_picture","Q622548":"motion_picture","Q624771":"motion_picture","Q16835935":"treaty","Q16956642":"treaty","Q19958750":"treaty","Q27768121":"treaty","Q29526855":"treaty","Q29527278":"treaty","Q29527544":"treaty","Q29883540":"treaty","Q30921722":"treaty","Q38653134":"treaty","Q39234269":"treaty","Q41535471":"treaty","Q50192946":"treaty","Q57205857":"treaty","Q1194534":"dataset","Q7979513":"speech","Q11261492":"speech","Q11496736":"speech","Q11504413":"speech","Q13611058":"speech","Q13632631":"speech","Q15853847":"speech","Q18907443":"speech","Q19776345":"speech","Q28472611":"speech","Q56191193":"speech","Q56192445":"speech","Q60061482":"speech","Q60780612":"speech","Q47123453":"report","Q1054574":"motion_picture","Q860626":"motion_picture","Q959790":"motion_picture","Q1788980":"motion_picture","Q2331945":"motion_picture","Q188473":"motion_picture","Q2678111":"motion_picture","Q2991560":"motion_picture","Q2484376":"motion_picture","Q16950433":"motion_picture","Q18331260":"motion_picture","Q19952560":"motion_picture","Q5428822":"broadcast","Q13582719":"song","Q388480":"song","Q950683":"book","Q39825":"dataset","Q49918":"dataset","Q82753":"dataset","Q186588":"dataset","Q15706459":"article-journal","Q59387148":"report","Q6960620":"book","Q7094076":"dataset","Q367680":"dataset","Q857354":"dataset","Q1503133":"book","Q3219655":"dataset","Q3304360":"dataset","Q5227330":"dataset","Q7943567":"dataset","Q17305522":"dataset","Q18814183":"dataset","Q21264512":"dataset","Q43570203":"dataset","Q44106130":"dataset","Q50826803":"dataset","Q55387750":"dataset","Q593744":"dataset","Q83790":"book","Q539662":"dataset","Q605175":"dataset","Q550089":"dataset","Q36524":"dataset","Q1673963":"dataset","Q17152639":"dataset","Q20088085":"entry-dictionary","Q15633587":"webpage","Q15138389":"webpage","Q20088089":"entry-dictionary","Q5398426":"broadcast","Q1259759":"broadcast","Q7724161":"broadcast","Q21664088":"broadcast","Q234262":"chapter","Q21481766":"chapter","Q26989423":"chapter","Q29154515":"chapter","Q43148525":"chapter","Q43180447":"chapter","Q53460949":"chapter","Q327349":"dataset","Q1394657":"dataset","Q1988927":"dataset","Q201456":"dataset","Q220393":"dataset","Q3071343":"dataset","Q254213":"dataset","Q319949":"dataset","Q672598":"dataset","Q780605":"dataset","Q815410":"dataset","Q819688":"dataset","Q854459":"dataset","Q897682":"dataset","Q1114135":"dataset","Q1147639":"dataset","Q1400059":"dataset","Q1665882":"dataset","Q1754061":"dataset","Q1915979":"dataset","Q1991865":"dataset","Q2038458":"dataset","Q2249973":"dataset","Q2597555":"dataset","Q3346024":"dataset","Q5141544":"dataset","Q5146094":"dataset","Q5962346":"dataset","Q6941730":"dataset","Q7096331":"dataset","Q10413470":"dataset","Q15194024":"dataset","Q11722865":"dataset","Q273057":"dataset","Q16832380":"dataset","Q20820424":"dataset","Q22692845":"dataset","Q52666561":"dataset","Q59209277":"dataset","Q59977151":"dataset","Q60686104":"dataset","Q2262868":"dataset","Q7449052":"dataset","Q596138":"motion_picture","Q3464665":"broadcast","Q24862":"motion_picture","Q7751682":"motion_picture","Q187044":"article-newspaper","Q22812458":"broadcast","Q170238":"broadcast","Q309481":"article-newspaper","Q2495037":"article-newspaper","Q2602337":"article-newspaper","Q5149212":"article-newspaper","Q17628188":"article-newspaper","Q17633526":"article-newspaper","Q17928402":"post-weblog","Q50081413":"webpage","Q20136634":"article","Q43290228":"article","Q57988118":"post","Q40745":"legal_case","Q245072":"legal_case","Q321568":"legal_case","Q375727":"legal_case","Q699735":"report","Q836925":"report","Q788874":"legal_case","Q830689":"report","Q1668727":"report","Q1498464":"legal_case","Q1926270":"report","Q2070370":"legal_case","Q2145003":"legal_case","Q2307704":"report","Q2309880":"report","Q2677586":"report","Q3000100":"report","Q3922396":"legal_case","Q4343952":"report","Q4690599":"report","Q6451276":"report","Q7968600":"legal_case","Q7918438":"report","Q12038591":"legal_case","Q13433827":"entry","Q15629444":"report","Q17090395":"report","Q17329259":"entry-encyclopedia","Q19355445":"report","Q61704031":"broadcast","Q27027169":"report","Q41274869":"report","Q47126552":"report","Q56013707":"report","Q58089619":"legal_case","Q157394":"motion_picture","Q207601":"broadcast","Q1504425":"article-journal","Q1241826":"broadcast","Q2155186":"broadcast","Q2435927":"broadcast","Q2774197":"article-journal","Q3588923":"broadcast","Q5177022":"broadcast","Q7316896":"article-journal","Q7551315":"motion_picture","Q10709386":"broadcast","Q622812":"broadcast","Q11079003":"broadcast","Q10885494":"article-journal","Q11293915":"broadcast","Q11325507":"broadcast","Q11334197":"broadcast","Q11351206":"broadcast","Q11378697":"broadcast","Q187947":"musical_score","Q11451968":"broadcast","Q11483878":"broadcast","Q11491683":"broadcast","Q12183006":"article-journal","Q18458820":"broadcast","Q56478376":"article-journal","Q58038936":"article-journal","Q58898396":"article-journal","Q58900805":"article-journal","Q58901470":"article-journal","Q58902427":"article-journal","Q59458414":"article-journal","Q4249087":"legal_case","Q5710433":"legal_case","Q60456691":"legal_case","Q17074865":"map","Q18609332":"legal_case","Q29197":"broadcast","Q18011171":"motion_picture","Q506240":"motion_picture","Q653916":"motion_picture","Q240862":"motion_picture","Q914242":"motion_picture","Q5287435":"broadcast","Q5338721":"motion_picture","Q13359539":"broadcast","Q21191265":"broadcast","Q26225765":"motion_picture","Q29555881":"broadcast","Q50062923":"broadcast","Q50914552":"broadcast","Q61220733":"broadcast","Q1924747":"dataset","Q26868375":"dataset","Q61782522":"dataset","Q2033233":"dataset","Q39086821":"review","Q595971":"dataset","Q3539533":"dataset","Q276":"broadcast","Q182415":"broadcast","Q336181":"broadcast","Q356055":"broadcast","Q358942":"broadcast","Q431102":"broadcast","Q661436":"broadcast","Q677466":"motion_picture","Q854995":"broadcast","Q986699":"broadcast","Q1261214":"broadcast","Q1358344":"broadcast","Q1366112":"broadcast","Q1407240":"broadcast","Q1407245":"broadcast","Q1472288":"broadcast","Q1619206":"broadcast","Q1684600":"broadcast","Q1819008":"broadcast","Q1962634":"broadcast","Q1857766":"broadcast","Q1924371":"broadcast","Q1948292":"broadcast","Q2081003":"broadcast","Q2231383":"broadcast","Q2304946":"broadcast","Q3744532":"broadcast","Q5455086":"broadcast","Q6626746":"broadcast","Q7697093":"broadcast","Q14623351":"broadcast","Q3511312":"broadcast","Q10676514":"broadcast","Q202866":"motion_picture","Q1107":"motion_picture","Q581714":"broadcast","Q21191019":"broadcast","Q11086742":"motion_picture","Q11504513":"broadcast","Q14942329":"broadcast","Q15836186":"broadcast","Q16068806":"broadcast","Q16206641":"broadcast","Q17145545":"broadcast","Q18640746":"broadcast","Q19845560":"broadcast","Q19973797":"broadcast","Q21217315":"broadcast","Q25090976":"broadcast","Q27912070":"broadcast","Q28664032":"broadcast","Q34682961":"broadcast","Q46706005":"broadcast","Q118171":"dataset","Q192588":"dataset","Q193351":"dataset","Q212805":"dataset","Q333761":"dataset","Q702448":"dataset","Q1869909":"motion_picture","Q29982285":"broadcast","Q780524":"dataset","Q989016":"dataset","Q1172362":"dataset","Q1235236":"dataset","Q1373925":"dataset","Q1391125":"dataset","Q1393704":"dataset","Q1414426":"dataset","Q1494224":"dataset","Q1519460":"dataset","Q1787017":"dataset","Q1957894":"dataset","Q2599456":"dataset","Q2274762":"dataset","Q2302053":"dataset","Q2404903":"dataset","Q2532732":"dataset","Q2881060":"dataset","Q2912944":"dataset","Q3133368":"dataset","Q3454922":"dataset","Q4117139":"dataset","Q4501235":"dataset","Q4677551":"dataset","Q5062195":"dataset","Q5322831":"dataset","Q5473309":"dataset","Q5572370":"dataset","Q7246853":"dataset","Q7702836":"dataset","Q9067653":"dataset","Q14806568":"dataset","Q15097084":"dataset","Q15100572":"dataset","Q16155335":"dataset","Q17014602":"dataset","Q22811662":"dataset","Q24579448":"dataset","Q28146196":"dataset","Q33270056":"dataset","Q36570165":"dataset","Q45028176":"dataset","Q54933017":"dataset","Q55341040":"dataset","Q59157251":"dataset","Q13406463":"webpage","Q60856733":"dataset","Q521414":"dataset","Q883895":"dataset","Q986756":"dataset","Q1345528":"dataset","Q3404855":"dataset","Q3405306":"dataset","Q3518943":"dataset","Q3664416":"dataset","Q4127466":"dataset","Q4350734":"dataset","Q60557971":"dataset","Q4350735":"dataset","Q4350754":"dataset","Q5058966":"dataset","Q5058970":"dataset","Q5058971":"dataset","Q5058968":"dataset","Q5058969":"dataset","Q5058974":"dataset","Q5058975":"dataset","Q5058972":"dataset","Q5058978":"dataset","Q5058977":"dataset","Q5058981":"dataset","Q5058989":"dataset","Q5334384":"dataset","Q7015254":"dataset","Q10497456":"dataset","Q12058091":"dataset","Q16056280":"dataset","Q19894430":"dataset","Q24934691":"dataset","Q25383554":"dataset","Q26207721":"dataset","Q28730356":"dataset","Q29795177":"dataset","Q8025448":"book","Q1114458":"book","Q3027814":"book","Q3268307":"book","Q3491290":"book","Q4955683":"book","Q5197887":"book","Q6071891":"book","Q5296":"webpage","Q57819011":"legal_case","Q57821094":"legal_case","Q218013":"dataset","Q283579":"dataset","Q426674":"dataset","Q479833":"dataset","Q721795":"dataset","Q838281":"dataset","Q843670":"dataset","Q877809":"dataset","Q900856":"dataset","Q949532":"dataset","Q1265166":"dataset","Q1571814":"dataset","Q2025786":"book","Q2250844":"book","Q4034405":"book","Q5227352":"dataset","Q2115":"dataset","Q14679":"dataset","Q577697":"map","Q5150048":"map","Q16840211":"book","Q21032630":"book","Q8034663":"book","Q11191558":"book","Q13769783":"dataset","Q14902318":"dataset","Q24063789":"dataset","Q25975660":"dataset","Q26260540":"dataset","Q11266439":"webpage","Q26267864":"dataset","Q26987229":"dataset","Q27198004":"dataset","Q28948553":"dataset","Q29053519":"dataset","Q29694587":"dataset","Q41709380":"dataset","Q47459830":"dataset","Q57936091":"book","Q58902997":"book","Q7572716":"dataset","Q59913845":"song","Q2143665":"motion_picture","Q1957385":"motion_picture","Q5769663":"motion_picture","Q5855976":"motion_picture","Q1441669":"broadcast","Q1441929":"broadcast","Q16943561":"broadcast","Q19858063":"broadcast","Q19858074":"broadcast","Q19858077":"broadcast","Q19858082":"broadcast","Q19858080":"broadcast","Q19858086":"broadcast","Q19858087":"broadcast","Q19858088":"broadcast","Q19858095":"broadcast","Q19858093":"broadcast","Q19858098":"broadcast","Q19858107":"broadcast","Q19858110":"broadcast","Q19858108":"broadcast","Q19858123":"broadcast","Q19858126":"broadcast","Q19858124":"broadcast","Q19858125":"broadcast","Q19858142":"broadcast","Q19858143":"broadcast","Q19858140":"broadcast","Q19858141":"broadcast","Q19859744":"broadcast","Q19859780":"broadcast","Q1271915":"dataset","Q2250805":"map","Q2359829":"map","Q2415383":"map","Q2869471":"map","Q4816871":"map","Q5135690":"map","Q11025270":"map","Q21936815":"map","Q21938018":"map","Q26885495":"map","Q333779":"map","Q640492":"map","Q690851":"manuscript","Q1105486":"manuscript","Q1501880":"map","Q1501945":"map","Q1550537":"map","Q1974665":"map","Q2915844":"map","Q54298448":"map","Q21188110":"broadcast","Q918098":"broadcast","Q4765080":"broadcast","Q17113138":"broadcast","Q856314":"manuscript","Q928128":"manuscript","Q19969434":"manuscript","Q5647631":"manuscript","Q1190781":"manuscript","Q1620808":"manuscript","Q1675712":"manuscript","Q3637297":"manuscript","Q18558914":"manuscript","Q492264":"musical_score","Q10590726":"motion_picture","Q60259696":"manuscript","Q60323106":"manuscript","Q60325498":"manuscript","Q60363009":"manuscript","Q2552822":"musical_score","Q7452061":"musical_score","Q3962157":"map","Q16825889":"map","Q1826720":"map","Q3935817":"dataset","Q18616720":"dataset","Q7601206":"dataset","Q7620972":"map","Q1353555":"dataset","Q22961568":"book","Q93204":"motion_picture","Q7832972":"motion_picture","Q312083":"map","Q322943":"treaty","Q459435":"motion_picture","Q587240":"manuscript","Q595819":"treaty","Q850950":"dataset","Q1003870":"treaty","Q1688818":"map","Q1048515":"map","Q1473669":"manuscript","Q1667520":"map","Q2723202":"map","Q2941628":"dataset","Q2981686":"manuscript","Q2981685":"manuscript","Q7551149":"motion_picture","Q2933856":"book","Q266680":"map","Q1702772":"map","Q2035351":"map","Q2073537":"manuscript","Q2204393":"map","Q2325507":"map","Q5469880":"report","Q5469893":"report","Q5469912":"report","Q10438653":"map","Q42793629":"speech","Q2678443":"dataset","Q1923776":"book","Q2981450":"book","Q1413174":"dataset","Q185529":"motion_picture","Q16254232":"motion_picture","Q31803237":"treaty","Q32945468":"dataset","Q59825643":"dataset","Q934552":"dataset","Q200562":"broadcast","Q303064":"broadcast","Q1484397":"broadcast","Q2049337":"broadcast","Q2123557":"broadcast","Q2308891":"report","Q2665960":"report","Q5227671":"broadcast","Q18030695":"report","Q18385907":"broadcast","Q21190411":"broadcast","Q47512784":"report","Q56330488":"book","Q33111614":"motion_picture","Q484692":"song","Q1033831":"song","Q1497584":"book","Q19705":"book","Q628080":"book","Q1535505":"book","Q2333573":"book","Q3357101":"book","Q12041885":"book","Q5151497":"motion_picture","Q7999883":"article","Q18398246":"motion_picture","Q56309057":"manuscript","Q61314299":"dataset","Q234280":"chapter","Q234300":"chapter","Q862334":"book","Q2973181":"motion_picture","Q3072049":"motion_picture","Q1747837":"motion_picture","Q12029612":"dataset","Q50380591":"book","Q51881567":"book","Q60029764":"book","Q914229":"article","Q5465451":"article","Q20135338":"motion_picture","Q1541065":"report","Q2594143":"dataset","Q16664076":"report","Q441261":"dataset","Q457843":"dataset","Q783287":"dataset","Q1115961":"dataset","Q1713174":"dataset","Q3327521":"dataset","Q151":"dataset","Q17123180":"motion_picture","Q15982056":"article-newspaper","Q59191021":"dataset","Q59248059":"dataset","Q59248072":"dataset","Q1371849":"dataset","Q17438413":"dataset","Q61914117":"dataset","Q3352071":"motion_picture","Q25051296":"webpage","Q25054829":"dataset","Q267136":"dataset","Q488053":"book","Q914881":"book","Q1397073":"dataset","Q1662581":"dataset","Q2268965":"dataset","Q3292731":"book","Q3406872":"dataset","Q5033354":"dataset","Q5227322":"dataset","Q5532670":"dataset","Q7515656":"book","Q7598341":"dataset","Q7995661":"dataset","Q14523803":"book","Q17146953":"dataset","Q25110279":"book","Q30008669":"book","Q30009376":"book","Q41623316":"dataset","Q38647918":"book","Q249697":"speech","Q1428914":"dataset","Q255135":"book","Q471894":"book","Q586744":"book","Q956165":"book","Q1569753":"book","Q2939758":"book","Q12040484":"book","Q13583784":"book","Q59351530":"book","Q61020892":"book","Q17086104":"map","Q17147147":"map","Q19393521":"map","Q58884":"broadcast","Q2635894":"broadcast","Q193842":"map","Q261468":"map","Q943929":"song","Q1123037":"song","Q336822":"song","Q336371":"map","Q459798":"map","Q831939":"map","Q865144":"map","Q889561":"map","Q1152543":"map","Q1187667":"broadcast","Q1281814":"map","Q1674401":"map","Q1742009":"broadcast","Q1778220":"map","Q1800237":"map","Q2126801":"map","Q2125867":"broadcast","Q2298569":"map","Q2940627":"map","Q4903803":"map","Q5687679":"map","Q10480692":"map","Q10604395":"map","Q10916116":"book","Q11960416":"map","Q12008992":"map","Q58901209":"dataset","Q19969268":"broadcast","Q20741385":"book","Q21009694":"book","Q24879310":"dataset","Q56028349":"book","Q56240541":"broadcast","Q56697520":"book","Q60586493":"dataset","Q183169":"webpage","Q825914":"book","Q1391116":"dataset","Q1516252":"book","Q1569406":"dataset","Q1609353":"dataset","Q1609504":"dataset","Q1862738":"book","Q2110197":"dataset","Q3237931":"broadcast","Q3956369":"broadcast","Q3962380":"dataset","Q4769616":"dataset","Q4804740":"book","Q5051330":"dataset","Q5615468":"dataset","Q6822329":"dataset","Q6912943":"broadcast","Q7144753":"dataset","Q10688394":"book","Q12331427":"dataset","Q15961983":"broadcast","Q18311760":"broadcast","Q1499601":"dataset","Q5374928":"map","Q7444356":"motion_picture","Q6729489":"motion_picture","Q7444692":"map","Q8036547":"map","Q1383152":"dataset","Q3564515":"speech","Q3890208":"dataset","Q21050458":"dataset","Q21050912":"dataset","Q26721650":"dataset","Q31841013":"dataset","Q1865123":"dataset","Q206290":"dataset","Q1088118":"dataset","Q7502102":"dataset","Q17121221":"map","Q23888763":"book","Q46992920":"speech","Q52506277":"dataset","Q51719975":"broadcast","Q19364663":"book","Q22938710":"book","Q193977":"motion_picture","Q59032066":"song","Q1989725":"song","Q2135500":"manuscript","Q3153927":"speech","Q526877":"broadcast","Q742157":"article-newspaper","Q6899707":"map","Q725377":"book","Q10541153":"book","Q21198407":"book","Q369074":"dataset","Q3249257":"motion_picture","Q4373044":"motion_picture","Q172067":"motion_picture","Q1046788":"motion_picture","Q24886171":"broadcast","Q53746253":"broadcast","Q16709869":"book","Q16960707":"book","Q19941906":"book","Q21660824":"book","Q21818614":"book","Q57987419":"interview","Q57987455":"interview","Q57987589":"interview","Q61725752":"book","Q225672":"book","Q263790":"book","Q284465":"book","Q431193":"book","Q608971":"book","Q634123":"book","Q817063":"book","Q833590":"book","Q1027825":"book","Q1385360":"book","Q1754581":"book","Q2114246":"book","Q2144117":"book","Q2732056":"book","Q2955456":"book","Q4203401":"book","Q7163040":"book","Q7603925":"broadcast","Q12765421":"book","Q15276670":"book","Q15627042":"book","Q6548306":"book","Q12046416":"map","Q472298":"legal_case","Q1261319":"map","Q5563391":"map","Q26644852":"broadcast","Q29167422":"dataset","Q7211":"dataset","Q48473":"dataset","Q217327":"legal_case","Q951437":"dataset","Q636033":"dataset","Q672593":"dataset","Q739047":"dataset","Q891854":"legal_case","Q1207369":"dataset","Q1391014":"dataset","Q1642648":"dataset","Q2859990":"dataset","Q3307317":"dataset","Q4330194":"dataset","Q6813020":"legal_case","Q6901292":"legal_case","Q7251471":"dataset","Q18711682":"legal_case","Q20057286":"dataset","Q23015465":"dataset","Q24243801":"dataset","Q24249534":"dataset","Q25917186":"legal_case","Q27214933":"dataset","Q28934204":"legal_case","Q39740866":"dataset","Q59495116":"dataset","Q60208424":"dataset","Q61037469":"legal_case","Q40426579":"map","Q43037778":"map","Q47008743":"map","Q26225493":"book","Q29043181":"dataset","Q55850593":"song","Q55850643":"song","Q58885732":"song","Q58885754":"song","Q927803":"song","Q430010":"song","Q2292588":"song","Q2499178":"dataset","Q2560570":"dataset","Q3077240":"dataset","Q3491832":"dataset","Q1235234":"dataset","Q7096323":"dataset","Q7831478":"song","Q1564816":"legal_case","Q2698974":"legal_case","Q20089346":"motion_picture","Q5366020":"motion_picture","Q11526166":"speech","Q4167410":"webpage","Q845159":"motion_picture","Q1003021":"dataset","Q4167836":"webpage","Q1249224":"report","Q11382506":"webpage","Q15475226":"webpage","Q15475319":"webpage","Q1991869":"book","Q11690026":"book","Q31209114":"webpage","Q35243371":"webpage","Q48781895":"motion_picture","Q56005592":"webpage","Q17586363":"book","Q20043999":"book","Q59738577":"webpage","Q61033232":"webpage","Q61033736":"dataset","Q61034350":"webpage","Q29573701":"dataset","Q645928":"motion_picture","Q3209941":"report","Q5165404":"bill","Q11078958":"report","Q45182324":"article-journal","Q56119332":"post-weblog","Q60797":"speech","Q1474597":"speech","Q2069352":"book","Q2983424":"motion_picture","Q19359000":"report","Q24067746":"post-weblog","Q51844620":"dataset","Q51539995":"webpage","Q55422400":"broadcast","Q130232":"motion_picture","Q635115":"dataset","Q1553078":"dataset","Q1784036":"book","Q1813223":"book","Q2326951":"book","Q2500820":"book","Q3423635":"dataset","Q4363806":"book","Q14605760":"webpage","Q21875313":"book","Q24633474":"broadcast","Q28136925":"broadcast","Q28135032":"broadcast","Q28472638":"speech","Q28472722":"speech","Q1011299":"broadcast","Q3276244":"broadcast","Q29883647":"treaty","Q42214612":"treaty","Q60215679":"broadcast","Q60215966":"broadcast","Q7033567":"treaty","Q8576":"treaty","Q3257212":"book","Q5166307":"treaty","Q7865023":"treaty","Q8187836":"treaty","Q16923948":"treaty","Q17211914":"treaty","Q20874666":"treaty","Q39233713":"treaty","Q8041497":"patent","Q50823049":"report","Q61715571":"book","Q193934":"book","Q193955":"book","Q990683":"book","Q12047175":"book","Q1250520":"dataset","Q2334774":"song","Q22001389":"dataset","Q61782519":"dataset","Q112762":"song","Q177771":"song","Q178122":"song","Q207683":"song","Q216860":"song","Q261434":"song","Q318894":"song","Q319448":"song","Q380233":"song","Q493169":"song","Q502658":"song","Q523896":"song","Q591990":"song","Q608253":"song","Q744327":"song","Q758422":"song","Q783874":"song","Q784074":"song","Q820119":"song","Q844450":"song","Q873000":"song","Q944800":"song","Q959583":"song","Q988502":"song","Q1009280":"song","Q2281713":"song","Q1033810":"song","Q1033813":"song","Q1151663":"song","Q1195253":"song","Q1195630":"song","Q1228189":"song","Q20477577":"dataset","Q1972954":"dataset","Q842256":"motion_picture","Q643684":"motion_picture","Q1033573":"dataset","Q1205607":"dataset","Q1971947":"dataset","Q2145124":"dataset","Q2819247":"dataset","Q4685824":"dataset","Q7002108":"dataset","Q7200622":"dataset","Q8267601":"dataset","Q9732903":"webpage","Q11002482":"webpage","Q12096573":"webpage","Q16059585":"webpage","Q16059613":"webpage","Q16059624":"webpage","Q19208935":"webpage","Q21450877":"webpage","Q31936067":"dataset","Q47500192":"dataset","Q1229479":"song","Q1232283":"song","Q1236108":"song","Q1288193":"song","Q1372064":"song","Q1382036":"song","Q1779217":"song","Q1779319":"song","Q1899706":"song","Q1905727":"song","Q1942905":"song","Q1956166":"song","Q1963108":"song","Q1966622":"song","Q2038845":"song","Q2058312":"song","Q2108499":"song","Q2165184":"song","Q2235992":"song","Q2298624":"song","Q2312959":"song","Q2358279":"song","Q2544997":"song","Q2707688":"song","Q2737175":"song","Q2891357":"song","Q2894096":"song","Q2956164":"song","Q2956172":"song","Q3033130":"song","Q3246270":"song","Q3299089":"song","Q3482281":"song","Q3562031":"song","Q3843655":"song","Q3889661":"song","Q3918025":"song","Q4056436":"song","Q4130112":"song","Q4528554":"song","Q4770819":"song","Q4797274":"song","Q5031532":"song","Q5037289":"song","Q5747946":"song","Q5766029":"song","Q6109162":"song","Q7148059":"song","Q7314000":"song","Q7561608":"song","Q7824869":"song","Q8053529":"song","Q8261762":"song","Q10677514":"song","Q21653344":"song","Q56572789":"song","Q503354":"song","Q11214531":"song","Q12115862":"song","Q12135013":"song","Q12313565":"song","Q13829124":"song","Q15810872":"song","Q15907187":"song","Q16084298":"song","Q16194930":"song","Q16912992":"song","Q17118203":"song","Q17150323":"song","Q18012876":"song","Q18406550":"song","Q19607140":"song","Q20087039":"song","Q20107778":"song","Q20980372":"song","Q21127215":"song","Q22086714":"song","Q23072435":"song","Q25022242":"song","Q27981708":"song","Q27981857":"song","Q29051387":"song","Q37731261":"song","Q42681239":"song","Q46863086":"song","Q55596270":"song","Q56425213":"song","Q56425237":"song","Q61688673":"song","Q229390":"motion_picture","Q319221":"motion_picture","Q369747":"motion_picture","Q370630":"motion_picture","Q421719":"motion_picture","Q430525":"motion_picture","Q455315":"motion_picture","Q459290":"motion_picture","Q505119":"motion_picture","Q517386":"motion_picture","Q652256":"motion_picture","Q663106":"motion_picture","Q790192":"motion_picture","Q848512":"motion_picture","Q1060398":"motion_picture","Q1146335":"motion_picture","Q1200678":"motion_picture","Q1251417":"motion_picture","Q1320115":"motion_picture","Q1361932":"motion_picture","Q1397462":"motion_picture","Q1933746":"motion_picture","Q1935609":"motion_picture","Q2125170":"motion_picture","Q2156835":"motion_picture","Q2165644":"motion_picture","Q2301591":"motion_picture","Q4382232":"broadcast","Q2321734":"motion_picture","Q2553613":"motion_picture","Q2903140":"motion_picture","Q3072043":"motion_picture","Q3250548":"motion_picture","Q3585697":"motion_picture","Q3648909":"motion_picture","Q3677141":"motion_picture","Q3677185":"motion_picture","Q3745400":"motion_picture","Q3745430":"motion_picture","Q4220915":"motion_picture","Q4484381":"motion_picture","Q5145881":"motion_picture","Q5378150":"motion_picture","Q7130449":"motion_picture","Q7858343":"motion_picture","Q9259727":"motion_picture","Q12309044":"motion_picture","Q12377598":"motion_picture","Q16721823":"motion_picture","Q16909344":"motion_picture","Q19799105":"motion_picture","Q19799133":"motion_picture","Q20442589":"motion_picture","Q20650540":"motion_picture","Q21182682":"motion_picture","Q24887738":"motion_picture","Q28735856":"motion_picture","Q29017630":"motion_picture","Q30070675":"motion_picture","Q30897819":"motion_picture","Q33373157":"motion_picture","Q43079104":"motion_picture","Q54086290":"motion_picture","Q54344007":"motion_picture","Q56192069":"motion_picture","Q58415294":"motion_picture","Q58903570":"motion_picture","Q61283808":"motion_picture","Q219557":"motion_picture","Q226730":"motion_picture","Q24865":"motion_picture","Q24869":"motion_picture","Q31235":"motion_picture","Q3956596":"book","Q20012720":"book","Q27070652":"book","Q738826":"speech","Q2623953":"speech","Q2781658":"speech","Q3479856":"speech","Q7454995":"speech","Q735478":"motion_picture","Q124922":"motion_picture","Q472637":"motion_picture","Q1092621":"motion_picture","Q1323308":"motion_picture","Q1352102":"motion_picture","Q1464369":"motion_picture","Q1474387":"motion_picture","Q1480924":"motion_picture","Q1760864":"motion_picture","Q1800833":"motion_picture","Q2084909":"motion_picture","Q27697957":"motion_picture","Q2670855":"motion_picture","Q3566966":"motion_picture","Q4765076":"motion_picture","Q20732395":"motion_picture","Q1684595":"dataset","Q7168625":"motion_picture","Q8192124":"motion_picture","Q5008290":"dataset","Q220399":"dataset","Q285745":"dataset","Q542475":"motion_picture","Q846544":"motion_picture","Q3072039":"motion_picture","Q23739":"broadcast","Q338632":"broadcast","Q288608":"broadcast","Q3421644":"broadcast","Q5465514":"broadcast","Q5812300":"broadcast","Q18340550":"webpage","Q21232614":"broadcast","Q1224870":"dataset","Q79715":"broadcast","Q278425":"dataset","Q548206":"motion_picture","Q632149":"motion_picture","Q996838":"motion_picture","Q1147986":"motion_picture","Q2258523":"map","Q2514870":"dataset","Q2559958":"broadcast","Q4342538":"map","Q15518544":"broadcast","Q15518777":"broadcast","Q20707560":"dataset","Q20871935":"motion_picture","Q55960075":"motion_picture","Q1224984":"dataset","Q5227308":"dataset","Q12328550":"dataset","Q20089094":"motion_picture","Q21040941":"dataset","Q668312":"motion_picture","Q30047053":"dataset","Q18493502":"legal_case","Q1067692":"motion_picture","Q18655723":"motion_picture","Q844993":"song","Q4763437":"book","Q19894488":"book","Q262533":"speech","Q591055":"speech","Q1851305":"speech","Q3588034":"speech","Q20669604":"speech","Q29642901":"dataset","Q1061420":"map","Q2914518":"map","Q186286":"broadcast","Q940462":"broadcast","Q15823625":"map","Q54328426":"broadcast","Q1713326":"motion_picture","Q4453959":"motion_picture","Q5905221":"musical_score","Q23368955":"motion_picture","Q55848868":"motion_picture","Q3072024":"motion_picture","Q965136":"map","Q3546572":"broadcast","Q5449041":"motion_picture","Q6645282":"broadcast","Q25360500":"broadcast","Q376820":"dataset","Q2422383":"dataset","Q14552560":"article-newspaper","Q219897":"dataset","Q787397":"map","Q14943256":"book","Q15715669":"map","Q3196335":"book","Q4700148":"book","Q11669289":"map","Q56683168":"map","Q6749508":"dataset","Q13039854":"dataset","Q19354904":"legal_case","Q25917154":"legal_case","Q25456031":"dataset","Q47484674":"dataset","Q948454":"dataset","Q1734165":"dataset","Q5441632":"book","Q7321644":"book","Q7890265":"book","Q28406796":"dataset","Q46130774":"dataset","Q54820068":"book","Q17146139":"map","Q23691":"song","Q54251760":"motion_picture","Q851995":"map","Q25336664":"dataset","Q11310550":"dataset","Q18086661":"dataset","Q18086666":"dataset","Q18086667":"dataset","Q18086665":"dataset","Q18086671":"dataset","Q18089574":"dataset","Q18089575":"dataset","Q18099930":"dataset","Q18100125":"dataset","Q18889352":"dataset","Q18922463":"dataset","Q20005020":"dataset","Q798134":"thesis","Q1414362":"thesis","Q30749496":"thesis","Q46629343":"thesis","Q51282441":"thesis","Q52823264":"thesis","Q58210330":"thesis","Q1907875":"thesis","Q23745":"broadcast","Q399811":"broadcast","Q775344":"broadcast","Q1658957":"broadcast","Q1786567":"broadcast","Q4783297":"broadcast","Q5219865":"broadcast","Q7185299":"broadcast","Q7731786":"broadcast","Q7892363":"broadcast","Q11086745":"broadcast","Q20986817":"broadcast","Q60393504":"broadcast","Q16342":"dataset","Q632285":"dataset","Q1751819":"dataset","Q2560532":"dataset","Q6517465":"dataset","Q1898445":"map","Q41436524":"book","Q50310598":"dataset","Q5366501":"broadcast","Q9018710":"broadcast","Q11935070":"broadcast","Q688869":"manuscript","Q962741":"manuscript","Q7797194":"dataset","Q1662452":"motion_picture","Q4499034":"song","Q6009879":"book","Q595801":"book","Q894351":"map","Q1352815":"broadcast","Q1569955":"dataset","Q2538131":"book","Q3348148":"dataset","Q5535082":"dataset","Q7574095":"dataset","Q47214765":"broadcast","Q61990518":"broadcast","Q2933978":"broadcast","Q6537693":"dataset","Q6888313":"book","Q12270042":"book","Q21292860":"broadcast","Q350514":"map","Q357674":"map","Q5191437":"dataset","Q24265951":"dataset","Q25110971":"book","Q29966258":"dataset","Q25894883":"dataset","Q2093973":"book","Q1711400":"broadcast","Q3071014":"broadcast","Q61029068":"webpage","Q61996773":"webpage","Q175902":"dataset","Q1295532":"webpage","Q1474116":"webpage","Q1501313":"dataset","Q1916557":"dataset","Q5333554":"dataset","Q7247749":"dataset","Q4330198":"dataset","Q5570651":"dataset","Q7251500":"dataset","Q7277178":"dataset","Q7689673":"dataset","Q15407973":"webpage","Q15647814":"webpage","Q16335141":"dataset","Q18392279":"dataset","Q15623926":"webpage","Q22808320":"webpage","Q24571879":"webpage","Q24574745":"webpage","Q17362920":"webpage","Q28065731":"webpage","Q28208970":"dataset","Q30432511":"webpage","Q54662266":"webpage","Q56428020":"webpage","Q58036154":"webpage","Q58181524":"webpage","Q58423626":"webpage","Q59541917":"webpage","Q59542487":"webpage","Q5227321":"dataset","Q178840":"broadcast","Q482612":"broadcast","Q662197":"broadcast","Q1054760":"broadcast","Q1273568":"broadcast","Q1676730":"broadcast","Q1802588":"broadcast","Q2388283":"broadcast","Q3189895":"broadcast","Q3951815":"broadcast","Q5778915":"broadcast","Q7050677":"broadcast","Q7135559":"broadcast","Q9335577":"broadcast","Q9671105":"broadcast","Q20061443":"broadcast","Q20220309":"broadcast","Q20267837":"broadcast","Q21233490":"broadcast","Q21191068":"broadcast","Q27868077":"broadcast","Q30939244":"broadcast","Q55082620":"broadcast","Q56320653":"broadcast","Q45787211":"dataset","Q1799894":"broadcast","Q19220511":"dataset","Q7841716":"motion_picture","Q5987970":"book","Q7864671":"motion_picture","Q21504449":"broadcast","Q61896850":"motion_picture","Q61911910":"motion_picture","Q15184295":"webpage","Q29581299":"book","Q3507630":"dataset","Q5571730":"webpage","Q13231199":"webpage","Q15851373":"webpage","Q19692233":"webpage","Q2921195":"book","Q20009925":"webpage","Q21167233":"webpage","Q25456482":"webpage","Q26884324":"webpage","Q28197061":"webpage","Q30032916":"webpage","Q33532284":"webpage","Q37152856":"webpage","Q19887878":"webpage","Q30044873":"report","Q11664270":"broadcast","Q1852859":"map","Q2297927":"motion_picture","Q2188827":"manuscript","Q4922471":"broadcast","Q16247289":"broadcast","Q25381170":"book","Q25696292":"dataset","Q11398":"dataset","Q210918":"dataset","Q267474":"dataset","Q1062352":"dataset","Q548492":"dataset","Q732744":"dataset","Q1520859":"dataset","Q1744559":"dataset","Q2748242":"dataset","Q3445240":"dataset","Q3518464":"dataset","Q3546241":"dataset","Q5172500":"dataset","Q6857882":"dataset","Q7398671":"dataset","Q22808060":"song","Q22298551":"dataset","Q22935148":"dataset","Q23014490":"dataset","Q23015153":"dataset","Q185867":"motion_picture","Q192625":"dataset","Q784969":"dataset","Q917904":"dataset","Q3546232":"dataset","Q4382932":"dataset","Q2357684":"dataset","Q2490652":"dataset","Q562667":"treaty","Q11510761":"treaty","Q39234115":"treaty","Q39235586":"treaty","Q39236188":"treaty","Q39236506":"treaty","Q39237589":"treaty","Q691836":"dataset","Q2299775":"dataset","Q2584888":"dataset","Q934210":"dataset","Q16355541":"dataset","Q57560929":"song","Q59826893":"dataset","Q478216":"dataset","Q1138178":"dataset","Q2621880":"dataset","Q2859969":"dataset","Q2964498":"dataset","Q4223049":"dataset","Q4421014":"dataset","Q16549505":"dataset","Q21441341":"dataset","Q26975748":"dataset","Q5366097":"motion_picture","Q1137588":"song","Q6022825":"broadcast","Q15977715":"broadcast","Q24906243":"broadcast","Q471839":"motion_picture","Q1794431":"motion_picture","Q3080071":"broadcast","Q6942568":"motion_picture","Q11900986":"motion_picture","Q16677772":"motion_picture","Q17517379":"motion_picture","Q20667187":"motion_picture","Q29168811":"motion_picture","Q34487266":"broadcast","Q47486001":"motion_picture","Q57780531":"motion_picture","Q223770":"motion_picture","Q4836991":"motion_picture","Q212781":"motion_picture","Q41270":"song","Q383904":"song","Q564848":"song","Q721644":"song","Q5158512":"song","Q6037387":"song","Q3962943":"motion_picture","Q21759196":"motion_picture","Q60630702":"motion_picture","Q222639":"motion_picture","Q1033891":"motion_picture","Q1535153":"motion_picture","Q1740789":"motion_picture","Q1776156":"motion_picture","Q1894374":"motion_picture","Q2421031":"motion_picture","Q332564":"motion_picture","Q853630":"motion_picture","Q909586":"motion_picture","Q987831":"motion_picture","Q1341051":"motion_picture","Q1342372":"motion_picture","Q1696148":"motion_picture","Q2584671":"motion_picture","Q4174664":"motion_picture","Q883179":"motion_picture","Q4925568":"motion_picture","Q5551875":"motion_picture","Q13377551":"motion_picture","Q16247268":"motion_picture","Q18089587":"motion_picture","Q18355406":"motion_picture","Q18648407":"motion_picture","Q4840473":"motion_picture","Q20656232":"motion_picture","Q23044991":"motion_picture","Q25110269":"motion_picture","Q27959357":"motion_picture","Q28968258":"motion_picture","Q28968511":"motion_picture","Q43911809":"motion_picture","Q1276148":"dataset","Q3546236":"dataset","Q819652":"motion_picture","Q1433443":"motion_picture","Q2096633":"motion_picture","Q10654943":"motion_picture","Q15898171":"motion_picture","Q1502766":"motion_picture","Q22981906":"motion_picture","Q33218678":"dataset","Q33219080":"dataset","Q1502102":"dataset","Q290066":"dataset","Q21473954":"dataset","Q884257":"map","Q1136047":"song","Q3442060":"motion_picture","Q6722594":"motion_picture","Q22802898":"dataset","Q1147354":"song","Q541947":"song","Q762917":"song","Q896981":"song","Q1329536":"song","Q1523875":"song","Q1802243":"song","Q4666464":"song","Q5419334":"song","Q5956747":"song","Q5956766":"song","Q10288496":"song","Q13142456":"song","Q54932319":"broadcast","Q16523070":"book","Q1345076":"dataset","Q1331138":"dataset","Q4984974":"motion_picture","Q5442753":"motion_picture","Q59688552":"motion_picture","Q1030329":"motion_picture","Q2560052":"motion_picture","Q50306849":"dataset","Q9351310":"dataset","Q17093751":"motion_picture","Q55616422":"motion_picture","Q5400070":"motion_picture","Q7097859":"motion_picture","Q2518205":"motion_picture","Q39774781":"song","Q40039114":"song","Q496523":"motion_picture","Q586250":"motion_picture","Q658334":"song","Q1206090":"song","Q2642760":"motion_picture","Q2956178":"song","Q3656521":"song","Q4184716":"song","Q4400497":"song","Q5897543":"motion_picture","Q10743749":"song","Q11989328":"song","Q12623540":"song","Q19367312":"motion_picture","Q47011432":"broadcast","Q61057707":"broadcast","Q1192644":"broadcast","Q1193356":"broadcast","Q1193877":"broadcast","Q1193889":"broadcast","Q1198546":"broadcast","Q1200102":"broadcast","Q1200891":"broadcast","Q1203502":"broadcast","Q1328971":"broadcast","Q15548228":"broadcast","Q18611586":"broadcast","Q27986339":"broadcast","Q16984663":"motion_picture","Q535518":"motion_picture","Q583768":"motion_picture","Q1377546":"motion_picture","Q2254193":"motion_picture","Q2292320":"motion_picture","Q3677202":"motion_picture","Q4044177":"motion_picture","Q4075563":"motion_picture","Q731194":"motion_picture","Q5578091":"motion_picture","Q5768328":"motion_picture","Q6926334":"motion_picture","Q7116678":"motion_picture","Q2527949":"dataset","Q6410349":"song","Q58006100":"dataset","Q1065413":"dataset","Q1334294":"dataset","Q5281480":"dataset","Q14806579":"dataset","Q21629439":"broadcast","Q27965091":"broadcast","Q27965088":"broadcast","Q27965089":"broadcast","Q1117103":"motion_picture","Q15077373":"song","Q21848887":"song","Q42525933":"song","Q1246452":"song","Q1564657":"song","Q1786016":"song","Q4138449":"song","Q26211803":"dataset","Q28107644":"dataset","Q438958":"dataset","Q893182":"dataset","Q1361620":"dataset","Q1744558":"dataset","Q2558761":"broadcast","Q3663344":"dataset","Q5837451":"dataset","Q17080472":"dataset","Q18762344":"dataset","Q22936940":"dataset","Q51282626":"thesis","Q51283070":"thesis","Q51283092":"thesis","Q51283110":"thesis","Q51283164":"thesis","Q51283181":"thesis","Q51283199":"thesis","Q51283219":"thesis","Q51283231":"thesis","Q51283362":"thesis","Q1789476":"dataset","Q1741854":"broadcast","Q11396323":"motion_picture","Q1428162":"song","Q4440575":"song","Q2137852":"motion_picture","Q20443008":"motion_picture","Q9049284":"song","Q2976573":"dataset","Q7247163":"dataset","Q18327786":"dataset","Q18327800":"dataset","Q28444881":"song","Q47009776":"motion_picture","Q4078107":"song","Q12242979":"broadcast","Q1308255":"dataset","Q828962":"dataset","Q2976602":"dataset","Q881912":"broadcast","Q16861376":"dataset","Q59784758":"broadcast","Q829147":"song","Q6457531":"motion_picture","Q28030321":"broadcast","Q28225717":"broadcast","Q4663261":"webpage","Q15145755":"webpage","Q18707678":"webpage","Q18711811":"webpage","Q20160182":"webpage","Q20870830":"webpage","Q22676729":"webpage","Q26214208":"webpage","Q28801937":"webpage","Q30279428":"webpage","Q55510433":"webpage","Q59259626":"webpage","Q20769287":"webpage","Q23894233":"webpage","Q24046192":"webpage","Q24514938":"webpage","Q30330522":"webpage","Q38084761":"webpage","Q58118449":"webpage","Q2886579":"dataset","Q21623879":"webpage","Q28092864":"webpage","Q52147067":"webpage","Q18043430":"webpage","Q18810260":"dataset","Q18889371":"dataset","Q18889411":"dataset","Q20893947":"legal_case","Q43096126":"motion_picture","Q56876503":"webpage","Q58408484":"webpage","Q58492747":"webpage","Q61984657":"webpage","Q3309896":"motion_picture","Q5864844":"motion_picture","Q6190581":"webpage","Q25826840":"webpage","Q220898":"motion_picture","Q2513417":"dataset","Q56885002":"webpage","Q179600":"dataset","Q714750":"dataset","Q15101896":"dataset","Q56558180":"song","Q845648":"webpage","Q58310010":"book","Q16937368":"song","Q28135297":"song","Q50309914":"dataset","Q57560968":"song","Q61740934":"song","Q61729725":"song","Q1047299":"motion_picture","Q2281511":"motion_picture","Q4292083":"motion_picture","Q11446446":"motion_picture","Q11464558":"motion_picture","Q11620244":"motion_picture","Q11673786":"motion_picture","Q16000226":"motion_picture","Q43069510":"motion_picture","Q8066387":"motion_picture","Q16824564":"motion_picture","Q52631698":"song","Q20589414":"song","Q20621902":"song","Q19659229":"song","Q2997685":"song","Q5124548":"song","Q512410":"song","Q23978249":"song","Q6647160":"webpage","Q18170752":"song","Q5881246":"song","Q1723850":"motion_picture","Q169672":"motion_picture","Q622310":"motion_picture","Q3072042":"motion_picture","Q5104880":"motion_picture","Q193605":"song","Q20818018":"dataset","Q1065444":"motion_picture","Q5258881":"motion_picture","Q856638":"dataset","Q5769583":"motion_picture","Q5769580":"motion_picture","Q5769586":"motion_picture","Q5769589":"motion_picture","Q5769592":"motion_picture","Q34848596":"motion_picture","Q2145099":"motion_picture","Q43082648":"broadcast","Q21441352":"dataset","Q2976563":"dataset","Q4680764":"dataset","Q4936202":"dataset","Q4992609":"dataset","Q5281190":"dataset","Q5281191":"dataset","Q5281189":"dataset","Q5281192":"dataset","Q5281193":"dataset","Q5465786":"dataset","Q5575198":"dataset","Q7133628":"dataset","Q7133619":"dataset","Q7133626":"dataset","Q7133625":"dataset","Q7133631":"dataset","Q7133632":"dataset","Q7133633":"dataset","Q7135076":"dataset","Q7136196":"dataset","Q7532102":"dataset","Q7539622":"dataset","Q7539620":"dataset","Q7992082":"dataset","Q7992083":"dataset","Q7992119":"dataset","Q7992116":"dataset","Q7992128":"dataset","Q7992164":"dataset","Q17145514":"dataset","Q28130146":"dataset","Q28130147":"dataset","Q28130145":"dataset","Q28134034":"dataset","Q28134060":"dataset","Q28134100":"dataset","Q28134126":"dataset","Q4179738":"song","Q26829682":"webpage","Q22870229":"webpage","Q22875692":"webpage","Q22876063":"webpage","Q22876332":"webpage","Q25737003":"webpage","Q25830508":"webpage","Q57971242":"webpage","Q5611964":"webpage","Q5613278":"webpage","Q5615491":"webpage","Q5618337":"webpage","Q5620523":"webpage","Q5621344":"webpage","Q5622928":"webpage","Q5624848":"webpage","Q5626725":"webpage","Q5636579":"webpage","Q5827463":"webpage","Q5904431":"webpage","Q5911510":"webpage","Q6072180":"webpage","Q6232685":"webpage","Q6305829":"webpage","Q6372354":"webpage","Q6419146":"webpage","Q6499145":"webpage","Q6584170":"webpage","Q6584434":"webpage","Q6606549":"webpage","Q6622740":"webpage","Q6632234":"webpage","Q7241821":"webpage","Q7485705":"webpage","Q8784047":"webpage","Q10560362":"webpage","Q10584970":"webpage","Q10712699":"webpage","Q10730006":"webpage","Q10805463":"webpage","Q10992965":"webpage","Q11011669":"webpage","Q11052053":"webpage","Q11223110":"webpage","Q11839555":"webpage","Q12930680":"webpage","Q13383621":"webpage","Q13394564":"webpage","Q13492790":"webpage","Q13512760":"webpage","Q13763959":"webpage","Q14335223":"webpage","Q14336297":"webpage","Q14336339":"webpage","Q14358273":"webpage","Q14358335":"webpage","Q14358826":"webpage","Q14358898":"webpage","Q14358899":"webpage","Q14396951":"webpage","Q14404469":"webpage","Q14445515":"webpage","Q22867433":"webpage","Q15709178":"webpage","Q17615621":"webpage","Q18340985":"webpage","Q18881752":"webpage","Q22668105":"webpage","Q22706969":"webpage","Q22830149":"webpage","Q22834716":"webpage","Q22834726":"webpage","Q22838914":"webpage","Q22844738":"webpage","Q22846593":"webpage","Q22846942":"webpage","Q22846954":"webpage","Q22846964":"webpage","Q22858302":"webpage","Q22862005":"webpage","Q22867722":"webpage","Q22869003":"webpage","Q33130924":"motion_picture","Q30415057":"webpage","Q55648788":"webpage","Q4663903":"webpage","Q21528878":"webpage","Q22247630":"webpage","Q249083":"dataset","Q1750705":"dataset","Q955185":"dataset","Q1326107":"dataset","Q1520639":"dataset","Q2943040":"dataset","Q6404298":"dataset","Q7248117":"dataset","Q7674850":"dataset","Q29057009":"webpage","Q35250433":"webpage","Q35779580":"webpage","Q47382471":"webpage","Q47524402":"webpage","Q54734643":"webpage","Q58573615":"webpage","Q61866692":"webpage","Q8615872":"webpage","Q21286738":"webpage","Q21469493":"webpage","Q21479588":"webpage","Q23841178":"webpage","Q24571886":"webpage","Q26211786":"dataset","Q28368760":"webpage","Q28373483":"webpage","Q849666":"motion_picture","Q18089617":"motion_picture","Q18889701":"dataset","Q20010800":"webpage","Q163126":"dataset","Q1967745":"dataset","Q2122972":"dataset","Q2565860":"dataset","Q3516420":"dataset","Q13331174":"webpage","Q15088954":"dataset","Q15885744":"dataset","Q16069643":"dataset","Q17146890":"dataset","Q18435139":"dataset","Q20107258":"dataset","Q23894246":"webpage","Q57733325":"dataset","Q17175676":"motion_picture","Q26196748":"motion_picture","Q21484471":"webpage","Q265147":"song","Q56558213":"song","Q627181":"song","Q1151259":"song","Q7023411":"song","Q190635":"dataset","Q526334":"dataset","Q1982918":"dataset","Q2362354":"dataset","Q22842824":"webpage","Q3129804":"motion_picture","Q22677515":"webpage","Q48552277":"webpage","Q56876519":"webpage","Q11753321":"webpage","Q15671253":"webpage","Q20769160":"webpage","Q24731821":"webpage","Q26142649":"webpage","Q36330215":"webpage","Q6306272":"webpage","Q14385296":"webpage","Q14403646":"webpage","Q20107493":"dataset","Q20743001":"webpage","Q14460829":"webpage","Q11643859":"song","Q16141944":"song","Q17990546":"song","Q20043946":"song","Q44292661":"webpage","Q29075123":"webpage","Q40218570":"webpage","Q910144":"dataset","Q5622823":"webpage","Q13565583":"webpage","Q19648608":"webpage","Q19915239":"dataset","Q21278897":"webpage","Q21441359":"dataset","Q21441363":"dataset","Q23841351":"webpage","Q26932615":"webpage","Q26961029":"webpage","Q27949687":"webpage","Q27949697":"webpage","Q28858528":"webpage","Q29075121":"webpage","Q922853":"song","Q3879286":"song","Q3368338":"dataset","Q10997407":"webpage","Q19842659":"webpage","Q56062113":"webpage"}
 
-},{}],109:[function(require,module,exports){
+},{}],101:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -9901,7 +9654,7 @@ exports.parse = void 0;
 const parse = input => input.match(/\/(Q\d+)(?:[#?/]|\s*$)/)[1];
 
 exports.parse = parse;
-},{}],110:[function(require,module,exports){
+},{}],102:[function(require,module,exports){
 "use strict";
 
 require("whatwg-fetch");
@@ -9978,7 +9731,7 @@ window.addEventListener('load', function () {
     element.insertAdjacentHTML('beforeend', output);
   });
 });
-},{"@citation-js/core":"citation-js","whatwg-fetch":147}],111:[function(require,module,exports){
+},{"@citation-js/core":"citation-js","whatwg-fetch":139}],103:[function(require,module,exports){
 'use strict'
 
 exports.byteLength = byteLength
@@ -10130,7 +9883,7 @@ function fromByteArray (uint8) {
   return parts.join('')
 }
 
-},{}],112:[function(require,module,exports){
+},{}],104:[function(require,module,exports){
 (function (Buffer){(function (){
 /*!
  * The buffer module from node.js, for the browser.
@@ -11911,7 +11664,8 @@ function numberIsNaN (obj) {
 }
 
 }).call(this)}).call(this,require("buffer").Buffer)
-},{"base64-js":111,"buffer":112,"ieee754":113}],113:[function(require,module,exports){
+},{"base64-js":103,"buffer":104,"ieee754":105}],105:[function(require,module,exports){
+/*! ieee754. BSD-3-Clause License. Feross Aboukhadijeh <https://feross.org/opensource> */
 exports.read = function (buffer, offset, isLE, mLen, nBytes) {
   var e, m
   var eLen = (nBytes * 8) - mLen - 1
@@ -11997,7 +11751,7 @@ exports.write = function (buffer, value, offset, isLE, mLen, nBytes) {
   buffer[offset + i - d] |= s * 128
 }
 
-},{}],114:[function(require,module,exports){
+},{}],106:[function(require,module,exports){
 // the whatwg-fetch polyfill installs the fetch() function
 // on the global object (window or self)
 //
@@ -12005,7 +11759,7 @@ exports.write = function (buffer, value, offset, isLE, mLen, nBytes) {
 require('whatwg-fetch');
 module.exports = self.fetch.bind(self);
 
-},{"whatwg-fetch":147}],115:[function(require,module,exports){
+},{"whatwg-fetch":139}],107:[function(require,module,exports){
 'use strict';
 
 
@@ -12054,7 +11808,7 @@ module.exports.safeLoad            = renamed('safeLoad', 'load');
 module.exports.safeLoadAll         = renamed('safeLoadAll', 'loadAll');
 module.exports.safeDump            = renamed('safeDump', 'dump');
 
-},{"./lib/dumper":117,"./lib/exception":118,"./lib/loader":119,"./lib/schema":120,"./lib/schema/core":121,"./lib/schema/default":122,"./lib/schema/failsafe":123,"./lib/schema/json":124,"./lib/type":126,"./lib/type/binary":127,"./lib/type/bool":128,"./lib/type/float":129,"./lib/type/int":130,"./lib/type/map":131,"./lib/type/merge":132,"./lib/type/null":133,"./lib/type/omap":134,"./lib/type/pairs":135,"./lib/type/seq":136,"./lib/type/set":137,"./lib/type/str":138,"./lib/type/timestamp":139}],116:[function(require,module,exports){
+},{"./lib/dumper":109,"./lib/exception":110,"./lib/loader":111,"./lib/schema":112,"./lib/schema/core":113,"./lib/schema/default":114,"./lib/schema/failsafe":115,"./lib/schema/json":116,"./lib/type":118,"./lib/type/binary":119,"./lib/type/bool":120,"./lib/type/float":121,"./lib/type/int":122,"./lib/type/map":123,"./lib/type/merge":124,"./lib/type/null":125,"./lib/type/omap":126,"./lib/type/pairs":127,"./lib/type/seq":128,"./lib/type/set":129,"./lib/type/str":130,"./lib/type/timestamp":131}],108:[function(require,module,exports){
 'use strict';
 
 
@@ -12115,7 +11869,7 @@ module.exports.repeat         = repeat;
 module.exports.isNegativeZero = isNegativeZero;
 module.exports.extend         = extend;
 
-},{}],117:[function(require,module,exports){
+},{}],109:[function(require,module,exports){
 'use strict';
 
 /*eslint-disable no-use-before-define*/
@@ -13082,7 +12836,7 @@ function dump(input, options) {
 
 module.exports.dump = dump;
 
-},{"./common":116,"./exception":118,"./schema/default":122}],118:[function(require,module,exports){
+},{"./common":108,"./exception":110,"./schema/default":114}],110:[function(require,module,exports){
 // YAML error class. http://stackoverflow.com/questions/8458984
 //
 'use strict';
@@ -13139,7 +12893,7 @@ YAMLException.prototype.toString = function toString(compact) {
 
 module.exports = YAMLException;
 
-},{}],119:[function(require,module,exports){
+},{}],111:[function(require,module,exports){
 'use strict';
 
 /*eslint-disable max-len,no-use-before-define*/
@@ -14868,7 +14622,7 @@ function load(input, options) {
 module.exports.loadAll = loadAll;
 module.exports.load    = load;
 
-},{"./common":116,"./exception":118,"./schema/default":122,"./snippet":125}],120:[function(require,module,exports){
+},{"./common":108,"./exception":110,"./schema/default":114,"./snippet":117}],112:[function(require,module,exports){
 'use strict';
 
 /*eslint-disable max-len*/
@@ -14991,7 +14745,7 @@ Schema.prototype.extend = function extend(definition) {
 
 module.exports = Schema;
 
-},{"./exception":118,"./type":126}],121:[function(require,module,exports){
+},{"./exception":110,"./type":118}],113:[function(require,module,exports){
 // Standard YAML's Core schema.
 // http://www.yaml.org/spec/1.2/spec.html#id2804923
 //
@@ -15004,7 +14758,7 @@ module.exports = Schema;
 
 module.exports = require('./json');
 
-},{"./json":124}],122:[function(require,module,exports){
+},{"./json":116}],114:[function(require,module,exports){
 // JS-YAML's default schema for `safeLoad` function.
 // It is not described in the YAML specification.
 //
@@ -15028,7 +14782,7 @@ module.exports = require('./core').extend({
   ]
 });
 
-},{"../type/binary":127,"../type/merge":132,"../type/omap":134,"../type/pairs":135,"../type/set":137,"../type/timestamp":139,"./core":121}],123:[function(require,module,exports){
+},{"../type/binary":119,"../type/merge":124,"../type/omap":126,"../type/pairs":127,"../type/set":129,"../type/timestamp":131,"./core":113}],115:[function(require,module,exports){
 // Standard YAML's Failsafe schema.
 // http://www.yaml.org/spec/1.2/spec.html#id2802346
 
@@ -15047,7 +14801,7 @@ module.exports = new Schema({
   ]
 });
 
-},{"../schema":120,"../type/map":131,"../type/seq":136,"../type/str":138}],124:[function(require,module,exports){
+},{"../schema":112,"../type/map":123,"../type/seq":128,"../type/str":130}],116:[function(require,module,exports){
 // Standard YAML's JSON schema.
 // http://www.yaml.org/spec/1.2/spec.html#id2803231
 //
@@ -15068,7 +14822,7 @@ module.exports = require('./failsafe').extend({
   ]
 });
 
-},{"../type/bool":128,"../type/float":129,"../type/int":130,"../type/null":133,"./failsafe":123}],125:[function(require,module,exports){
+},{"../type/bool":120,"../type/float":121,"../type/int":122,"../type/null":125,"./failsafe":115}],117:[function(require,module,exports){
 'use strict';
 
 
@@ -15171,7 +14925,7 @@ function makeSnippet(mark, options) {
 
 module.exports = makeSnippet;
 
-},{"./common":116}],126:[function(require,module,exports){
+},{"./common":108}],118:[function(require,module,exports){
 'use strict';
 
 var YAMLException = require('./exception');
@@ -15239,7 +14993,7 @@ function Type(tag, options) {
 
 module.exports = Type;
 
-},{"./exception":118}],127:[function(require,module,exports){
+},{"./exception":110}],119:[function(require,module,exports){
 'use strict';
 
 /*eslint-disable no-bitwise*/
@@ -15366,7 +15120,7 @@ module.exports = new Type('tag:yaml.org,2002:binary', {
   represent: representYamlBinary
 });
 
-},{"../type":126}],128:[function(require,module,exports){
+},{"../type":118}],120:[function(require,module,exports){
 'use strict';
 
 var Type = require('../type');
@@ -15403,7 +15157,7 @@ module.exports = new Type('tag:yaml.org,2002:bool', {
   defaultStyle: 'lowercase'
 });
 
-},{"../type":126}],129:[function(require,module,exports){
+},{"../type":118}],121:[function(require,module,exports){
 'use strict';
 
 var common = require('../common');
@@ -15502,7 +15256,7 @@ module.exports = new Type('tag:yaml.org,2002:float', {
   defaultStyle: 'lowercase'
 });
 
-},{"../common":116,"../type":126}],130:[function(require,module,exports){
+},{"../common":108,"../type":118}],122:[function(require,module,exports){
 'use strict';
 
 var common = require('../common');
@@ -15660,7 +15414,7 @@ module.exports = new Type('tag:yaml.org,2002:int', {
   }
 });
 
-},{"../common":116,"../type":126}],131:[function(require,module,exports){
+},{"../common":108,"../type":118}],123:[function(require,module,exports){
 'use strict';
 
 var Type = require('../type');
@@ -15670,7 +15424,7 @@ module.exports = new Type('tag:yaml.org,2002:map', {
   construct: function (data) { return data !== null ? data : {}; }
 });
 
-},{"../type":126}],132:[function(require,module,exports){
+},{"../type":118}],124:[function(require,module,exports){
 'use strict';
 
 var Type = require('../type');
@@ -15684,7 +15438,7 @@ module.exports = new Type('tag:yaml.org,2002:merge', {
   resolve: resolveYamlMerge
 });
 
-},{"../type":126}],133:[function(require,module,exports){
+},{"../type":118}],125:[function(require,module,exports){
 'use strict';
 
 var Type = require('../type');
@@ -15721,7 +15475,7 @@ module.exports = new Type('tag:yaml.org,2002:null', {
   defaultStyle: 'lowercase'
 });
 
-},{"../type":126}],134:[function(require,module,exports){
+},{"../type":118}],126:[function(require,module,exports){
 'use strict';
 
 var Type = require('../type');
@@ -15767,7 +15521,7 @@ module.exports = new Type('tag:yaml.org,2002:omap', {
   construct: constructYamlOmap
 });
 
-},{"../type":126}],135:[function(require,module,exports){
+},{"../type":118}],127:[function(require,module,exports){
 'use strict';
 
 var Type = require('../type');
@@ -15822,7 +15576,7 @@ module.exports = new Type('tag:yaml.org,2002:pairs', {
   construct: constructYamlPairs
 });
 
-},{"../type":126}],136:[function(require,module,exports){
+},{"../type":118}],128:[function(require,module,exports){
 'use strict';
 
 var Type = require('../type');
@@ -15832,7 +15586,7 @@ module.exports = new Type('tag:yaml.org,2002:seq', {
   construct: function (data) { return data !== null ? data : []; }
 });
 
-},{"../type":126}],137:[function(require,module,exports){
+},{"../type":118}],129:[function(require,module,exports){
 'use strict';
 
 var Type = require('../type');
@@ -15863,7 +15617,7 @@ module.exports = new Type('tag:yaml.org,2002:set', {
   construct: constructYamlSet
 });
 
-},{"../type":126}],138:[function(require,module,exports){
+},{"../type":118}],130:[function(require,module,exports){
 'use strict';
 
 var Type = require('../type');
@@ -15873,7 +15627,7 @@ module.exports = new Type('tag:yaml.org,2002:str', {
   construct: function (data) { return data !== null ? data : ''; }
 });
 
-},{"../type":126}],139:[function(require,module,exports){
+},{"../type":118}],131:[function(require,module,exports){
 'use strict';
 
 var Type = require('../type');
@@ -15963,7 +15717,7 @@ module.exports = new Type('tag:yaml.org,2002:timestamp', {
   represent: representYamlTimestamp
 });
 
-},{"../type":126}],140:[function(require,module,exports){
+},{"../type":118}],132:[function(require,module,exports){
 (function(root, factory) {
   if (typeof define === 'function' && define.amd) {
     define([], factory) /* global define */
@@ -16565,7 +16319,7 @@ module.exports = new Type('tag:yaml.org,2002:timestamp', {
 
 }));
 
-},{}],141:[function(require,module,exports){
+},{}],133:[function(require,module,exports){
 // shim for using process in browser
 var process = module.exports = {};
 
@@ -16751,7 +16505,7 @@ process.chdir = function (dir) {
 };
 process.umask = function() { return 0; };
 
-},{}],142:[function(require,module,exports){
+},{}],134:[function(require,module,exports){
 // Copyright Joyent, Inc. and other Node contributors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
@@ -16837,7 +16591,7 @@ var isArray = Array.isArray || function (xs) {
   return Object.prototype.toString.call(xs) === '[object Array]';
 };
 
-},{}],143:[function(require,module,exports){
+},{}],135:[function(require,module,exports){
 // Copyright Joyent, Inc. and other Node contributors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
@@ -16924,13 +16678,13 @@ var objectKeys = Object.keys || function (obj) {
   return res;
 };
 
-},{}],144:[function(require,module,exports){
+},{}],136:[function(require,module,exports){
 'use strict';
 
 exports.decode = exports.parse = require('./decode');
 exports.encode = exports.stringify = require('./encode');
 
-},{"./decode":142,"./encode":143}],145:[function(require,module,exports){
+},{"./decode":134,"./encode":135}],137:[function(require,module,exports){
 /* eslint-env browser */
 
 const { Buffer } = require('buffer/')
@@ -17118,7 +16872,7 @@ syncFetch.Request = SyncRequest
 syncFetch.Response = SyncResponse
 module.exports = syncFetch
 
-},{"buffer/":146}],146:[function(require,module,exports){
+},{"buffer/":138}],138:[function(require,module,exports){
 (function (Buffer){(function (){
 /*!
  * The buffer module from node.js, for the browser.
@@ -18939,7 +18693,7 @@ var hexSliceLookupTable = (function () {
 })()
 
 }).call(this)}).call(this,require("buffer").Buffer)
-},{"base64-js":111,"buffer":112,"ieee754":113}],147:[function(require,module,exports){
+},{"base64-js":103,"buffer":104,"ieee754":105}],139:[function(require,module,exports){
 (function (global, factory) {
   typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
   typeof define === 'function' && define.amd ? define(['exports'], factory) :
@@ -19561,7 +19315,7 @@ var hexSliceLookupTable = (function () {
 
 })));
 
-},{}],148:[function(require,module,exports){
+},{}],140:[function(require,module,exports){
 const toDateObject = require('./wikibase_time_to_date_object')
 
 const helpers = {}
@@ -19682,7 +19436,7 @@ helpers.getEntityIdFromGuid = guid => {
 
 module.exports = helpers
 
-},{"./wikibase_time_to_date_object":163}],149:[function(require,module,exports){
+},{"./wikibase_time_to_date_object":155}],141:[function(require,module,exports){
 const { wikibaseTimeToISOString, wikibaseTimeToEpochTime, wikibaseTimeToSimpleDay } = require('./helpers')
 
 const simple = datavalue => datavalue.value
@@ -19803,7 +19557,7 @@ module.exports = {
   }
 }
 
-},{"./helpers":148}],150:[function(require,module,exports){
+},{"./helpers":140}],142:[function(require,module,exports){
 const { simplifyEntity } = require('./simplify_entity')
 
 const wb = {
@@ -19830,11 +19584,15 @@ module.exports = {
   wd: wb
 }
 
-},{"./simplify_entity":154}],151:[function(require,module,exports){
+},{"./simplify_entity":146}],143:[function(require,module,exports){
 const truthyPropertyClaims = propClaims => {
   const aggregate = propClaims.reduce(aggregatePerRank, {})
   // on truthyness: https://www.mediawiki.org/wiki/Wikibase/Indexing/RDF_Dump_Format#Truthy_statements
   return aggregate.preferred || aggregate.normal || []
+}
+
+const nonDeprecatedPropertyClaims = propClaims => {
+  return propClaims.filter(claim => claim.rank !== 'deprecated')
 }
 
 const aggregatePerRank = (aggregate, claim) => {
@@ -19852,9 +19610,9 @@ const truthyClaims = claims => {
   return truthClaimsOnly
 }
 
-module.exports = { truthyClaims, truthyPropertyClaims }
+module.exports = { truthyClaims, truthyPropertyClaims, nonDeprecatedPropertyClaims }
 
-},{}],152:[function(require,module,exports){
+},{}],144:[function(require,module,exports){
 const { labels, descriptions, aliases, lemmas, glosses } = require('./simplify_text_attributes')
 
 const {
@@ -19906,10 +19664,10 @@ module.exports = {
   // entities,
 }
 
-},{"./simplify_claims":153,"./simplify_forms":155,"./simplify_senses":156,"./simplify_sitelinks":157,"./simplify_sparql_results":158,"./simplify_text_attributes":159}],153:[function(require,module,exports){
+},{"./simplify_claims":145,"./simplify_forms":147,"./simplify_senses":148,"./simplify_sitelinks":149,"./simplify_sparql_results":150,"./simplify_text_attributes":151}],145:[function(require,module,exports){
 const { parse: parseClaim } = require('./parse_claim')
 const { uniq } = require('../utils/utils')
-const { truthyPropertyClaims } = require('./rank')
+const { truthyPropertyClaims, nonDeprecatedPropertyClaims } = require('./rank')
 
 // Expects an entity 'claims' object
 // Ex: entity.claims
@@ -19934,8 +19692,11 @@ const simplifyPropertyClaims = (propClaims, ...options) => {
   // Ex: simplifyPropertyClaims(entity.claims.P124211616)
   if (propClaims == null || propClaims.length === 0) return []
 
-  const { keepNonTruthy, areSubSnaks } = parseOptions(options)
-  if (!(keepNonTruthy || areSubSnaks)) {
+  const { keepNonTruthy, keepNonDeprecated, areSubSnaks } = parseOptions(options)
+
+  if (keepNonDeprecated) {
+    propClaims = nonDeprecatedPropertyClaims(propClaims)
+  } else if (!(keepNonTruthy || areSubSnaks)) {
     propClaims = truthyPropertyClaims(propClaims)
   }
 
@@ -20097,7 +19858,7 @@ module.exports = {
   simplifyReferences,
 }
 
-},{"../utils/utils":174,"./parse_claim":149,"./rank":151}],154:[function(require,module,exports){
+},{"../utils/utils":166,"./parse_claim":141,"./rank":143}],146:[function(require,module,exports){
 const simplify = require('./simplify')
 
 const simplifyEntity = (entity, options) => {
@@ -20157,7 +19918,7 @@ simplify.entities = simplifyEntities
 
 module.exports = { simplifyEntity, simplifyEntities }
 
-},{"./simplify":152}],155:[function(require,module,exports){
+},{"./simplify":144}],147:[function(require,module,exports){
 const { isFormId } = require('./helpers')
 const { representations: simplifyRepresentations } = require('./simplify_text_attributes')
 const { simplifyClaims } = require('./simplify_claims')
@@ -20177,7 +19938,7 @@ const simplifyForms = (forms, options) => forms.map(form => simplifyForm(form, o
 
 module.exports = { simplifyForm, simplifyForms }
 
-},{"./helpers":148,"./simplify_claims":153,"./simplify_text_attributes":159}],156:[function(require,module,exports){
+},{"./helpers":140,"./simplify_claims":145,"./simplify_text_attributes":151}],148:[function(require,module,exports){
 const { isSenseId } = require('./helpers')
 const { glosses: simplifyGlosses } = require('./simplify_text_attributes')
 const { simplifyClaims } = require('./simplify_claims')
@@ -20196,7 +19957,7 @@ const simplifySenses = (senses, options) => senses.map(sense => simplifySense(se
 
 module.exports = { simplifySense, simplifySenses }
 
-},{"./helpers":148,"./simplify_claims":153,"./simplify_text_attributes":159}],157:[function(require,module,exports){
+},{"./helpers":140,"./simplify_claims":145,"./simplify_text_attributes":151}],149:[function(require,module,exports){
 const { getSitelinkUrl } = require('./sitelinks')
 
 module.exports = (sitelinks, options = {}) => {
@@ -20205,6 +19966,12 @@ module.exports = (sitelinks, options = {}) => {
 }
 
 const aggregateValues = (sitelinks, addUrl) => (index, key) => {
+  // Accomodating for wikibase-cli, which might set the sitelink to null
+  // to signify that a requested sitelink was not found
+  if (sitelinks[key] == null) {
+    index[key] = sitelinks[key]
+    return index
+  }
   const { title } = sitelinks[key]
   if (addUrl) {
     index[key] = { title, url: getSitelinkUrl(key, title) }
@@ -20214,7 +19981,7 @@ const aggregateValues = (sitelinks, addUrl) => (index, key) => {
   return index
 }
 
-},{"./sitelinks":160}],158:[function(require,module,exports){
+},{"./sitelinks":152}],150:[function(require,module,exports){
 module.exports = (input, options = {}) => {
   if (typeof input === 'string') input = JSON.parse(input)
 
@@ -20286,7 +20053,12 @@ const convertStatementUriToGuid = uri => {
 }
 
 const identifyVars = vars => {
-  const richVars = vars.filter(varName => vars.some(isAssociatedVar(varName)))
+  let richVars = vars.filter(varName => vars.some(isAssociatedVar(varName)))
+  richVars = richVars.filter(richVar => {
+    return !richVars.some(otherRichVar => {
+      return richVar !== otherRichVar && richVar.startsWith(otherRichVar)
+    })
+  })
   const associatedVarPattern = new RegExp(`^(${richVars.join('|')})[A-Z]`)
   const associatedVars = vars.filter(varName => associatedVarPattern.test(varName))
   const standaloneVars = vars.filter(varName => {
@@ -20332,7 +20104,7 @@ const specialNames = {
   altLabel: 'aliases'
 }
 
-},{}],159:[function(require,module,exports){
+},{}],151:[function(require,module,exports){
 const simplifyTextAttributes = multivalue => data => {
   const simplified = {}
   Object.keys(data).forEach(lang => {
@@ -20359,7 +20131,7 @@ module.exports = {
   glosses: singleValue
 }
 
-},{}],160:[function(require,module,exports){
+},{}],152:[function(require,module,exports){
 const { fixedEncodeURIComponent, replaceSpaceByUnderscores, isPlainObject } = require('../utils/utils')
 const { isPropertyId } = require('./helpers')
 const wikidataBase = 'https://www.wikidata.org/wiki/'
@@ -20471,11 +20243,341 @@ const projectsBySuffix = {
 
 module.exports = { getSitelinkUrl, getSitelinkData, isSitelinkKey }
 
-},{"../utils/utils":174,"./helpers":148,"./sitelinks_languages":161}],161:[function(require,module,exports){
+},{"../utils/utils":166,"./helpers":140,"./sitelinks_languages":153}],153:[function(require,module,exports){
 // Generated by 'npm run update-sitelinks-languages'
-module.exports = [ 'aa', 'ab', 'ace', 'ady', 'af', 'ak', 'als', 'alt', 'am', 'ang', 'an', 'arc', 'ar', 'ary', 'arz', 'ast', 'as', 'atj', 'avk', 'av', 'awa', 'ay', 'azb', 'az', 'ban', 'bar', 'bat_smg', 'ba', 'bcl', 'be_x_old', 'be', 'bg', 'bh', 'bi', 'bjn', 'bm', 'bn', 'bo', 'bpy', 'br', 'bs', 'bug', 'bxr', 'ca', 'cbk_zam', 'cdo', 'ceb', 'ce', 'cho', 'chr', 'ch', 'chy', 'ckb', 'co', 'crh', 'cr', 'csb', 'cs', 'cu', 'cv', 'cy', 'da', 'de', 'din', 'diq', 'dsb', 'dty', 'dv', 'dz', 'ee', 'el', 'eml', 'en', 'eo', 'es', 'et', 'eu', 'ext', 'fa', 'ff', 'fiu_vro', 'fi', 'fj', 'fo', 'frp', 'frr', 'fr', 'fur', 'fy', 'gag', 'gan', 'ga', 'gcr', 'gd', 'glk', 'gl', 'gn', 'gom', 'gor', 'got', 'gu', 'gv', 'hak', 'ha', 'haw', 'he', 'hif', 'hi', 'ho', 'hr', 'hsb', 'ht', 'hu', 'hy', 'hyw', 'hz', 'ia', 'id', 'ie', 'ig', 'ii', 'ik', 'ilo', 'inh', 'io', 'is', 'it', 'iu', 'jam', 'ja', 'jbo', 'jv', 'kaa', 'kab', 'ka', 'kbd', 'kbp', 'kg', 'ki', 'kj', 'kk', 'kl', 'km', 'kn', 'koi', 'ko', 'krc', 'kr', 'ksh', 'ks', 'ku', 'kv', 'kw', 'ky', 'lad', 'la', 'lbe', 'lb', 'lez', 'lfn', 'lg', 'lij', 'li', 'lld', 'lmo', 'ln', 'lo', 'lrc', 'ltg', 'lt', 'lv', 'mad', 'mai', 'map_bms', 'mdf', 'mg', 'mhr', 'mh', 'min', 'mi', 'mk', 'ml', 'mni', 'mn', 'mnw', 'mo', 'mrj', 'mr', 'ms', 'mt', 'mus', 'mwl', 'myv', 'my', 'mzn', 'nah', 'nap', 'na', 'nds_nl', 'nds', 'ne', 'new', 'ng', 'nia', 'nl', 'nn', 'nov', 'no', 'nqo', 'nrm', 'nso', 'nv', 'ny', 'oc', 'olo', 'om', 'or', 'os', 'pag', 'pam', 'pap', 'pa', 'pcd', 'pdc', 'pfl', 'pih', 'pi', 'pl', 'pms', 'pnb', 'pnt', 'ps', 'pt', 'qu', 'rm', 'rmy', 'rn', 'roa_rup', 'roa_tara', 'ro', 'rue', 'ru', 'rw', 'sah', 'sat', 'sa', 'scn', 'sco', 'sc', 'sd', 'se', 'sg', 'shn', 'sh', 'shy', 'simple', 'si', 'skr', 'sk', 'sl', 'smn', 'sm', 'sn', 'sources', 'so', 'sq', 'srn', 'sr', 'ss', 'stq', 'st', 'su', 'sv', 'sw', 'szl', 'szy', 'ta', 'tay', 'tcy', 'tet', 'te', 'tg', 'th', 'ti', 'tk', 'tl', 'tn', 'to', 'tpi', 'trv', 'tr', 'ts', 'tt', 'tum', 'tw', 'tyv', 'ty', 'udm', 'ug', 'uk', 'ur', 'uz', 'vec', 'vep', 've', 'vi', 'vls', 'vo', 'war', 'wa', 'wo', 'wuu', 'xal', 'xh', 'xmf', 'yi', 'yo', 'yue', 'za', 'zea', 'zh_classical', 'zh_min_nan', 'zh_yue', 'zh', 'zu' ]
+module.exports = [
+  'aa',
+  'ab',
+  'ace',
+  'ady',
+  'af',
+  'ak',
+  'als',
+  'alt',
+  'ami',
+  'am',
+  'ang',
+  'an',
+  'arc',
+  'ar',
+  'ary',
+  'arz',
+  'ast',
+  'as',
+  'atj',
+  'avk',
+  'av',
+  'awa',
+  'ay',
+  'azb',
+  'az',
+  'ban',
+  'bar',
+  'bat_smg',
+  'ba',
+  'bcl',
+  'be_x_old',
+  'be',
+  'bg',
+  'bh',
+  'bi',
+  'bjn',
+  'bm',
+  'bn',
+  'bo',
+  'bpy',
+  'br',
+  'bs',
+  'bug',
+  'bxr',
+  'ca',
+  'cbk_zam',
+  'cdo',
+  'ceb',
+  'ce',
+  'cho',
+  'chr',
+  'ch',
+  'chy',
+  'ckb',
+  'co',
+  'crh',
+  'cr',
+  'csb',
+  'cs',
+  'cu',
+  'cv',
+  'cy',
+  'dag',
+  'da',
+  'de',
+  'din',
+  'diq',
+  'dsb',
+  'dty',
+  'dv',
+  'dz',
+  'ee',
+  'el',
+  'eml',
+  'en',
+  'eo',
+  'es',
+  'et',
+  'eu',
+  'ext',
+  'fa',
+  'ff',
+  'fiu_vro',
+  'fi',
+  'fj',
+  'fo',
+  'frp',
+  'frr',
+  'fr',
+  'fur',
+  'fy',
+  'gag',
+  'gan',
+  'ga',
+  'gcr',
+  'gd',
+  'glk',
+  'gl',
+  'gn',
+  'gom',
+  'gor',
+  'got',
+  'gu',
+  'gv',
+  'hak',
+  'ha',
+  'haw',
+  'he',
+  'hif',
+  'hi',
+  'ho',
+  'hr',
+  'hsb',
+  'ht',
+  'hu',
+  'hy',
+  'hyw',
+  'hz',
+  'ia',
+  'id',
+  'ie',
+  'ig',
+  'ii',
+  'ik',
+  'ilo',
+  'inh',
+  'io',
+  'is',
+  'it',
+  'iu',
+  'jam',
+  'ja',
+  'jbo',
+  'jv',
+  'kaa',
+  'kab',
+  'ka',
+  'kbd',
+  'kbp',
+  'kg',
+  'ki',
+  'kj',
+  'kk',
+  'kl',
+  'km',
+  'kn',
+  'koi',
+  'ko',
+  'krc',
+  'kr',
+  'ksh',
+  'ks',
+  'ku',
+  'kv',
+  'kw',
+  'ky',
+  'lad',
+  'la',
+  'lbe',
+  'lb',
+  'lez',
+  'lfn',
+  'lg',
+  'lij',
+  'li',
+  'lld',
+  'lmo',
+  'ln',
+  'lo',
+  'lrc',
+  'ltg',
+  'lt',
+  'lv',
+  'mad',
+  'mai',
+  'map_bms',
+  'mdf',
+  'mg',
+  'mhr',
+  'mh',
+  'min',
+  'mi',
+  'mk',
+  'ml',
+  'mni',
+  'mn',
+  'mnw',
+  'mo',
+  'mrj',
+  'mr',
+  'ms',
+  'mt',
+  'mus',
+  'mwl',
+  'myv',
+  'my',
+  'mzn',
+  'nah',
+  'nap',
+  'na',
+  'nds_nl',
+  'nds',
+  'ne',
+  'new',
+  'ng',
+  'nia',
+  'nl',
+  'nn',
+  'nov',
+  'no',
+  'nqo',
+  'nrm',
+  'nso',
+  'nv',
+  'ny',
+  'oc',
+  'olo',
+  'om',
+  'or',
+  'os',
+  'pag',
+  'pam',
+  'pap',
+  'pa',
+  'pcd',
+  'pdc',
+  'pfl',
+  'pih',
+  'pi',
+  'pl',
+  'pms',
+  'pnb',
+  'pnt',
+  'ps',
+  'pt',
+  'pwn',
+  'qu',
+  'rm',
+  'rmy',
+  'rn',
+  'roa_rup',
+  'roa_tara',
+  'ro',
+  'rue',
+  'ru',
+  'rw',
+  'sah',
+  'sat',
+  'sa',
+  'scn',
+  'sco',
+  'sc',
+  'sd',
+  'se',
+  'sg',
+  'shi',
+  'shn',
+  'sh',
+  'shy',
+  'simple',
+  'si',
+  'skr',
+  'sk',
+  'sl',
+  'smn',
+  'sm',
+  'sn',
+  'sources',
+  'so',
+  'sq',
+  'srn',
+  'sr',
+  'ss',
+  'stq',
+  'st',
+  'su',
+  'sv',
+  'sw',
+  'szl',
+  'szy',
+  'ta',
+  'tay',
+  'tcy',
+  'tet',
+  'te',
+  'tg',
+  'th',
+  'ti',
+  'tk',
+  'tl',
+  'tn',
+  'to',
+  'tpi',
+  'trv',
+  'tr',
+  'ts',
+  'tt',
+  'tum',
+  'tw',
+  'tyv',
+  'ty',
+  'udm',
+  'ug',
+  'uk',
+  'ur',
+  'uz',
+  'vec',
+  'vep',
+  've',
+  'vi',
+  'vls',
+  'vo',
+  'war',
+  'wa',
+  'wo',
+  'wuu',
+  'xal',
+  'xh',
+  'xmf',
+  'yi',
+  'yo',
+  'yue',
+  'za',
+  'zea',
+  'zh_classical',
+  'zh_min_nan',
+  'zh_yue',
+  'zh',
+  'zu'
+]
 
-},{}],162:[function(require,module,exports){
+},{}],154:[function(require,module,exports){
 const helpers = require('./helpers')
 
 const validate = (name, testName) => value => {
@@ -20489,7 +20591,7 @@ module.exports = {
   revisionId: validate('revision id', 'isRevisionId')
 }
 
-},{"./helpers":148}],163:[function(require,module,exports){
+},{"./helpers":140}],155:[function(require,module,exports){
 module.exports = wikibaseTime => {
   // Also accept claim datavalue.value objects
   if (typeof wikibaseTime === 'object') {
@@ -20530,7 +20632,7 @@ const expandedYearDate = (sign, rest, year) => {
   return new Date(date)
 }
 
-},{}],164:[function(require,module,exports){
+},{}],156:[function(require,module,exports){
 // See https://www.wikidata.org/w/api.php?action=help&modules=query%2Bsearch
 
 const { isPlainObject } = require('../utils/utils')
@@ -20593,7 +20695,7 @@ module.exports = buildUrl => params => {
   })
 }
 
-},{"../utils/utils":174}],165:[function(require,module,exports){
+},{"../utils/utils":166}],157:[function(require,module,exports){
 const { isPlainObject, forceArray, shortLang } = require('../utils/utils')
 const validate = require('../helpers/validate')
 
@@ -20642,7 +20744,7 @@ module.exports = buildUrl => (ids, languages, props, format, redirects) => {
   return buildUrl(query)
 }
 
-},{"../helpers/validate":162,"../utils/utils":174}],166:[function(require,module,exports){
+},{"../helpers/validate":154,"../utils/utils":166}],158:[function(require,module,exports){
 const { isPlainObject, forceArray, shortLang } = require('../utils/utils')
 
 module.exports = buildUrl => (titles, sites, languages, props, format, redirects) => {
@@ -20699,21 +20801,21 @@ module.exports = buildUrl => (titles, sites, languages, props, format, redirects
 // convert 2 letters language code to Wikipedia sitelinks code
 const parseSite = site => site.length === 2 ? `${site}wiki` : site
 
-},{"../utils/utils":174}],167:[function(require,module,exports){
+},{"../utils/utils":166}],159:[function(require,module,exports){
 const validate = require('../helpers/validate')
 const { isPlainObject } = require('../utils/utils')
 
-module.exports = instance => (id, revision) => {
+module.exports = (instance, wgScriptPath) => (id, revision) => {
   if (isPlainObject(id)) {
     revision = id.revision
     id = id.id
   }
   validate.entityId(id)
   validate.revisionId(revision)
-  return `${instance}/w/index.php?title=Special:EntityData/${id}.json&revision=${revision}`
+  return `${instance}/${wgScriptPath}/index.php?title=Special:EntityData/${id}.json&revision=${revision}`
 }
 
-},{"../helpers/validate":162,"../utils/utils":174}],168:[function(require,module,exports){
+},{"../helpers/validate":154,"../utils/utils":166}],160:[function(require,module,exports){
 const { isPlainObject } = require('../utils/utils')
 
 module.exports = buildUrl => {
@@ -20741,7 +20843,7 @@ const getIdsGroups = ids => {
   return groups
 }
 
-},{"../utils/utils":174,"./get_entities":165}],169:[function(require,module,exports){
+},{"../utils/utils":166,"./get_entities":157}],161:[function(require,module,exports){
 const { forceArray } = require('../utils/utils')
 const { isItemId } = require('../helpers/helpers')
 const validate = require('../helpers/validate')
@@ -20806,9 +20908,11 @@ const caseInsensitiveValueQuery = (properties, value, filter, limit) => {
 
 const prefixifyProperty = property => 'wdt:' + property
 
-},{"../helpers/helpers":148,"../helpers/validate":162,"../utils/utils":174,"./sparql_query":172}],170:[function(require,module,exports){
+},{"../helpers/helpers":140,"../helpers/validate":154,"../utils/utils":166,"./sparql_query":164}],162:[function(require,module,exports){
 const { forceArray } = require('../utils/utils')
 const validate = require('../helpers/validate')
+
+// See https://www.wikidata.org/w/api.php?action=help&modules=query+revisions
 
 module.exports = buildUrl => (ids, options = {}) => {
   ids = forceArray(ids)
@@ -20827,7 +20931,12 @@ module.exports = buildUrl => (ids, options = {}) => {
   if (uniqueId && options.end) query.rvend = getEpochSeconds(options.end)
 
   const { prop, user, excludeuser, tag } = options
-  if (prop) query.rvprop = forceArray(prop).join('|')
+  if (prop) {
+    query.rvprop = forceArray(prop).join('|')
+  } else {
+    query.rvprop = 'ids|flags|timestamp|user|userid|size|slotsize|sha1|slotsha1|contentmodel|comment|parsedcomment|content|tags|roles|oresscores'
+  }
+  query.rvslots = '*'
   if (user) query.rvuser = user
   if (excludeuser) query.rvexcludeuser = excludeuser
   if (tag) query.rvtag = tag
@@ -20845,7 +20954,7 @@ const getEpochSeconds = date => {
 
 const earliestPointInMs = new Date('2000-01-01').getTime()
 
-},{"../helpers/validate":162,"../utils/utils":174}],171:[function(require,module,exports){
+},{"../helpers/validate":154,"../utils/utils":166}],163:[function(require,module,exports){
 const { isPlainObject } = require('../utils/utils')
 const types = [ 'item', 'property', 'lexeme', 'form', 'sense' ]
 
@@ -20889,7 +20998,7 @@ module.exports = buildUrl => (search, language, limit, format, uselang) => {
   })
 }
 
-},{"../utils/utils":174}],172:[function(require,module,exports){
+},{"../utils/utils":166}],164:[function(require,module,exports){
 const { fixedEncodeURIComponent } = require('../utils/utils')
 
 module.exports = sparqlEndpoint => sparql => {
@@ -20897,7 +21006,7 @@ module.exports = sparqlEndpoint => sparql => {
   return `${sparqlEndpoint}?format=json&query=${query}`
 }
 
-},{"../utils/utils":174}],173:[function(require,module,exports){
+},{"../utils/utils":166}],165:[function(require,module,exports){
 const isBrowser = typeof location !== 'undefined' && typeof document !== 'undefined'
 
 let stringifyQuery
@@ -20921,7 +21030,7 @@ module.exports = instanceApiEndpoint => queryObj => {
   return instanceApiEndpoint + '?' + stringifyQuery(queryObj)
 }
 
-},{"querystring":144}],174:[function(require,module,exports){
+},{"querystring":136}],166:[function(require,module,exports){
 module.exports = {
   // Ex: keep only 'fr' in 'fr_FR'
   shortLang: language => language.toLowerCase().split('_')[0],
@@ -20952,7 +21061,7 @@ module.exports = {
 
 const encodeCharacter = char => '%' + char.charCodeAt(0).toString(16)
 
-},{}],175:[function(require,module,exports){
+},{}],167:[function(require,module,exports){
 const { isPlainObject } = require('./utils/utils')
 
 const simplify = require('./helpers/simplify')
@@ -20969,6 +21078,9 @@ const common = Object.assign({ simplify, parse }, helpers, sitelinksHelpers, ran
 const WBK = config => {
   if (!isPlainObject(config)) throw new Error('invalid config')
   const { instance, sparqlEndpoint } = config
+  let { wgScriptPath = 'w' } = config
+
+  wgScriptPath = wgScriptPath.replace(/^\//, '')
 
   if (!(instance || sparqlEndpoint)) {
     throw new Error(`one of instance or sparqlEndpoint should be set at initialization.\n${tip}`)
@@ -20980,9 +21092,9 @@ const WBK = config => {
 
     instanceRoot = instance
       .replace(/\/$/, '')
-      .replace('/w/api.php', '')
+      .replace(`/${wgScriptPath}/api.php`, '')
 
-    instanceApiEndpoint = `${instanceRoot}/w/api.php`
+    instanceApiEndpoint = `${instanceRoot}/${wgScriptPath}/api.php`
 
     const buildUrl = require('./utils/build_url')(instanceApiEndpoint)
 
@@ -20992,7 +21104,7 @@ const WBK = config => {
       getEntities: require('./queries/get_entities')(buildUrl),
       getManyEntities: require('./queries/get_many_entities')(buildUrl),
       getRevisions: require('./queries/get_revisions')(buildUrl),
-      getEntityRevision: require('./queries/get_entity_revision')(instance),
+      getEntityRevision: require('./queries/get_entity_revision')(instance, wgScriptPath),
       getEntitiesFromSitelinks: require('./queries/get_entities_from_sitelinks')(buildUrl)
     }
   } else {
@@ -21050,13 +21162,13 @@ const missingInstance = missingConfig('an instance')
 
 module.exports = WBK
 
-},{"../lib/helpers/rank":151,"../lib/helpers/sitelinks":160,"./helpers/helpers":148,"./helpers/parse_responses":150,"./helpers/simplify":152,"./queries/cirrus_search":164,"./queries/get_entities":165,"./queries/get_entities_from_sitelinks":166,"./queries/get_entity_revision":167,"./queries/get_many_entities":168,"./queries/get_reverse_claims":169,"./queries/get_revisions":170,"./queries/search_entities":171,"./queries/sparql_query":172,"./utils/build_url":173,"./utils/utils":174}],176:[function(require,module,exports){
+},{"../lib/helpers/rank":143,"../lib/helpers/sitelinks":152,"./helpers/helpers":140,"./helpers/parse_responses":142,"./helpers/simplify":144,"./queries/cirrus_search":156,"./queries/get_entities":157,"./queries/get_entities_from_sitelinks":158,"./queries/get_entity_revision":159,"./queries/get_many_entities":160,"./queries/get_reverse_claims":161,"./queries/get_revisions":162,"./queries/search_entities":163,"./queries/sparql_query":164,"./utils/build_url":165,"./utils/utils":166}],168:[function(require,module,exports){
 module.exports = require('wikibase-sdk')({
   instance: 'https://www.wikidata.org',
   sparqlEndpoint: 'https://query.wikidata.org/sparql'
 })
 
-},{"wikibase-sdk":175}],"citation-js":[function(require,module,exports){
+},{"wikibase-sdk":167}],"citation-js":[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -21065,7 +21177,7 @@ Object.defineProperty(exports, "__esModule", {
 Object.defineProperty(exports, "Cite", {
   enumerable: true,
   get: function () {
-    return _Cite.default;
+    return _index.default;
   }
 });
 Object.defineProperty(exports, "logger", {
@@ -21074,33 +21186,30 @@ Object.defineProperty(exports, "logger", {
     return _logger.default;
   }
 });
-Object.defineProperty(exports, "version", {
-  enumerable: true,
-  get: function () {
-    return _package.version;
-  }
-});
-exports.util = exports.plugins = void 0;
+exports.version = exports.util = exports.plugins = void 0;
 
-var _Cite = _interopRequireDefault(require("./Cite/"));
+var _index = _interopRequireDefault(require("./Cite/index.js"));
 
-var plugins = _interopRequireWildcard(require("./plugins/"));
+var plugins = _interopRequireWildcard(require("./plugins/index.js"));
 
 exports.plugins = plugins;
 
-var util = _interopRequireWildcard(require("./util/"));
+var util = _interopRequireWildcard(require("./util/index.js"));
 
 exports.util = util;
 
-var _logger = _interopRequireDefault(require("./logger"));
+var _logger = _interopRequireDefault(require("./logger.js"));
 
-var _package = require("../package.json");
+var _package = _interopRequireDefault(require("../package.json"));
 
-require("./plugin-common");
+require("./plugin-common/index.js");
 
 function _getRequireWildcardCache(nodeInterop) { if (typeof WeakMap !== "function") return null; var cacheBabelInterop = new WeakMap(); var cacheNodeInterop = new WeakMap(); return (_getRequireWildcardCache = function (nodeInterop) { return nodeInterop ? cacheNodeInterop : cacheBabelInterop; })(nodeInterop); }
 
 function _interopRequireWildcard(obj, nodeInterop) { if (!nodeInterop && obj && obj.__esModule) { return obj; } if (obj === null || typeof obj !== "object" && typeof obj !== "function") { return { default: obj }; } var cache = _getRequireWildcardCache(nodeInterop); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (key !== "default" && Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj.default = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-},{"../package.json":42,"./Cite/":3,"./logger":10,"./plugin-common":11,"./plugins/":23,"./util/":38}]},{},[50,74,78,84,86,94,104,110]);
+
+const version = _package.default.version;
+exports.version = version;
+},{"../package.json":42,"./Cite/index.js":3,"./logger.js":10,"./plugin-common/index.js":11,"./plugins/index.js":23,"./util/index.js":38}]},{},[50,74,78,81,83,88,96,102]);


### PR DESCRIPTION
### Description
Update the Citation.js bundle to citation-js 0.5.6 and [plugin-software-formats](https://github.com/citation-js/plugin-software-formats) 0.5.3. See https://github.com/citation-js/plugin-software-formats/issues/12. Bundle content as specified here: https://github.com/WDscholia/scholia/pull/1454

### Checklist
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered accessibility in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
