### PR TITLE
Use <a> tag instead of img.href

### DIFF
--- a/scholia/app/static/css/scholia.css
+++ b/scholia/app/static/css/scholia.css
@@ -172,7 +172,6 @@ a.dropdown-item.active {
 }
 
 #item-image {
-    max-width: 50%;
     object-fit: contain;
 }
 

--- a/scholia/app/templates/base.html
+++ b/scholia/app/templates/base.html
@@ -147,11 +147,17 @@ askQuery("{{ panel }}", `# tool: scholia
 	    imageURL += encodeURIComponent(imageName);
 	    var itemImage = document.getElementById("item-image");
 	    if (itemImage) {
-		itemImage.src = imageURL;
-		itemImage.title = imageName.slice(0, imageName.lastIndexOf('.'));
-		itemImage.setAttribute('alt', imageName);
-		itemImage.href = "https://commons.wikimedia.org/wiki/File:" + encodeURIComponent(imageName);    
-	    }
+      itemImage.src = imageURL;
+      itemImage.title = imageName.slice(0, imageName.lastIndexOf('.'));
+      itemImage.setAttribute('alt', imageName);
+
+      var link = document.createElement('a');
+      link.href = "https://commons.wikimedia.org/wiki/File:" + encodeURIComponent(imageName);
+      link.style = "max-width: 50%"
+      var parent = itemImage.parentNode;
+      parent.replaceChild(link, itemImage);
+      link.appendChild(itemImage);
+    }
 	}
 
 	function socialMediaLink(detailsList, user, site, logo = '') {


### PR DESCRIPTION
Better fix for #1778

### Description
> Please include a summary of the change, relevant motivation and context. If possible and applicable, include before and after screenshots and a URL where the changes can be seen.
    
While current implementation works, it doesn't indicate that the image is click-able with the cursor or show the destination in the browser

### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* Checked Q4693015 (square image), Q2469 (landscape) and Q12418 (portrait)

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
