### PR TITLE
Added an /organization/QID1/use/QID2 subaspect

### DIFF
--- a/scholia/app/templates/index.html
+++ b/scholia/app/templates/index.html
@@ -142,6 +142,14 @@
 		    </dd>
 		</dl>
 
+		<dl>
+		    <dt>
+		        <a href="organization/Q319078/use/Q326489">University of Melbourne and ggplot2</a></dt>
+            <dd>
+		    Explore what people affiliated with this institution have published using this open-source data visualization software. 
+		    </dd>
+		</dl>
+
 
 
 

--- a/scholia/app/templates/organization-index.html
+++ b/scholia/app/templates/organization-index.html
@@ -50,7 +50,7 @@ Universities, research centers, ...
   <li><a href="Q835960/use/Q3699942">University of São Paulo and Cytoscape</a></li>
   <li><a href="Q7966487/use/Q112236343">WEHI and limma</a></li>
   <li><a href="Q4689656/use/Q513297">African Academy of Sciences and ArcGIS</a></li>
-  <li><a href="Q11942/use/Q1137203">ETH Zürich and ImageJ</a></li>
+  <li><a href="Q11942/use/Q1659584">ETH Zürich and ImageJ</a></li>
 </ul>
 
 

--- a/scholia/app/templates/organization-index.html
+++ b/scholia/app/templates/organization-index.html
@@ -44,5 +44,15 @@ Universities, research centers, ...
 </ul>
 
 
+<h3>Subaspect: Organizations and resources used</h3>
+
+<ul>
+  <li><a href="Q835960/use/Q3699942">University of São Paulo and Cytoscape</a></li>
+  <li><a href="Q7966487/use/Q112236343">WEHI and limma</a></li>
+  <li><a href="Q4689656/use/Q513297">African Academy of Sciences and ArcGIS</a></li>
+  <li><a href="Q11942/use/Q1137203">ETH Zürich and ImageJ</a></li>
+</ul>
+
+
 
 {% endblock %}

--- a/scholia/app/templates/organization-use.html
+++ b/scholia/app/templates/organization-use.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+
+{% set aspect = "organization-use" %}
+
+{% block in_ready %}
+
+{{ sparql_to_table('recent-literature') }}
+
+{{ sparql_to_table('authors') }}
+
+
+{% endblock %}
+
+
+
+{% block page_content %}
+
+<h1 id="h1">Organization-use</h1>
+
+<div id="intro"></div>
+
+<h2 class="headline" id="recent-literature">Recent publications</h2>
+
+<table class="table table-hover" id="recent-literature-table"></table>
+
+
+<h2 class="headline" id="authors">Authors</h2>
+
+<table class="table table-hover" id="authors-table"></table>
+
+
+{% endblock %}

--- a/scholia/app/templates/organization-use_authors.sparql
+++ b/scholia/app/templates/organization-use_authors.sparql
@@ -1,0 +1,26 @@
+PREFIX target1: <http://www.wikidata.org/entity/{{ q1 }}>
+PREFIX target2: <http://www.wikidata.org/entity/{{ q2 }}>
+
+SELECT
+    (COUNT(DISTINCT ?work) AS ?works)
+  ?author ?authorLabel ?authorDescription (CONCAT("/author/", SUBSTR(STR(?author), 32)) AS ?authorUrl)
+    (SAMPLE(?work) AS ?example_work)
+ ?example_workLabel (CONCAT("/work/", SUBSTR(STR(?example_work), 32)) AS ?example_workUrl)
+WITH {
+  SELECT DISTINCT ?author WHERE {
+    ?author ( wdt:P108 | wdt:P463 | wdt:P1416 ) / wdt:P361* target1: .
+  } 
+} AS %researchers
+WHERE {
+  INCLUDE %researchers
+
+  ?work wdt:P50 ?author ;
+        wdt:P4510 target2: .
+  OPTIONAL {
+    ?work wdt:P577 ?publication_datetime .
+    BIND(xsd:date(?publication_datetime) AS ?publication_date)
+  }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en,da,de,es,fr,jp,nl,no,ru,sv,zh". }
+}
+GROUP BY ?works ?author ?authorLabel ?authorDescription ?authorUrl ?example_work ?example_workLabel ?example_workUrl
+ORDER BY DESC (?works)

--- a/scholia/app/templates/organization-use_authors.sparql
+++ b/scholia/app/templates/organization-use_authors.sparql
@@ -2,25 +2,29 @@ PREFIX target1: <http://www.wikidata.org/entity/{{ q1 }}>
 PREFIX target2: <http://www.wikidata.org/entity/{{ q2 }}>
 
 SELECT
-    (COUNT(DISTINCT ?work) AS ?works)
+  ?works
   ?author ?authorLabel ?authorDescription (CONCAT("/author/", SUBSTR(STR(?author), 32)) AS ?authorUrl)
-    (SAMPLE(?work) AS ?example_work)
- ?example_workLabel (CONCAT("/work/", SUBSTR(STR(?example_work), 32)) AS ?example_workUrl)
+  ?example_work ?example_workLabel (CONCAT("/work/", SUBSTR(STR(?example_work), 32)) AS ?example_workUrl)
 WITH {
   SELECT DISTINCT ?author WHERE {
     ?author ( wdt:P108 | wdt:P463 | wdt:P1416 ) / wdt:P361* target1: .
   } 
 } AS %researchers
