### PR TITLE
Serve thumbnail instead of full image

### DIFF
--- a/scholia/app/templates/base.html
+++ b/scholia/app/templates/base.html
@@ -142,9 +142,9 @@ askQuery("{{ panel }}", `# tool: scholia
 	    // spaces must be replaced by underscores in the file name
 	    imageName = imageName.replaceAll(" ", "_")
 	    var imageNameMd5 = md5(imageName);
-	    var imageURL = "https://upload.wikimedia.org/wikipedia/commons/" 
+	    var imageURL = "https://upload.wikimedia.org/wikipedia/commons/thumb/" 
 	    imageURL += imageNameMd5[0] + "/" + imageNameMd5.slice(0,2) + "/"
-	    imageURL += encodeURIComponent(imageName);
+	    imageURL += encodeURIComponent(imageName) + "/500px-" + encodeURIComponent(imageName);
 	    var itemImage = document.getElementById("item-image");
 	    if (itemImage) {
 		itemImage.src = imageURL;


### PR DESCRIPTION
Apologies for so many PRs but want to keep them atomic

### Description
> Please include a summary of the change, relevant motivation and context. If possible and applicable, include before and after screenshots and a URL where the changes can be seen.
    
Right now if you go on the scholia page for the mona lisa, the picture takes awhile to display as the file served by commons is 90MB. Instead with this PR, commons serves a thumbnail which is 500px across and is ~100kb 

### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* Tested with the Mona Lisa page
* Tested with Q970550 which has an image smaller than the thumbnail size (commons scales it up to the thumbnail size)

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
