### PR TITLE
Bug/scientific event as event #1715

### DIFF
--- a/scholia/app/templates/event_future-events.sparql
+++ b/scholia/app/templates/event_future-events.sparql
@@ -2,11 +2,9 @@ SELECT ?time ?short_name ?event ?eventLabel ?location ?locationLabel
 WITH {
   SELECT DISTINCT ?event WHERE {
     # This union seems to be faster than a VALUES-based query
-    { ?event wdt:P31 / wdt:P279* wd:Q2020153 . }
+    { ?event wdt:P31 / wdt:P279* wd:Q52260246 . }
     UNION 
     { ?event wdt:P31 / wdt:P279* wd:Q46855 . }
-    UNION 
-    { ?event wdt:P31 / wdt:P279* wd:Q40444998 . }
   }
 } AS %events
 WITH {

--- a/scholia/app/templates/event_past-events.sparql
+++ b/scholia/app/templates/event_past-events.sparql
@@ -2,11 +2,9 @@ SELECT ?time ?short_name ?event ?eventLabel ?location ?locationLabel
 WITH {
   SELECT DISTINCT ?event WHERE {
     # This union seems to be faster than a VALUES-based query
-    { ?event wdt:P31 / wdt:P279* wd:Q2020153 . }
+    { ?event wdt:P31 / wdt:P279* wd:Q52260246 . }
     UNION 
     { ?event wdt:P31 / wdt:P279* wd:Q46855 . }
-    UNION 
-    { ?event wdt:P31 / wdt:P279* wd:Q40444998 . }
   }
 } AS %events
 WITH {


### PR DESCRIPTION
Fixes #1715

### Description
Fix handling of instances of scientific event so they show up in the event tables.
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
* Checked that https://www.wikidata.org/wiki/Q109804073 showed up in past events.

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
