### PR TITLE
Add gallery for works with a commons category

### DIFF
--- a/scholia/app/templates/ask_work_gallery.sparql
+++ b/scholia/app/templates/ask_work_gallery.sparql
@@ -1,0 +1,3 @@
+ASK {
+  wd:{{q}} wdt:P373 ?gallery  .
+}

--- a/scholia/app/templates/work.html
+++ b/scholia/app/templates/work.html
@@ -37,6 +37,12 @@
 
 {% endcall %}
 
+{% call ask_query_callback('gallery') %}
+
+{{ sparql_to_iframe('associated-images') }}
+
+{% endcall %}
+
 {% endblock %}
 
 
@@ -68,6 +74,14 @@ Topics based on a weighting between main subject of work, cited and citing works
 
 <div class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" id="timeline-iframe"></iframe>
+</div>
+
+<div id="gallery" class="d-none">
+<h2 id="associated-images">Associated images</h2>
+
+<div class="embed-responsive embed-responsive-4by3">
+  <iframe class="embed-responsive-item" id="associated-images-iframe"></iframe>
+</div>
 </div>
 
 <h2>Related works</h2>

--- a/scholia/app/templates/work_associated-images.sparql
+++ b/scholia/app/templates/work_associated-images.sparql
@@ -1,0 +1,13 @@
+#defaultView:ImageGrid
+PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
+
+SELECT DISTINCT ?image WHERE {
+  {
+    # Images from whatever property value is linked.
+    
+    # Excluded "different from" property and take all other properties
+    target: !wdt:P1889 ?item .
+
+    ?item wdt:P18 ?image . 
+  }
+}   

--- a/tests/test_ask_query.py
+++ b/tests/test_ask_query.py
@@ -27,6 +27,16 @@ def test_work_cito():
     assert ask_query(file_name, false_case) == False
 
 
+def test_work_gallery():
+    file_name = "ask_work_gallery.sparql"
+
+    true_case = "Q19966966"  # One hundred and one new species of Trigonopterus weevils from New Guinea
+    false_case = "Q22241243"  # Zika virus outside Africa
+
+    assert ask_query(file_name, true_case) == True
+    assert ask_query(file_name, false_case) == False
+
+
 def ask_query(file_name, q_number):
     file_path = "scholia/app/templates/" + file_name
     with open(file_path) as read:


### PR DESCRIPTION
Draft as I'm unsure how to access Commons category/gallery images

On the way to closing the issue #187

### Description
> Please include a summary of the change, relevant motivation and context. If possible and applicable, include before and after screenshots and a URL where the changes can be seen.

This PR `ASK`s whether a work has an associated [Commons category (P373)](https://www.wikidata.org/wiki/Property:P373) and then shows a gallery of associated images in the same way as the author image gallery
    
![image](https://user-images.githubusercontent.com/6676843/174501807-611cce2e-068e-4bde-b699-f9f65f2e3b4f.png)

However displaying images from the category would be better

![image](https://user-images.githubusercontent.com/6676843/174501823-c83b6266-7006-4fda-8f02-dd7662792e52.png)

Property [Commons gallery](https://www.wikidata.org/wiki/Property:P935) (P935) may also be useful

Haven't yet figured out how to access the images from either, **help wanted**

### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* I created a Python test
* I manually checked that the gallery was hidden for an item with no commons category (Q22241243) and visible when there was one (Q19966966)

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [ ] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
