### PR TITLE
Handle Reactome pathways

### DIFF
--- a/scholia/app/templates/pathway_participants.sparql
+++ b/scholia/app/templates/pathway_participants.sparql
@@ -4,7 +4,8 @@ SELECT ?part ?partLabel ?partDescription ?type
 WITH {
   SELECT ?part (GROUP_CONCAT(DISTINCT ?type_label; separator=", ") AS ?type)
   WHERE {
-    target: wdt:P31 wd:Q4915012 ;
+    VALUES ?process { wd:Q4915012 wd:Q2996394 }
+    target: wdt:P31 ?process ;
              wdt:P527 ?part .
     OPTIONAL { 
       ?part wdt:P31 ?type_ .


### PR DESCRIPTION
Fixes #1979

### Description
Reactome uses a different type (P31) than WikiPathways does (despite the same team behind it).
    
### Caveats

- biological processes are wider then pathways

Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

### Testing
Check http://www.wikidata.org/entity/Q50294491 before and after the patch. The second will show parts. https://w.wiki/5C5R

### Checklist

This patch only updates one of the SPARQL queries and no code changes are made.

* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] My changes generate no new warnings
* [ ] I have not used code from external sources without attribution
* [ ] I have considered accessibility in my implementation 
* [ ] There are no remaining debug statements (print, console.log, ...)
