### PR TITLE
Change limit to 3 headings to create table of contents

### DIFF
--- a/scholia/app/templates/base.html
+++ b/scholia/app/templates/base.html
@@ -687,7 +687,7 @@ askQuery("{{ panel }}", `# tool: scholia
 
      // Add table of content
   var headings = document.querySelectorAll("h2,h3");
-  if (headings.length >= 4) {
+  if (headings.length >= 3) {
     var tocParent = document.createElement("div");
     tocParent.className = "table-of-contents"
 


### PR DESCRIPTION
Fixes #1908

### Description
> Please include a summary of the change, relevant motivation and context. If possible and applicable, include before and after screenshots and a URL where the changes can be seen.

The issue was that the property page only has three headings and so #1519 a table of contents would not be added. This PR reduces this to 3 headings

![image](https://user-images.githubusercontent.com/6676843/172073246-f98d9c3a-21ac-4150-b3f2-5f5052dbf5b6.png)

    
### Caveats


> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* Checked P378

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
