### PR TITLE
added missing question mark

### DIFF
--- a/scholia/app/templates/organization-topic_authors.sparql
+++ b/scholia/app/templates/organization-topic_authors.sparql
@@ -3,7 +3,7 @@ PREFIX target2: <http://www.wikidata.org/entity/{{ q2 }}>
 
 SELECT
   ?works
-  ?author ?authorLabel ?authorDescription (CONCAT("/author/", SUBSTR(STR(?author), 32)) AS authorUrl)
+  ?author ?authorLabel ?authorDescription (CONCAT("/author/", SUBSTR(STR(?author), 32)) AS ?authorUrl)
   ?example_work ?example_workLabel (CONCAT("/work/", SUBSTR(STR(?example_work), 32)) AS ?example_workUrl)
 WITH {
   SELECT


### PR DESCRIPTION
Fixes #2048 

### Description

I added the missing question mark, and the example page https://scholia.toolforge.org/organization/Q1269766/topic/Q35 now renders properly:

![Screenshot 2022-07-07 at 18-41-39 Technical University of Denmark - Scholia](https://user-images.githubusercontent.com/465923/177826341-4e0ab454-24ee-44b7-9a0b-ba87d8b2d2a6.png)
