### PR TITLE
Add placeholder text to search element

### DIFF
--- a/scholia/app/templates/base.html
+++ b/scholia/app/templates/base.html
@@ -880,7 +880,7 @@ askQuery("{{ panel }}", `# tool: scholia
     </ul>
     {% block nav_search %}
     <div class='nav nav-search'>
-        <input class="form-control" type="text" id="searchterm"/>
+        <input class="form-control" type="text" id="searchterm" placeholder="Search..."/>
     </div>
     {% endblock %}
   </div>


### PR DESCRIPTION
Apologies for the shortest PR ever haha

### Description
> Please include a summary of the change, relevant motivation and context. If possible and applicable, include before and after screenshots and a URL where the changes can be seen.
    
Basically we don't have placeholder text on the main search element. Most people probably intuit it's function or try interacting with it and figure it out, but we should be explicit.

before:
![image](https://user-images.githubusercontent.com/6676843/170592408-26277542-41ae-41c7-82f8-317f4450964e.png)

after: 
![image](https://user-images.githubusercontent.com/6676843/170592377-16656a31-bda1-43ab-84d4-2948c250e5b9.png)

I searched the rest of the repository and this is the only input with no placeholder text

### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* Test A
* Test B

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
