### PR TITLE
Bug/distinct authors aspect panels 1998

### DIFF
--- a/scholia/app/templates/authors_citations-per-publication-year.sparql
+++ b/scholia/app/templates/authors_citations-per-publication-year.sparql
@@ -7,14 +7,21 @@ SELECT ?year ?number_of_citations ?author_label WHERE {
         SELECT
 	  ?author
 	  ?year
-	  (COUNT(DISTINCT ?citing_work) AS ?number_of_citations)
+
+          # DISTINCT to avoid count citations whether ther are multiple
+	  # publication dates
+	  (COUNT(DISTINCT ?citation) AS ?number_of_citations)
 	WHERE {
           hint:Query hint:optimizer "None".
           VALUES ?author {  {% for q in qs %} wd:{{ q }} {% endfor %}  }
-          ?work wdt:P50 ?author .
-          ?work wdt:P577 ?publication_date .
+          ?work wdt:P50 ?author ;
+                wdt:P577 ?publication_date .
           ?citing_work wdt:P2860 ?work
           BIND(STR(YEAR(?publication_date)) AS ?year)
+
+	  # We want to count the number of citations rather than the number of
+	  # citing works or the number of cited works
+          BIND(CONCAT(STR(?work), STR(?citing_work)) AS ?citation)
         }
         GROUP BY ?author ?year 
       } 

--- a/scholia/app/templates/authors_citations-per-publication-year.sparql
+++ b/scholia/app/templates/authors_citations-per-publication-year.sparql
@@ -4,7 +4,11 @@ SELECT ?year ?number_of_citations ?author_label WHERE {
     SELECT ?year ?number_of_citations ?author ?author_label_
     WHERE {
       {
-        SELECT ?author ?year (COUNT(?citing_work) AS ?number_of_citations) WHERE {
+        SELECT
+	  ?author
+	  ?year
+	  (COUNT(DISTINCT ?citing_work) AS ?number_of_citations)
+	WHERE {
           hint:Query hint:optimizer "None".
           VALUES ?author {  {% for q in qs %} wd:{{ q }} {% endfor %}  }
           ?work wdt:P50 ?author .

--- a/scholia/app/templates/authors_works-per-publication-year.sparql
+++ b/scholia/app/templates/authors_works-per-publication-year.sparql
@@ -4,7 +4,7 @@ SELECT ?year ?number_of_works ?author_label WHERE {
     SELECT ?year ?number_of_works ?author ?author_label_
     WHERE {
       {
-        SELECT ?author ?year (COUNT(?work) AS ?number_of_works) WHERE {
+        SELECT ?author ?year (COUNT(DISTINCT ?work) AS ?number_of_works) WHERE {
           hint:Query hint:optimizer "None".
           VALUES ?author {   {% for q in qs %} wd:{{ q }} {% endfor %}   }
           ?work wdt:P50 ?author .

--- a/scholia/app/templates/use-curation.html
+++ b/scholia/app/templates/use-curation.html
@@ -6,6 +6,10 @@
 
 {{ sparql_to_table('missing-author-items') }}
 
+{{ sparql_to_table('works-with-few-topics',
+   options={ "linkPrefixes":{ "work": '../../work/' }}
+) }}
+
 
 {% endblock %}
 
@@ -22,6 +26,17 @@ Follow the link to use the Author disambiguator tool to try to resolve
 the authors.
 
 <table class="table table-hover" id="missing-author-items-table"></table>
+
+
+<h2 id="works-with-few-topics">Works with few topics</h2>
+
+Works that use the resource, but are tagged with few (or no) topics,
+may indicate that the work is missing annotation for topics.
+
+<table class="table table-hover" id="works-with-few-topics-table"></table>
+
+
+
 
 <hr>
 

--- a/scholia/app/templates/use-curation_works-with-few-topics.sparql
+++ b/scholia/app/templates/use-curation_works-with-few-topics.sparql
@@ -1,0 +1,33 @@
+# tool: scholia
+PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
+
+SELECT
+  ?number_of_topics
+  ?citing_works
+  ?work ?workLabel
+WITH {
+  # Count citations
+  SELECT
+    (COUNT(DISTINCT ?citing_work) AS ?citing_works)
+    ?work
+    (SAMPLE(?citing_work) AS ?example_citing_work)
+    (COUNT(DISTINCT ?topic) AS ?number_of_topics)
+  WHERE {
+    # subclasses included to get version of resources
+    ?work wdt:P4510 / wdt:P279* target: .
+    
+    OPTIONAL { ?work wdt:P921 ?topic . }
+    OPTIONAL { ?citing_work wdt:P2860 ?work. }
+  }
+  GROUP BY ?work
+  # HAVING (?topics < 1)
+  ORDER BY DESC(?count)
+  LIMIT 200
+} AS %result
+WHERE {
+  # Label results
+  INCLUDE %result
+  SERVICE wikibase:label {
+    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
+}
+ORDER BY ?number_of_topics DESC(?citing_works)


### PR DESCRIPTION
Fixes #1997 and #1998

### Description
Fix the counting of works and citations in the panels on the authors aspect. 
It could count wrong before.
    
### Caveats
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
I only checked with
http://127.0.0.1:8100/authors/Q20980928,Q24290415,Q24390693,Q26720269#works-per-publication-year

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
