### PR TITLE
Change "Co-author graph" to "Co-author graph of event participants"

### DIFF
--- a/scholia/app/templates/event.html
+++ b/scholia/app/templates/event.html
@@ -31,7 +31,7 @@
 <table class="table table-hover" id="people-table"></table>
 
 
-<h3 id="co-authors">Co-author graph</h3>
+<h3 id="co-authors">Co-author graph of event participants</h3>
 
 <div class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" id="co-authors-iframe"></iframe>

--- a/scholia/app/templates/event.html
+++ b/scholia/app/templates/event.html
@@ -31,7 +31,7 @@
 <table class="table table-hover" id="people-table"></table>
 
 
-<h3 id="co-authors">Co-author graph of event participants</h3>
+<h3 id="co-authors">Co-author graph of people involved in the event</h3>
 
 <div class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" id="co-authors-iframe"></iframe>


### PR DESCRIPTION
Fixes #2060 

I did not go for "attendees" (which was suggested in the issue) because some co-authors often were not actually *attending* the event, but I think co-authoring a paper presented there still makes them participant of some sort, and the corresponding Wikidata property ([P710](https://www.wikidata.org/wiki/Property:P710)) has the English label "participant".

### Description
I just changed the HTML section title, leaving the section id intact.