-WHERE {
-  INCLUDE %researchers
-
-  ?work wdt:P50 ?author ;
-        wdt:P4510 target2: .
-  OPTIONAL {
-    ?work wdt:P577 ?publication_datetime .
-    BIND(xsd:date(?publication_datetime) AS ?publication_date)
+WITH {
+  SELECT
+    ?author
+    (COUNT(DISTINCT ?work) AS ?works)
+    (SAMPLE(?work) AS ?example_work)
+  WHERE {
+    INCLUDE %researchers
+    ?work wdt:P50 ?author ;
+          wdt:P4510 target2: .
   }
+  GROUP BY ?author
+} AS %researchers_and_works
+WHERE {
+  INCLUDE %researchers_and_works
+
   SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en,da,de,es,fr,jp,nl,no,ru,sv,zh". }
 }
-GROUP BY ?works ?author ?authorLabel ?authorDescription ?authorUrl ?example_work ?example_workLabel ?example_workUrl
 ORDER BY DESC (?works)

--- a/scholia/app/templates/organization-use_recent-literature.sparql
+++ b/scholia/app/templates/organization-use_recent-literature.sparql
@@ -1,0 +1,23 @@
+PREFIX target1: <http://www.wikidata.org/entity/{{ q1 }}>
+PREFIX target2: <http://www.wikidata.org/entity/{{ q2 }}>
+
+SELECT DISTINCT
+  ?publication_date
+  ?work ?workLabel (CONCAT("/work/", SUBSTR(STR(?work), 32)) AS ?workUrl)
+WITH {
+  SELECT DISTINCT ?researcher WHERE {
+    ?researcher ( wdt:P108 | wdt:P463 | wdt:P1416 ) / wdt:P361* target1: .
+  } 
+} AS %researchers
+WHERE {
+  INCLUDE %researchers
+
+  ?work wdt:P50 ?researcher ;
+        wdt:P4510 target2: .
+  OPTIONAL {
+    ?work wdt:P577 ?publication_datetime .
+    BIND(xsd:date(?publication_datetime) AS ?publication_date)
+  }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en,da,de,es,fr,jp,nl,no,ru,sv,zh". }
+}
+ORDER BY DESC(?publication_date)

--- a/scholia/app/templates/organization.html
+++ b/scholia/app/templates/organization.html
@@ -6,7 +6,7 @@
 
 {{ sparql_to_table('employees-and-affiliated') }}
 {{ sparql_to_table('topics') }}
-{{ sparql_to_table('use') }}
+{{ sparql_to_table('uses') }}
 {{ sparql_to_table('recent-literature') }}
 {{ sparql_to_table('recent-citations') }}
 {{ sparql_to_table('awards') }}
@@ -61,11 +61,11 @@ Topics of publications by past and present employees, affiliates, and members, r
 
 <table class="table table-hover" id="recent-literature-table"></table>
 
-<h2 id="use">Use</h3>
+<h2 id="uses">Uses</h3>
 
 Resources used in works with associated authors.
 
-<table class="table table-hover" id="use-table"></table>
+<table class="table table-hover" id="uses-table"></table>
 
 <h2 id="page-production">Page production</h2>
 

--- a/scholia/app/templates/organization.html
+++ b/scholia/app/templates/organization.html
@@ -6,6 +6,7 @@
 
 {{ sparql_to_table('employees-and-affiliated') }}
 {{ sparql_to_table('topics') }}
+{{ sparql_to_table('use') }}
 {{ sparql_to_table('recent-literature') }}
 {{ sparql_to_table('recent-citations') }}
 {{ sparql_to_table('awards') }}
@@ -60,6 +61,11 @@ Topics of publications by past and present employees, affiliates, and members, r
 
 <table class="table table-hover" id="recent-literature-table"></table>
 
+<h2 id="use">Use</h3>
+
+Resources used in works with associated authors.
+
+<table class="table table-hover" id="use-table"></table>
 
 <h2 id="page-production">Page production</h2>
 

--- a/scholia/app/templates/organization_uses.sparql
+++ b/scholia/app/templates/organization_uses.sparql
@@ -4,7 +4,7 @@ SELECT
   ?researchers
   ?use ?useLabel (CONCAT("/use/", SUBSTR(STR(?use), 32)) AS ?useUrl)
   ("🔎" AS ?zoom)
-  (CONCAT("Q112326635/use/", SUBSTR(STR(?use), 32)) AS ?zoomUrl)
+  (CONCAT("{{ q }}/use/", SUBSTR(STR(?use), 32)) AS ?zoomUrl)
   ?useDescription
   ?samplework ?sampleworkLabel (CONCAT("/work/", SUBSTR(STR(?samplework), 32)) AS ?sampleworkUrl)
 WITH {

--- a/scholia/app/templates/organization_uses.sparql
+++ b/scholia/app/templates/organization_uses.sparql
@@ -1,0 +1,33 @@
+PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
+
+SELECT
+  ?researchers
+  ?use ?useLabel (CONCAT("/use/", SUBSTR(STR(?use), 32)) AS ?useUrl)
+  ("🔎" AS ?zoom)
+  (CONCAT("Q112326635/use/", SUBSTR(STR(?use), 32)) AS ?zoomUrl)
+  ?useDescription
+  ?samplework ?sampleworkLabel (CONCAT("/work/", SUBSTR(STR(?samplework), 32)) AS ?sampleworkUrl)
+WITH {
+  SELECT DISTINCT ?researcher WHERE {
+    ?researcher ( wdt:P108 | wdt:P463 | wdt:P1416 ) / wdt:P361* target: .
+  } 
+} AS %researchers
+WITH {
+  SELECT DISTINCT ?use
+    (COUNT(DISTINCT ?researcher) AS ?researchers)
+    (SAMPLE(?work) AS ?samplework)
+  WHERE {
+    INCLUDE %researchers
+    ?work wdt:P50 ?researcher . 
+    ?work wdt:P4510 ?use . 
+  } 
+  GROUP BY ?use
+  ORDER BY DESC(?researchers)
+  LIMIT 500
+} AS %works_and_number_of_researchers
+WHERE {
+  INCLUDE %works_and_number_of_researchers
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,nl,no,ru,sv,zh" . } 
+}
+GROUP BY ?researchers ?use ?useLabel ?useDescription ?samplework ?sampleworkLabel
+ORDER BY DESC(?researchers)

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -1314,6 +1314,7 @@ def show_organization_topic(q1, q2):
     """
     return render_template('organization-topic.html', q1=q1, q2=q2, q=q1)
 
+  
 @main.route('/organization/' + q1_pattern + '/use/' + q2_pattern)
 def show_organization_use(q1, q2):
     """Return HTML rendering for specific organization and use.

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -1314,6 +1314,25 @@ def show_organization_topic(q1, q2):
     """
     return render_template('organization-topic.html', q1=q1, q2=q2, q=q1)
 
+@main.route('/organization/' + q1_pattern + '/use/' + q2_pattern)
+def show_organization_use(q1, q2):
+    """Return HTML rendering for specific organization and use.
+
+    Parameters
+    ----------
+    q1 : str
+        Wikidata item identifier for organization.
+    q2 : str
+        Wikidata item identifier for use
+
+    Returns
+    -------
+    html : str
+        Rendered HTML for a specific organization and use.
+
+    """
+    return render_template('organization-use.html', q1=q1, q2=q2, q=q1)
+
 
 @main.route('/organizations/' + qs_pattern)
 def show_organizations(qs):

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -1314,7 +1314,7 @@ def show_organization_topic(q1, q2):
     """
     return render_template('organization-topic.html', q1=q1, q2=q2, q=q1)
 
-  
+
 @main.route('/organization/' + q1_pattern + '/use/' + q2_pattern)
 def show_organization_use(q1, q2):
     """Return HTML rendering for specific organization and use.


### PR DESCRIPTION
Fixes #2058 

### Description
> Please include a summary of the change, relevant motivation and context. If possible and applicable, include before and after screenshots and a URL where the changes can be seen.

This provides a way to browse organization-related information about the use of research resources. It is modeled after the existing organization/ topic subaspect.
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [X]  This change requires a documentation update
    * [X]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [X]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

See examples from organization-index.html :
<ul>
  <li><a href="Q835960/use/Q3699942">University of São Paulo and Cytoscape</a></li>
  <li><a href="Q7966487/use/Q112236343">WEHI and limma</a></li>
  <li><a href="Q4689656/use/Q513297">African Academy of Sciences and ArcGIS</a></li>
  <li><a href="Q11942/use/Q1659584">ETH Zürich and ImageJ</a></li>
</ul>

### Checklist
* [X] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [X] My changes generate no new warnings
* [X] I have not used code from external sources without attribution
* [X] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [X] There are no remaining debug statements (print, console.log, ...)

### Screenshots

The Scholia homepage has a new entry under Combinations: University of Melbourne and ggplot2:
![Screenshot from 2022-07-24 07-04-46](https://user-images.githubusercontent.com/465923/180633068-5f9fa2cb-d6bd-4c7b-9ffc-7972b5c94373.png)

Following that link leads to the new organization/ use subaspect:
![Screenshot 2022-07-24 at 07-09-21 University of Melbourne - Scholia](https://user-images.githubusercontent.com/465923/180633146-329a369a-4921-4a39-85fa-ba7c49b78cca.png)

The subaspect is linked from the organization profile via a zoom lense icon in the use panel:
![Screenshot from 2022-07-24 07-13-30](https://user-images.githubusercontent.com/465923/180633251-a7ffb40f-70d1-456c-8d86-03c5a7251cfe.png)

The subaspect can also be reached from the organization index page, which has a new section to that end:
![Screenshot 2022-07-24 at 07-15-37 Organization - Scholia](https://user-images.githubusercontent.com/465923/180633273-5cad7a8a-9539-4931-b516-c76c8e8d6dee.png)
