### PR TITLE
Move cite button to top row

### DIFF
--- a/scholia/app/templates/base.html
+++ b/scholia/app/templates/base.html
@@ -900,7 +900,11 @@ askQuery("{{ panel }}", `# tool: scholia
 <div class="container d-flex justify-content-between">
     <div class="dropdown" id="aspect-chooser">
     </div>
-    <a id='curation-link' role="button" class="btn btn-outline-secondary d-none">Improve data</a>
+    <div>
+      {% block page_actions %}
+      <a id='curation-link' role="button" class="btn btn-outline-secondary d-none">Improve data</a>
+      {% endblock %}
+    </div>
 </div>
 <div class="container">
     {% block page_content %}{% endblock %}

--- a/scholia/app/templates/software.html
+++ b/scholia/app/templates/software.html
@@ -15,15 +15,16 @@
 
 {% endblock %}
 
+{% block page_actions %}
+<a href="/software/{{ q }}/export" role="button" class="btn btn-outline-secondary">Cite</a>
+{{ super() }}
+{% endblock %}
+
 {% block page_content %}
 
 <h1 id="h1">Software</h1>
 
 <div id="intro"></div>
-
-<div id="actions" class="mt-3">
-    <a href="/software/{{ q }}/export" role="button" class="btn btn-outline-secondary">Cite</a>
-</div>
 
 <table class="table table-hover" id="data-table"></table>
 

--- a/scholia/app/templates/work.html
+++ b/scholia/app/templates/work.html
@@ -45,6 +45,10 @@
 
 {% endblock %}
 
+{% block page_actions %}
+<a href="/work/{{ q }}/export" role="button" class="btn btn-outline-secondary">Cite</a>
+{{ super() }}
+{% endblock %}
 
 {% block page_content %}
 <h1 id="h1">Work</h1>
@@ -52,10 +56,6 @@
 <div id="intro"></div>
 
 <div id="details"></div>
-
-<div id="actions" class="mt-3">
-    <a href="/work/{{ q }}/export" role="button" class="btn btn-outline-secondary">Cite</a>
-</div>
 
 <table class="table table-hover" id="data-table"></table>
 


### PR DESCRIPTION
### Description
Moves the citation button from below the title/description to next to the "Improve data" button, using a new block `page_actions`.
    
### Caveats
Using the `page_actions` block currently requires calling `{{ super() }}`, otherwise the "Improve data" button disappears.

### Testing
  - Go to a work page and click the "Cite" button
  - Repeat for a software page

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
