### PR TITLE
Org map - Use the headquarters location by default

### DIFF
--- a/scholia/app/templates/topic_organization-map.sparql
+++ b/scholia/app/templates/topic_organization-map.sparql
@@ -16,7 +16,11 @@ WITH {
     # Authors who have published works on the topic
     ?work wdt:P50 ?author . 
     ?author ( wdt:P108 | wdt:P463 | wdt:P1416 ) / wdt:P361* ?organization . 
-    ?organization wdt:P625 ?geo .
+    # Use the headquarters location by default but keep the coordinate location as a fallback
+    OPTIONAL{?organization p:P159/pq:P625 ?hq_geo}
+    OPTIONAL{?organization wdt:P625 ?coord_geo}
+    BIND(IF(BOUND(?hq_geo), ?hq_geo, ?coord_geo) AS ?geo) .
+    FILTER(BOUND(?geo)) .
   }
   GROUP BY ?organization ?geo
   ORDER BY DESC (?count)


### PR DESCRIPTION
It seems as though the preferred method of storing an organisation's location is by adding a [P625](http://www.wikidata.org/entity/P625) (coordinate location) qualifier on a [P159](http://www.wikidata.org/entity/P159) (headquarters location) statement.

This commit changes the org map query to use the headquarters location by default but still keeps the coordinate location as a fallback.

Relevant discussions:
* https://www.wikidata.org/wiki/Wikidata:Project_chat/Archive/2021/03#coordinate_location_(P625)_to_headquarters_location_(P159)_switch
* https://www.wikidata.org/wiki/Wikidata:Project_chat/Archive/2022/04#DeltaBot's_coordinate_location_(P625)_to_headquarters_location_(P159)_move