### PR TITLE
adds statistics about NMR spectra

### DIFF
--- a/scholia/app/templates/chemical-index_statistics.sparql
+++ b/scholia/app/templates/chemical-index_statistics.sparql
@@ -20,6 +20,9 @@ WITH {
 WITH {
   SELECT (COUNT(*) AS ?count) WHERE { [] wdt:P6689 []. }
 } AS %massSpectra
+WITH {
+  SELECT (COUNT(*) AS ?count) WHERE { [] wdt:P9405 []. }
+} AS %nmrSpectra
 WHERE {
   {
     INCLUDE %meltingpoints
@@ -54,6 +57,11 @@ WHERE {
   {
     INCLUDE %massSpectra
     BIND("Total number of chemicals with mass spectra" AS ?description)
+  }
+  UNION
+  {
+    INCLUDE %nmrSpectra
+    BIND("Total number of chemicals with NMR spectra" AS ?description)
   }
 }
 ORDER BY DESC(?count)


### PR DESCRIPTION
Fixes #1948

### Description
Adds the number of chemicals with an NMRShiftDB external identifier.
    
### Caveats

None.

### Testing
The query has been tested on the WDQS.

### Checklist
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered accessibility in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
