### PR TITLE
adding case variants to award-curation_missing-author-items.sparql

### DIFF
--- a/scholia/app/templates/award-curation_missing-author-items.sparql
+++ b/scholia/app/templates/award-curation_missing-author-items.sparql
@@ -1,27 +1,53 @@
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
 SELECT
-  (COUNT(?work) AS ?count) 
-  ?author_name
-  (CONCAT(
-      'https://author-disambiguator.toolforge.org/names_oauth.php?doit=Look+for+author&name=',
-      ENCODE_FOR_URI(?author_name)) AS ?author_resolver_url)
-WHERE {
-  {
-    SELECT DISTINCT ?author_name {
-      ?recipient p:P166 ?award_statement . 
-      ?award_statement ps:P166 target: .
-      
-      ?recipient skos:altLabel | rdfs:label ?author_name_ .
-      
-      # The SELECT-DISTINCT-BIND trick here is due to Stanislav Kralin
-      # https://stackoverflow.com/questions/53933564
-      BIND (STR(?author_name_) AS ?author_name)
-    }
-    LIMIT 2000
+(COUNT(?work) AS ?count) 
+?string
+(CONCAT(
+  'https://author-disambiguator.toolforge.org/names_oauth.php?doit=Look+for+author&name=',
+  ENCODE_FOR_URI(?string)) AS ?author_resolver_url)
+WITH {
+  SELECT DISTINCT ?author_name {
+    ?recipient p:P166 ?award_statement . 
+    ?award_statement ps:P166 target: .
+
+    ?recipient skos:altLabel | rdfs:label ?author_name_ .
+
+    # The SELECT-DISTINCT-BIND trick here is due to Stanislav Kralin
+    # https://stackoverflow.com/questions/53933564
+    BIND (STR(?author_name_) AS ?author_name)
   }
-  OPTIONAL { ?work wdt:P2093 ?author_name . }
+  LIMIT 2000
+} AS %RAWstrings
+WITH
+# This part is due to Dipsacus fullonum, as per https://w.wiki/5Brk
+{
+  # Calculate capitalization variants of these raw strings
+  SELECT 
+    DISTINCT 
+      ?string
+  WHERE
+  {
+    {
+      INCLUDE %RAWstrings
+              BIND(STR(?author_name) AS ?string) # the raw strings
+    }
+    UNION
+    {
+      INCLUDE %RAWstrings
+              BIND(UCASE(STR(?author_name)) AS ?string) # uppercased versions of the raw strings
+    }
+    UNION
+    {
+      INCLUDE %RAWstrings
+              BIND(LCASE(STR(?author_name)) AS ?string) # lowercased versions of the raw strings
+    }
+  }
+} AS %NORMALIZEDstrings
+WHERE {
+  # Find works that have "author name string" values equal to these normalized strings
+  INCLUDE %NORMALIZEDstrings
+          ?work wdt:P2093 ?string. 
 }
-GROUP BY ?author_name 
-HAVING (?count > 0)
-ORDER BY DESC(?count)
+GROUP BY ?string
+ORDER BY DESC (?count)

--- a/scholia/app/templates/award-curation_missing-author-items.sparql
+++ b/scholia/app/templates/award-curation_missing-author-items.sparql
@@ -30,24 +30,24 @@ WITH
   {
     {
       INCLUDE %RAWstrings
-              BIND(STR(?author_name) AS ?string) # the raw strings
+      BIND(STR(?author_name) AS ?string) # the raw strings
     }
     UNION
     {
       INCLUDE %RAWstrings
-              BIND(UCASE(STR(?author_name)) AS ?string) # uppercased versions of the raw strings
+      BIND(UCASE(STR(?author_name)) AS ?string) # uppercased versions of the raw strings
     }
     UNION
     {
       INCLUDE %RAWstrings
-              BIND(LCASE(STR(?author_name)) AS ?string) # lowercased versions of the raw strings
+      BIND(LCASE(STR(?author_name)) AS ?string) # lowercased versions of the raw strings
     }
   }
 } AS %NORMALIZEDstrings
 WHERE {
   # Find works that have "author name string" values equal to these normalized strings
   INCLUDE %NORMALIZEDstrings
-          ?work wdt:P2093 ?string. 
+  ?work wdt:P2093 ?string. 
 }
 GROUP BY ?string
 ORDER BY DESC (?count)


### PR DESCRIPTION
Fixes #1977 

### Description

added case variants.
Example: https://scholia.toolforge.org/award/Q38104/curation#missing-author-items

#### Before
![Screenshot from 2022-05-21 23-09-48](https://user-images.githubusercontent.com/465923/169669318-47642d8b-33b6-4676-8ada-8d428849714a.png)
![Screenshot from 2022-05-21 23-10-32](https://user-images.githubusercontent.com/465923/169669316-4296982c-32f3-4f4b-a310-116533417c5b.png)


#### After

Note that the results differ in part due to the ```LIMIT```, in part due to this change.

![Screenshot from 2022-05-21 23-10-51](https://user-images.githubusercontent.com/465923/169669315-8cf03b71-2678-4860-b442-7bd7f3c981d0.png)
![Screenshot from 2022-05-21 23-11-29](https://user-images.githubusercontent.com/465923/169669313-5a1422b9-d07c-4df1-b058-409d8fec7595.png)


### Checklist
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered accessibility in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
