### PR TITLE
filtering out the qualifier values in scholia/app/templates/work_statements.sparql

### DIFF
--- a/scholia/app/templates/work_statements.sparql
+++ b/scholia/app/templates/work_statements.sparql
@@ -17,6 +17,7 @@ WITH {
     ?item ?p ?statement .
     ?property wikibase:claim ?p . 
     ?statement ?a ?value .
+    FILTER (!CONTAINS(LCASE(STR(?a)), "http://www.wikidata.org/prop/qualifier/"))
     ?item ?b ?value . 
     OPTIONAL {?statement ?psv_statement_predicate ?psv_statement .
     ?statement_predicate_property wikibase:statementValue ?psv_statement_predicate.

--- a/scholia/app/templates/work_statements.sparql
+++ b/scholia/app/templates/work_statements.sparql
@@ -17,7 +17,7 @@ WITH {
     ?item ?p ?statement .
     ?property wikibase:claim ?p . 
     ?statement ?a ?value .
-    FILTER (!CONTAINS(LCASE(STR(?a)), "http://www.wikidata.org/prop/qualifier/"))
+    FILTER (!STRSTARTS(LCASE(STR(?a)), "http://www.wikidata.org/prop/qualifier/"))
     ?item ?b ?value . 
     OPTIONAL {?statement ?psv_statement_predicate ?psv_statement .
     ?statement_predicate_property wikibase:statementValue ?psv_statement_predicate.


### PR DESCRIPTION
Fixes #2046 

### Description

Added a line to filter out the qualifier values.

Screenshot of ```/work/Q112339024```:
![Screenshot from 2022-07-06 12-46-34](https://user-images.githubusercontent.com/465923/177533759-07435f95-e39a-4157-85d2-a27928d5aa7e.png)
