### PR TITLE
adjust work-curation_author-resolving.sparql to account for case when work has no P50 statement

### DIFF
--- a/scholia/app/templates/work-curation_author-resolving.sparql
+++ b/scholia/app/templates/work-curation_author-resolving.sparql
@@ -14,8 +14,9 @@ WITH {
 } AS %authors
 WITH {
   SELECT DISTINCT ?author_name WHERE {
+    {
     INCLUDE %authors
-    { ?author skos:altLabel | rdfs:label | (^ps:P50 / pq:P1932) ?author_name . }
+    ?author skos:altLabel | rdfs:label | (^ps:P50 / pq:P1932) ?author_name . }
     UNION
     { target: wdt:P2093 ?author_name . } 
   }


### PR DESCRIPTION
Fixes #2050 

### Description
moved the INCLUDE %authors to the ?author part of the UNION 

Test page: https://scholia.toolforge.org/work/Q56490640/curation

Screenshot after fix:
![Screenshot from 2022-07-08 15-27-19](https://user-images.githubusercontent.com/465923/178001572-2ab6f305-6b94-47be-a240-c443c768592f.png)

