### PR TITLE
Add redirect for doi-prefix as specified

### DIFF
--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -736,7 +736,7 @@ def redirect_doi_prefix(doi):
     if len(qs) > 0:
         q = qs[0]
         return redirect(url_for('app.show_publisher', q=q), code=302)
-    return render_template('404-doi.html', doi=doi)
+    return render_template('404.html', doi=doi)
 
 
 @main.route('/event/' + q_pattern)

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -14,7 +14,7 @@ from ..rss import (wb_get_author_latest_works, wb_get_venue_latest_works,
 from ..arxiv import metadata_to_quickstatements, string_to_arxiv
 from ..arxiv import get_metadata as get_arxiv_metadata
 from ..query import (arxiv_to_qs, cas_to_qs, atomic_symbol_to_qs, doi_to_qs,
-                     github_to_qs, biorxiv_to_qs, chemrxiv_to_qs,
+                     doi_prefix_to_qs, github_to_qs, biorxiv_to_qs, chemrxiv_to_qs,
                      identifier_to_qs, inchikey_to_qs, issn_to_qs, orcid_to_qs,
                      viaf_to_qs, q_to_class, q_to_dois, random_author,
                      twitter_to_qs, cordis_to_qs, mesh_to_qs, pubmed_to_qs,
@@ -718,6 +718,24 @@ def redirect_doi(doi):
     if len(qs) > 0:
         q = qs[0]
         return redirect(url_for('app.show_work', q=q), code=302)
+    return render_template('404-doi.html', doi=doi)
+
+
+@main.route('/doi-prefix/<path:doi>')
+def redirect_doi_prefix(doi):
+    """Detect and redirect for DOI.
+
+    Parameters
+    ----------
+    doi : str
+        DOI identifier.
+
+    """
+    normalize_doi = remove_special_characters_url(doi)
+    qs = doi_prefix_to_qs(normalize_doi)
+    if len(qs) > 0:
+        q = qs[0]
+        return redirect(url_for('app.show_publisher', q=q), code=302)
     return render_template('404-doi.html', doi=doi)
 
 

--- a/scholia/query.py
+++ b/scholia/query.py
@@ -383,6 +383,44 @@ def doi_to_qs(doi):
             for item in data['results']['bindings']]
 
 
+def doi_prefix_to_qs(doi):
+    """Convert DOI prefix to Wikidata ID.
+
+    Wikidata Query Service is used to resolve the DOI.
+
+    The DOI string is converted to uppercase before any
+    query is made. Uppercase DOIs are default in Wikidata.
+
+    Parameters
+    ----------
+    doi : str
+        DOI prefix identifier
+
+    Returns
+    -------
+    qs : list of str
+        Strings of Wikidata ID.
+
+    Examples
+    --------
+    >>> doi_prefix_to_qs('10.1186') == ['Q463494']
+    True
+
+    >>> doi_prefix_to_qs('10.1016') == ['Q746413']
+    True
+    """
+    query = 'select ?work where {{ ?work wdt:P1662 "{doi}" }}'.format(
+        doi=escape_string(doi.upper()))
+
+    url = 'https://query.wikidata.org/sparql'
+    params = {'query': query, 'format': 'json'}
+    response = requests.get(url, params=params, headers=HEADERS)
+    data = response.json()
+
+    return [item['work']['value'][31:]
+            for item in data['results']['bindings']]
+
+
 def iso639_to_q(language):
     """Convert ISO639 to Q item.
 


### PR DESCRIPTION
Fixes #1955

### Description
> Please include a summary of the change, relevant motivation and context. If possible and applicable, include before and after screenshots and a URL where the changes can be seen.
    
http://127.0.0.1:8100/doi-prefix/10.1371 redirects to http://127.0.0.1:8100/publisher/Q233358

### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* Tested for the DOI prefix given
* Tested for invalid DOI prefix, redirects to the usual 404 page

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [ ] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
