### PR TITLE
Link venue in venue column

### DIFF
--- a/scholia/app/static/scholia.js
+++ b/scholia/app/static/scholia.js
@@ -103,43 +103,54 @@ function convertDataTableData(data, columns, linkPrefixes = {}, linkSuffixes = {
 
 	    } else if (
 			key + 'Label' in data[i] &&
+            key + 'Url' in data[i]
+	    ) {
+            convertedRow[key] = '<a href="' +
+		    data[i][key + 'Url'] +
+		    '">' + data[i][key + 'Label'] + '</a>';
+
+	    } else if (
+			key + 'Label' in data[i] &&
 			/^http/.test(data[i][key]) &&
 			data[i][key].length > 30
 	    ) {
-		convertedRow[key] = '<a href="' +
+		    convertedRow[key] = '<a href="' +
 		    (linkPrefixes[key] || "../") + 
 		    data[i][key].slice(31) +
             (linkSuffixes[key] || "") +
 		    '">' + data[i][key + 'Label'] + '</a>';
-	    } else if (key.slice(-5) == 'Label') {
+
+        } else if (key.slice(-5) == 'Label') {
 		// pass
 		
 	    } else if (key + 'Url' in data[i]) {
-		convertedRow[key] = '<a href="' +
+		    convertedRow[key] = '<a href="' +
 		    data[i][key + 'Url'] +
 		    '">' + data[i][key] + '</a>';
+
 	    } else if (key.slice(-3) == 'Url') {
 		// pass
 
 	    } else if (key.slice(-3) == 'url') {
 		// Convert URL to a link
-		convertedRow[key] = "<a href='" +
+		    convertedRow[key] = "<a href='" +
 		    data[i][key] + "'>" + 
 		    $("<div>").text(data[i][key]).html() + '</a>';
 
 	    } else if (key == 'orcid') {
 		// Add link to ORCID website
-		convertedRow[key] = '<a href="https://orcid.org/' +
+		    convertedRow[key] = '<a href="https://orcid.org/' +
 		    data[i][key] + '">' + 
 		    data[i][key] + '</a>';
 
 	    } else if (key == 'doi') {
 		// Add link to Crossref
-		convertedRow[key] = '<a href="https://doi.org/' +
+		    convertedRow[key] = '<a href="https://doi.org/' +
 		    encodeURIComponent(data[i][key]) + '">' +
 		    $("<div>").text(data[i][key]).html() + '</a>';
+
 	    } else {
-		convertedRow[key] = data[i][key];
+		    convertedRow[key] = data[i][key];
 	    }
 	}
 	convertedData.push(convertedRow);

--- a/scholia/app/templates/author_venue-statistics.sparql
+++ b/scholia/app/templates/author_venue-statistics.sparql
@@ -3,7 +3,7 @@ PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 # Venue statistics for a specific author
 SELECT
   ?count (SAMPLE(?short_name_) AS ?short_name)
-  ?venue ?venueLabel
+  ?venue ?venueLabel (CONCAT("/venue/", SUBSTR(STR(?venue), 32)) AS ?venueUrl)
   ?topics ?topicsUrl
 WITH {
   SELECT


### PR DESCRIPTION
Fixes #1481

### Description
> Please include a summary of the change, relevant motivation and context. If possible and applicable, include before and after screenshots and a URL where the changes can be seen.

Generally adds the ability for a column to have a label and a URL. Previously they could have only have one.

Specifically link the venue column to the venue aspect

![image](https://user-images.githubusercontent.com/6676843/173627430-befebabb-bf42-4b4f-9bdb-5b11348b3f82.png)


### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* Checked on the example page. Should only affect queries where there is a label and a url

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
