### PR TITLE
Co-uses for use curation #1899

### DIFF
--- a/scholia/app/templates/use-curation.html
+++ b/scholia/app/templates/use-curation.html
@@ -6,9 +6,14 @@
 
 {{ sparql_to_table('missing-author-items') }}
 
+{{ sparql_to_table('missing-co-uses',
+   options={ "linkPrefixes":{ "work": '../../work/' }}
+) }}
+
 {{ sparql_to_table('works-with-few-topics',
    options={ "linkPrefixes":{ "work": '../../work/' }}
 ) }}
+
 
 
 {% endblock %}
@@ -26,6 +31,11 @@ Follow the link to use the Author disambiguator tool to try to resolve
 the authors.
 
 <table class="table table-hover" id="missing-author-items-table"></table>
+
+
+<h2 id="missing-co-uses">Missing-co-uses</h2>
+
+<table class="table table-hover" id="missing-co-uses-table"></table>
 
 
 <h2 id="works-with-few-topics">Works with few topics</h2>

--- a/scholia/app/templates/use-curation_missing-co-uses.sparql
+++ b/scholia/app/templates/use-curation_missing-co-uses.sparql
@@ -1,0 +1,31 @@
+# tool: scholia
+PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
+
+SELECT
+  ?uses
+  ?citing_works
+  ?work ?workLabel
+WITH {
+  # Count citations
+  SELECT
+    (COUNT(DISTINCT ?citing_work) AS ?citing_works)
+    ?work
+    (SAMPLE(?citing_work) AS ?example_citing_work)
+    (COUNT(DISTINCT ?use) AS ?uses)
+  WHERE {
+    ?work wdt:P4510 target: .
+    OPTIONAL { ?work wdt:P4510 ?use . FILTER (?use != target: )}
+    OPTIONAL { ?citing_work wdt:P2860 ?work. }
+  }
+  GROUP BY ?work
+  HAVING (?uses < 1)
+  ORDER BY DESC(?count)
+  LIMIT 100
+} AS %result
+WHERE {
+  # Label results
+  INCLUDE %result
+  SERVICE wikibase:label {
+    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
+}
+ORDER BY ?uses DESC(?citing_works)

--- a/scholia/app/templates/use-curation_missing-co-uses.sparql
+++ b/scholia/app/templates/use-curation_missing-co-uses.sparql
@@ -2,7 +2,7 @@
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
 SELECT
-  ?uses
+  ?couses
   ?citing_works
   ?work ?workLabel
 WITH {
@@ -11,14 +11,17 @@ WITH {
     (COUNT(DISTINCT ?citing_work) AS ?citing_works)
     ?work
     (SAMPLE(?citing_work) AS ?example_citing_work)
-    (COUNT(DISTINCT ?use) AS ?uses)
+    (COUNT(DISTINCT ?use) AS ?couses)
   WHERE {
     ?work wdt:P4510 target: .
     OPTIONAL { ?work wdt:P4510 ?use . FILTER (?use != target: )}
     OPTIONAL { ?citing_work wdt:P2860 ?work. }
   }
   GROUP BY ?work
-  HAVING (?uses < 1)
+
+  # Disabled to also show works with few co-uses
+  # HAVING (?couses < 1)
+
   ORDER BY DESC(?count)
   LIMIT 100
 } AS %result
@@ -28,4 +31,4 @@ WHERE {
   SERVICE wikibase:label {
     bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
 }
-ORDER BY ?uses DESC(?citing_works)
+ORDER BY ?couses DESC(?citing_works)


### PR DESCRIPTION
Fixes #1899 

### Description
Shows missing or few co-uses works on use-curation page
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
* examined, e.g., http://127.0.0.1:8100/use/Q1635410/curation

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
