### PR TITLE
Limits for use profile 2070

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-new-aspect.md
+++ b/.github/ISSUE_TEMPLATE/add-new-aspect.md
@@ -1,5 +1,5 @@
 ---
-name: Add new aspect
+name: New aspect request
 about: Add an aspect for ...
 title: ''
 labels: aspects
@@ -7,10 +7,12 @@ assignees: ''
 
 ---
 
-[//]: # "==Do not write above this line==
-A Scholia aspect is used to profile the target item in a specific way, e.g.
-https://scholia.toolforge.org/topic/Q202864
-profiles Q202864 (Zika virus) as a topic.
+[//]: # "==Information:==
+Scholia URLs are in the form https://scholia.toolforge.org/[aspect]/[item]#[panel]
+
+A Scholia aspect is used to profile the target item in a specific way, 
+e.g. https://scholia.toolforge.org/topic/Q202864 profiles Q202864 (Zika virus) as a topic.
+
 A query within a given aspect is called a panel. Please use the ``Add new panel to ... aspect ...`` template to propose a new panel for an aspect.
 ==Write below this line=="
 **What kind of aspect would you like to add to Scholia?**

--- a/.github/ISSUE_TEMPLATE/add-new-panel.md
+++ b/.github/ISSUE_TEMPLATE/add-new-panel.md
@@ -1,17 +1,19 @@
 ---
-name: Add new panel
-about: Add a panel on .. to aspect ..
+name: New panel request
+about: Add a panel on ... to aspect ...
 title: ''
 labels: panels
 assignees: ''
 
 ---
 
-[//]: # "==Do not write above this line==
-A Scholia aspect is used to profile the target item in a specific way, e.g.
-https://scholia.toolforge.org/topic/Q202864
-profiles Q202864 (Zika virus) as a topic.
-A query within a given aspect is called a panel. Please use the ``Add new aspect ...`` template to propose a new aspect.
+[//]: # "==Information:==
+Scholia URLs are in the form https://scholia.toolforge.org/[aspect]/[item]#[panel]
+
+A Scholia panel displays the result of a query on a target item in an aspect.
+e.g. https://scholia.toolforge.org/topic/Q202864#publications-per-year shows the publications per year of the topic profile of Q202864 (Zika virus)
+
+Please use the ``Add new aspect ...`` template to propose a new aspect.
 ==Write below this line=="
 **What kind of panel would you like to add to which Scholia aspect?**
 

--- a/.github/ISSUE_TEMPLATE/modify-a-sparql-query.md
+++ b/.github/ISSUE_TEMPLATE/modify-a-sparql-query.md
@@ -1,5 +1,5 @@
 ---
-name: Modify a SPARQL query
+name: SPARQL query modification
 about: Propose a change to a SPARQL query currently in use at Scholia
 title: ''
 labels: SPARQL
@@ -12,4 +12,4 @@ Please provide a link to a Scholia profile and the appropriate section heading a
 
 **What change do you propose, and why?**
 
-**Anything else to consider here?**
+**Any other considerations?**

--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,6 @@ ENV/
 # Eclipse
 .pydev
 .pydevproject
+
+# VirtualFish files
+.venv

--- a/scholia/app/static/css/nightmode.css
+++ b/scholia/app/static/css/nightmode.css
@@ -24,4 +24,8 @@
         background-color: var(--theme-blue);
         border-color: var(--theme-blue);
     }
+
+    .navbar-toggler-icon {
+        background-image: url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 30 30' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='rgba(255, 255, 255, 0.5)' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 7h22M4 15h22M4 23h22'/%3E%3C/svg%3E");
+    }
 }

--- a/scholia/app/static/css/scholia.css
+++ b/scholia/app/static/css/scholia.css
@@ -97,9 +97,7 @@ a:hover {
 }
 
 .navbar {
-    height: 4rem;
-    flex-wrap: nowrap;
-    justify-content: flex-start;
+    min-height: 4rem;
 }
 
 .nav {
@@ -191,6 +189,10 @@ a.dropdown-item.active {
     padding-right: 5px;
     margin-left: -27px;
     top: 0.5rem;
+}
+
+.navbar-toggler-icon {
+    background-image: url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 30 30' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='rgba(0, 0, 0, 0.5)' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 7h22M4 15h22M4 23h22'/%3E%3C/svg%3E");
 }
 
 .table-of-contents {

--- a/scholia/app/static/css/scholia.css
+++ b/scholia/app/static/css/scholia.css
@@ -152,6 +152,7 @@ h2 {
 
 h3 {
     font-size: 1.65rem;
+    clear: both;
 }
 
 .dropdown-menu li {

--- a/scholia/app/static/scholia.js
+++ b/scholia/app/static/scholia.js
@@ -285,53 +285,75 @@ function sparqlToDataTable(sparql, element, filename, options = {}) {
 
         convertedData = convertDataTableData(simpleData.data, simpleData.columns);
         columns = [];
-        for (i = 0; i < convertedData.columns.length; i++) {
-            var column = {
-                data: convertedData.columns[i],
-                title: capitalizeFirstLetter(convertedData.columns[i]).replace(/_/g, "&nbsp;"),
-                defaultContent: "",
+        if (convertedData.data.length > 0) {
+            for (i = 0; i < convertedData.columns.length; i++) {
+                var column = {
+                    data: convertedData.columns[i],
+                    title: capitalizeFirstLetter(convertedData.columns[i]).replace(/_/g, "&nbsp;"),
+                    defaultContent: "",
+                }
+                if (column['title'] == 'Count') {
+                  // check that the count is not a link
+                  if (convertedData.data[0]["count"][0] != "<") {
+                    column['render'] = $.fn.dataTable.render.number(',', '.');
+                  }
+                  if (i == 0) {
+                    column['className'] = 'dt-right';
+                  }
+                } else if (
+                  column['title'] == 'Score' ||
+                  column['title'] == 'Distance' ||
+                  /\Wper\W/.test(column['title'])
+                ) {
+                  column['render'] = $.fn.dataTable.render.number(',', '.', 2);
+                }
+                columns.push(column);
             }
-            if (column['title'] == 'Count') {
-              // check that the count is not a link
-              if (convertedData.data[0]["count"][0] != "<") {
-                column['render'] = $.fn.dataTable.render.number(',', '.');
-              }
-              if (i == 0) {
-                column['className'] = 'dt-right';
-              }
-            } else if (
-              column['title'] == 'Score' ||
-              column['title'] == 'Distance' ||
-              /\Wper\W/.test(column['title'])
-            ) {
-              column['render'] = $.fn.dataTable.render.number(',', '.', 2);
+
+            if (convertedData.data.length <= 10) {
+                paging = false;
             }
-            columns.push(column);
+
+            $(element).html(""); // remove loader
+
+            var table = $(element).DataTable({
+                data: convertedData.data,
+                columns: columns,
+                lengthMenu: [[10, 25, 100, -1], [10, 25, 100, "All"]],
+                ordering: true,
+                order: [],
+                paging: paging,
+                sDom: sDom,
+                scrollX: false,
+                language: {
+                  emptyTable: "This query yielded no results. ",
+                  sZeroRecords: "This query yielded no results."
+                }
+            });
+
+            $(element).append(datatableFooter);
+        } else {
+            $(element).html(''); // remove loader
+
+            $(element).DataTable({
+                data: [],
+                lengthChange: false,
+                searching: false,
+                paging: false,
+                ordering: true,
+                order: [],
+                sDom: sDom,
+                scrollX: false,
+                language: {
+                    emptyTable: 'This query yielded no results. ',
+                    sZeroRecords: 'This query yielded no results.',
+                },
+            });
+
+            $(element).append(datatableFooter);
         }
-	
-        if (convertedData.data.length <= 10) {
-            paging = false;
-        }
-
-        $(element).html(""); // remove loader
-
-        var table = $(element).DataTable({ 
-            data: convertedData.data,
-            columns: columns,
-            lengthMenu: [[10, 25, 100, -1], [10, 25, 100, "All"]],
-            ordering: true,
-            order: [],
-            paging: paging,
-            sDom: sDom,
-            scrollX: false,
-            language: {
-              emptyTable: "This query yielded no results. ",
-              sZeroRecords: "This query yielded no results."
-            }
-        });
-
-        $(element).append(datatableFooter);
     }).fail(function () {
+        $(element).html(''); // remove loader
         $(element).prepend(
             '<p>This query has timed out, we recommend that you follow the link to the Wikidata Query Service below to modify the query to be less intensive. </p> '
         );

--- a/scholia/app/static/scholia.js
+++ b/scholia/app/static/scholia.js
@@ -161,9 +161,9 @@ function entityToLabel(entity, language = 'en') {
     }
 
     // Fallback
-    languages = ['en', 'da', 'de', 'es', 'fr', 'jp',
+    var languages = ['en', 'da', 'de', 'es', 'fr', 'jp',
         'nl', 'no', 'ru', 'sv', 'zh'];
-    for (lang in languages) {
+    for (var lang in languages) {
         if (lang in entity['labels']) {
             return entity['labels'][lang].value;
         }
@@ -176,7 +176,7 @@ function entityToLabel(entity, language = 'en') {
 
 function resize(element) {
     //width = document.getElementById("topics-works-matrix").clientWidth;
-    width = $(element)[0].clientWidth;
+    var width = $(element)[0].clientWidth;
     d3.select(element).attr("width", width);
     console.log("resized with width " + width);
 }
@@ -219,9 +219,9 @@ function sparqlToDataTablePost(sparql, element, filename, options = {}) {
     $.post(url, data = { query: sparql }, function (response, textStatus) {
         var simpleData = sparqlDataToSimpleData(response);
 
-        convertedData = convertDataTableData(simpleData.data, simpleData.columns);
-        columns = [];
-        for (i = 0; i < convertedData.columns.length; i++) {
+        var convertedData = convertDataTableData(simpleData.data, simpleData.columns);
+        var columns = [];
+        for (var i = 0; i < convertedData.columns.length; i++) {
             var column = {
                 data: convertedData.columns[i],
                 title: capitalizeFirstLetter(convertedData.columns[i]).replace(/_/g, "&nbsp;"),
@@ -257,7 +257,7 @@ function sparqlToDataTablePost(sparql, element, filename, options = {}) {
                 '</a></span></caption>'
         );
     }, "json");
-};
+}
 
 
 function sparqlToDataTable(sparql, element, filename, options = {}) {
@@ -363,7 +363,7 @@ function sparqlToDataTable(sparql, element, filename, options = {}) {
 
 function sparqlToIframe(sparql, element, filename) {
     let $iframe = $(element)
-    url = "https://query.wikidata.org/embed.html#" + encodeURIComponent(sparql);
+    var url = "https://query.wikidata.org/embed.html#" + encodeURIComponent(sparql);
     $iframe.attr('src', url);
     $iframe.attr('loading', 'lazy');
 
@@ -389,7 +389,7 @@ function sparqlToIframe(sparql, element, filename) {
             );
         }
     })
-};
+}
 
 
 function sparqlToMatrix(sparql, element, filename){
@@ -414,7 +414,7 @@ function sparqlToMatrix(sparql, element, filename){
    
         // Sizes
         var margin = { top: 100, right: 0, bottom: 0, left: 0 },
-            width = $(element)[0].clientWidth
+            width = $(element)[0].clientWidth,
             axis_height = works.length * 12,
             full_height = axis_height + margin.top;
    
@@ -484,7 +484,7 @@ function sparqlToMatrix(sparql, element, filename){
             .style("font-size", "16px");
    
         var mouseover = function(d) {
-            html =
+            var html =
             "<a href='../work/" +
             d.work.value.substring(31) +
             "'>" +
@@ -567,7 +567,7 @@ function sparqlToPathWayPageViewer(sparql, filename){
             $("#description").text(dataValues.pathwayDescription);
           }
           if ("organism" in dataValues) {
-            organismScholia = dataValues.organism.replace("http://www.wikidata.org/entity/","https://scholia.toolforge.org/taxon/")
+            var organismScholia = dataValues.organism.replace("http://www.wikidata.org/entity/","https://scholia.toolforge.org/taxon/")
             $("#Organism").after('<a href="' + organismScholia + '">' +
                      escapeHTML(dataValues.organismLabel) +
                      '</a>'); 
@@ -595,8 +595,8 @@ function sparqlToPathWayPageViewer(sparql, filename){
 
 
 function sparqlToShortInchiKey(sparql, key,  element, filename) {
-    shortkey = key.substring(0,14)
-    new_sparql = sparql.replace("_shortkey_",shortkey)
+    var shortkey = key.substring(0,14)
+    var new_sparql = sparql.replace("_shortkey_",shortkey)
     sparqlToDataTable(new_sparql, element, filename);
 }
 
@@ -604,7 +604,7 @@ function sparqlToShortInchiKey(sparql, key,  element, filename) {
 function askQuery(panel, askQuery, callback) {
      var endpointUrl = 'https://query.wikidata.org/sparql';
      
-     settings = {
+     var settings = {
        headers: { Accept: 'application/sparql-results+json' },
        data: { query: askQuery },
      };

--- a/scholia/app/static/scholia.js
+++ b/scholia/app/static/scholia.js
@@ -376,20 +376,22 @@ function sparqlToDataTable(sparql, element, filename, options = {}) {
             } else {
                 $('#' + loaderID).remove(); // remove loader
 
-                $(element).DataTable({
-                    data: [],
-                    lengthChange: false,
-                    searching: false,
-                    paging: false,
-                    ordering: true,
-                    order: [],
-                    sDom: sDom,
-                    scrollX: false,
-                    language: {
-                        emptyTable: 'This query yielded no results. ',
-                        sZeroRecords: 'This query yielded no results.',
-                    },
-                });
+                if (!$.fn.dataTable.isDataTable(element)) {
+                    $(element).DataTable({
+                        data: [],
+                        lengthChange: false,
+                        searching: false,
+                        paging: false,
+                        ordering: true,
+                        order: [],
+                        sDom: sDom,
+                        scrollX: false,
+                        language: {
+                            emptyTable: 'This query yielded no results. ',
+                            sZeroRecords: 'This query yielded no results.',
+                        },
+                    });
+                }
             }
         }).fail(function () {
             $('#' + loaderID).remove(); // remove loader

--- a/scholia/app/static/scholia.js
+++ b/scholia/app/static/scholia.js
@@ -181,6 +181,23 @@ function resize(element) {
     console.log("resized with width " + width);
 }
 
+function addReloadButton(element, callback) {    
+    var heading = element.previousElementSibling;
+
+    var button = document.createElement('button');
+    button.classList = 'btn btn-outline-secondary float-right';
+    button.innerHTML = 'Reload';
+    button.id = element.id + "-reload";
+    button.addEventListener('click', callback);
+    if (['H2', 'H3', 'H4'].includes(heading.tagName)) {
+        button.classList = 'btn btn-outline-secondary float-right';
+        heading.append(button);
+    } else {
+        button.classList = 'btn btn-outline-secondary d-block ml-auto';
+        button.style = 'clear: both';
+        element.insertAdjacentElement('beforebegin', button);
+    }
+}
 
 function sparqlToResponse(sparql, doneCallback) {
     var endpointUrl = "https://query.wikidata.org/bigdata/namespace/wdq/sparql";
@@ -234,7 +251,7 @@ function sparqlToDataTablePost(sparql, element, filename, options = {}) {
           paging = false;
         }
 
-        $(element).html('');
+        $(element).html(''); // remove loader
 
         var table = $(element).DataTable({
             data: convertedData.data,
@@ -276,89 +293,115 @@ function sparqlToDataTable(sparql, element, filename, options = {}) {
         '">' +
         filename.replace('_', ': ') +
         '</a></span></caption>';
-
-    $(element).html("<div class='loader'><div></div><div></div><div></div></div>")
     $(element).append(datatableFooter);
 
-    $.getJSON(url, function (response) {
-        var simpleData = sparqlDataToSimpleData(response);
+    const table = document.getElementById(element.slice(1));
+    addReloadButton(table, makeRequest);
 
-        convertedData = convertDataTableData(simpleData.data, simpleData.columns);
-        columns = [];
-        if (convertedData.data.length > 0) {
-            for (i = 0; i < convertedData.columns.length; i++) {
-                var column = {
-                    data: convertedData.columns[i],
-                    title: capitalizeFirstLetter(convertedData.columns[i]).replace(/_/g, "&nbsp;"),
-                    defaultContent: "",
-                }
-                if (column['title'] == 'Count') {
-                  // check that the count is not a link
-                  if (convertedData.data[0]["count"][0] != "<") {
-                    column['render'] = $.fn.dataTable.render.number(',', '.');
-                  }
-                  if (i == 0) {
-                    column['className'] = 'dt-right';
-                  }
-                } else if (
-                  column['title'] == 'Score' ||
-                  column['title'] == 'Distance' ||
-                  /\Wper\W/.test(column['title'])
-                ) {
-                  column['render'] = $.fn.dataTable.render.number(',', '.', 2);
-                }
-                columns.push(column);
-            }
+    makeRequest();
 
-            if (convertedData.data.length <= 10) {
-                paging = false;
-            }
-
-            $(element).html(""); // remove loader
-
-            var table = $(element).DataTable({
-                data: convertedData.data,
-                columns: columns,
-                lengthMenu: [[10, 25, 100, -1], [10, 25, 100, "All"]],
-                ordering: true,
-                order: [],
-                paging: paging,
-                sDom: sDom,
-                scrollX: false,
-                language: {
-                  emptyTable: "This query yielded no results. ",
-                  sZeroRecords: "This query yielded no results."
-                }
-            });
-
-            $(element).append(datatableFooter);
-        } else {
-            $(element).html(''); // remove loader
-
-            $(element).DataTable({
-                data: [],
-                lengthChange: false,
-                searching: false,
-                paging: false,
-                ordering: true,
-                order: [],
-                sDom: sDom,
-                scrollX: false,
-                language: {
-                    emptyTable: 'This query yielded no results. ',
-                    sZeroRecords: 'This query yielded no results.',
-                },
-            });
-
-            $(element).append(datatableFooter);
+    function makeRequest() {
+        if ($.fn.dataTable.isDataTable(element)) {
+            // unnecessary to clear the data here but better UX to make it clear 
+            // that we are reloading the data.
+            $(element).DataTable().clear().draw();
         }
-    }).fail(function () {
-        $(element).html(''); // remove loader
-        $(element).prepend(
-            '<p>This query has timed out, we recommend that you follow the link to the Wikidata Query Service below to modify the query to be less intensive. </p> '
+
+        const loaderID = element.slice(1) + '-loader';
+        table.insertAdjacentHTML('beforebegin',
+            "<div id='" +
+                loaderID +
+                "' class='loader'><div></div><div></div><div></div></div>"
         );
-    });
-};
+
+        
+        $.getJSON(url, function (response) {
+            var simpleData = sparqlDataToSimpleData(response);
+
+            convertedData = convertDataTableData(simpleData.data, simpleData.columns);
+            columns = [];
+            if (convertedData.data.length > 0) {
+                for (i = 0; i < convertedData.columns.length; i++) {
+                    var column = {
+                        data: convertedData.columns[i],
+                        title: capitalizeFirstLetter(convertedData.columns[i]).replace(/_/g, "&nbsp;"),
+                        defaultContent: "",
+                    }
+                    if (column['title'] == 'Count') {
+                    // check that the count is not a link
+                    if (convertedData.data[0]["count"][0] != "<") {
+                        column['render'] = $.fn.dataTable.render.number(',', '.');
+                    }
+                    if (i == 0) {
+                        column['className'] = 'dt-right';
+                    }
+                    } else if (
+                    column['title'] == 'Score' ||
+                    column['title'] == 'Distance' ||
+                    /\Wper\W/.test(column['title'])
+                    ) {
+                    column['render'] = $.fn.dataTable.render.number(',', '.', 2);
+                    }
+                    columns.push(column);
+                }
+
+                if (convertedData.data.length <= 10) {
+                    paging = false;
+                }
+
+                $("#" + loaderID).remove(); // remove loader
+
+                if ($.fn.dataTable.isDataTable(element)) {
+                    // $(element).DataTable().clear();
+                    $(element).DataTable().rows.add(convertedData.data).draw();
+                } else {
+                    $(element).DataTable({
+                        data: convertedData.data,
+                        columns: columns,
+                        lengthMenu: [
+                            [10, 25, 100, -1],
+                            [10, 25, 100, 'All'],
+                        ],
+                        ordering: true,
+                        order: [],
+                        paging: paging,
+                        sDom: sDom,
+                        scrollX: false,
+                        language: {
+                            emptyTable: 'This query yielded no results. ',
+                            sZeroRecords: 'This query yielded no results.',
+                        },
+                    });
+                }
+            } else {
+                $('#' + loaderID).remove(); // remove loader
+
+                $(element).DataTable({
+                    data: [],
+                    lengthChange: false,
+                    searching: false,
+                    paging: false,
+                    ordering: true,
+                    order: [],
+                    sDom: sDom,
+                    scrollX: false,
+                    language: {
+                        emptyTable: 'This query yielded no results. ',
+                        sZeroRecords: 'This query yielded no results.',
+                    },
+                });
+            }
+        }).fail(function () {
+            $('#' + loaderID).remove(); // remove loader
+            $(element).prepend(
+                '<p>This query has timed out, we recommend that you follow the link to the Wikidata Query Service below to modify the query to be less intensive. </p> '
+            );
+            const reloadButton = document.getElementById(element.slice(1) + '-reload')
+            reloadButton.classList.add('btn-secondary');
+            reloadButton.classList.remove('btn-outline-secondary');
+        });
+    }
+}
 
 
 function sparqlToIframe(sparql, element, filename) {

--- a/scholia/app/templates/base.html
+++ b/scholia/app/templates/base.html
@@ -794,7 +794,7 @@ askQuery("{{ panel }}", `# tool: scholia
   <a class="navbar-brand" href="{{ url_for('app.index') }}"><img
       src="{{ url_for('static', filename='images/scholia_wordmark.svg') }}" width="112px" height="24px"
       alt="Scholia"></a>
-  <button class="navbar-light navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
+  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
     aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
   </button>

--- a/scholia/app/templates/base.html
+++ b/scholia/app/templates/base.html
@@ -154,8 +154,11 @@ askQuery("{{ panel }}", `# tool: scholia
 	    var imageURL = "https://upload.wikimedia.org/wikipedia/commons/thumb/" 
 	    imageURL += imageNameMd5[0] + "/" + imageNameMd5.slice(0,2) + "/"
 	    var filetype = imageName.match(/\.(\w+)$/);
-	    if (filetype[1] === "tif" || filetype[1] === "tiff") {
+      var extension = filetype[1].toLowerCase()
+	    if (extension === "tif" || extension === "tiff") {
 	      imageURL += encodeURIComponent(imageName) + "/lossy-page1-500px-" + encodeURIComponent(imageName) + ".jpg";
+	    } else if (extension === "svg") {
+	      imageURL += encodeURIComponent(imageName) + "/500px-" + encodeURIComponent(imageName) + ".png";
 	    } else {
 	      imageURL += encodeURIComponent(imageName) + "/500px-" + encodeURIComponent(imageName);
 	    }

--- a/scholia/app/templates/base.html
+++ b/scholia/app/templates/base.html
@@ -228,6 +228,12 @@ askQuery("{{ panel }}", `# tool: scholia
 	     socialMediaLink(detailsList, user, site);
 	 }
 
+	 /* Official homepage */
+	 if ("P856" in item.claims) {
+	     var homepage = item.claims.P856[0].mainsnak.datavalue.value
+	     detailsList.push('&nbsp;<a href="' + homepage + '">' + homepage + '</a>');
+	 }
+
 	 if (detailsList.length > 0) {
 	     $('#details').append(detailsList.join(" | "));
 	 }

--- a/scholia/app/templates/base.html
+++ b/scholia/app/templates/base.html
@@ -188,6 +188,21 @@ askQuery("{{ panel }}", `# tool: scholia
 	     detailsList.push(html);
 	 }
 
+	 function sortRank(a, b) {
+	  const aRank = a["rank"];
+	  const bRank = b["rank"];
+	  if (aRank == bRank) {
+	    return 0;
+	  }
+	  if (aRank == "preferred" || bRank == "deprecated") {
+	    return -1;
+	  }
+	  if (bRank == "preferred" || aRank == "deprecated") {
+	    return 1;
+	  }
+    return 0;
+	}
+
 	 var detailsList = Array();
 	 if ("P496" in item.claims) {
 	     var user = {name: item.claims.P496[0].mainsnak.datavalue.value, prefix: 'https://orcid.org/'};
@@ -230,8 +245,9 @@ askQuery("{{ panel }}", `# tool: scholia
 
 	 /* Official homepage */
 	 if ("P856" in item.claims) {
-	     var homepage = item.claims.P856[0].mainsnak.datavalue.value
-	     detailsList.push('&nbsp;<a href="' + homepage + '">' + homepage + '</a>');
+	     var homepage = item.claims.P856.sort(sortRank)[0]
+       var homepageURL = homepage.mainsnak.datavalue.value
+	     detailsList.push('&nbsp;<a href="' + homepageURL + '">' + homepageURL + '</a>');
 	 }
 
 	 if (detailsList.length > 0) {

--- a/scholia/app/templates/chemical-class.html
+++ b/scholia/app/templates/chemical-class.html
@@ -9,6 +9,7 @@
 {{ sparql_to_table('related-chemicals') }}
 {{ sparql_to_table('recent-literature') }}
 {{ sparql_to_iframe('publications-per-year') }}
+{{ sparql_to_table('found-in-taxon') }}
 
 {% endblock %}
 
@@ -40,6 +41,10 @@
 <div class="embed-responsive embed-responsive-16by9">
   <iframe class="embed-responsive-item" id="publications-per-year-iframe" ></iframe>
 </div>
+
+<h2 id="found-in-taxon">Taxa in which the chemical class was found</h2>
+
+<table class="table table-hover" id="found-in-taxon-table"></table>
 
 {% endblock %}
     

--- a/scholia/app/templates/chemical-class_found-in-taxon.sparql
+++ b/scholia/app/templates/chemical-class_found-in-taxon.sparql
@@ -1,0 +1,15 @@
+PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
+
+SELECT DISTINCT ?taxon ?taxonLabel (CONCAT("/taxon/", SUBSTR(STR(?taxon), 32)) AS ?taxonUrl) (COUNT(DISTINCT(?chemical)) AS ?count) WHERE {
+  ?chemical wdt:P31/wdt:P279* target: ;
+            p:P703 ?taxonStatement .
+  ?taxonStatement ps:P703 ?taxon .
+  OPTIONAL {
+      ?taxonStatement prov:wasDerivedFrom/pr:P248 ?source .
+      OPTIONAL { ?source wdt:P356 ?DOI . }
+    }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+} 
+  GROUP BY ?taxon ?taxonLabel
+  ORDER BY DESC(?count)
+  LIMIT 250

--- a/scholia/app/templates/chemical.html
+++ b/scholia/app/templates/chemical.html
@@ -52,6 +52,8 @@
 
 <h2 id="Related" id="related">Related Compounds</h2>
 
+(Including the compound itself)
+
 <table class="table table-hover" id="related-table"></table>
 
 <h2 id="PhysChem" id="physchem-properties">Physchem Properties</h2>

--- a/scholia/app/templates/event.html
+++ b/scholia/app/templates/event.html
@@ -7,6 +7,7 @@
 
 {{ sparql_to_table('people') }}
 {{ sparql_to_table('proceedings') }}
+{{ sparql_to_table('presentations') }}
 {{ sparql_to_table('recent-publications') }}
 {{ sparql_to_table('related-events-people') }}
 {{ sparql_to_table('related-events-timelocation') }}
@@ -63,6 +64,14 @@ Recent publications by organizers, speakers or participants of the event.
 Works published in the proceedings related to the event.
 
 <table class="table table-hover" id="proceedings-table"></table>
+
+
+<h3 id="presentations">Presentations</h3>
+
+Works (like talks, presentations, posters) presented at the event.
+
+<table class="table table-hover" id="presentations-table"></table>
+
 
 
 <h2>Related events</h2>

--- a/scholia/app/templates/event.html
+++ b/scholia/app/templates/event.html
@@ -31,7 +31,7 @@
 <table class="table table-hover" id="people-table"></table>
 
 
-<h3 id="co-authors">Co-author graph</h3>
+<h3 id="co-authors">Co-author graph of people involved in the event</h3>
 
 <div class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" id="co-authors-iframe"></iframe>

--- a/scholia/app/templates/event_presentations.sparql
+++ b/scholia/app/templates/event_presentations.sparql
@@ -1,0 +1,30 @@
+PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
+
+SELECT
+  ?work ?workLabel (CONCAT("/work/", SUBSTR(STR(?work), 32)) AS ?workUrl)
+  ?authors ?authorsUrl
+  ?topics ?topicsUrl
+WITH {
+  SELECT 
+    ?work
+    (GROUP_CONCAT(DISTINCT ?author_label; separator=", ") AS ?authors)
+    (CONCAT("../authors/", GROUP_CONCAT(DISTINCT SUBSTR(STR(?author), 32); separator=",")) AS ?authorsUrl)    
+    (GROUP_CONCAT(DISTINCT ?topic_label; separator=", ") AS ?topics)
+    (CONCAT("../topics/", GROUP_CONCAT(DISTINCT SUBSTR(STR(?topic), 32); separator=",")) AS ?topicsUrl)
+  WHERE {
+    ?work  wdt:P9788 | wdt:P5072  target: .
+    OPTIONAL {
+      ?work wdt:P50 ?author .
+      ?author rdfs:label ?author_label . FILTER(LANG(?author_label) = "en")
+    }
+    OPTIONAL {
+      ?work wdt:P921 ?topic .
+      ?topic rdfs:label ?topic_label . FILTER(LANG(?topic_label) = "en")
+    }
+  }
+  GROUP BY ?work
+} AS %results
+WHERE {
+  INCLUDE %results
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+}

--- a/scholia/app/templates/index-statistics_statistics.sparql
+++ b/scholia/app/templates/index-statistics_statistics.sparql
@@ -25,7 +25,8 @@ WHERE {
 { {SELECT (COUNT(*) AS ?c) WHERE {[] wdt:P2093 []} } BIND("Author name strings" AS ?d)} UNION
 { {SELECT (COUNT(*) AS ?c) WHERE {[] wdt:P2427 []} } BIND("Items with a GRID ID" AS ?d)} UNION
 { {SELECT (COUNT(*) AS ?c) WHERE {[] wdt:P2860 []} } BIND("Citations" AS ?d)} UNION
-{ {SELECT (COUNT(*) AS ?c) WHERE {[] wdt:P31 wd:Q13442814.} } BIND("Scholarly articles" AS ?d)}
+{ {SELECT (COUNT(*) AS ?c) WHERE {[] wdt:P31 wd:Q13442814.} } BIND("Scholarly articles" AS ?d)} UNION
+{ {SELECT (COUNT(DISTINCT ?work) AS ?c) WHERE { { ?work wdt:P31 wd:Q45182324 . } UNION { ?work wdt:P793 wd:Q7316896 . } UNION { ?work wdt:P5824 [] . } } } BIND("Retracted articles" AS ?d)}
 BIND (?c AS ?count)
 BIND (?d AS ?description)
 }

--- a/scholia/app/templates/software-index_most-used-software.sparql
+++ b/scholia/app/templates/software-index_most-used-software.sparql
@@ -1,8 +1,13 @@
-SELECT ?count ?software ?softwareLabel ?described_by_example ?described_by_exampleLabel ?example_use ?example_useLabel
+SELECT
+  ?count
+  ?software ?softwareLabel ?softwareUrl
+  ?described_by_example ?described_by_exampleLabel
+  ?example_use ?example_useLabel
 WITH {
   SELECT
     (COUNT(DISTINCT ?work) AS ?count)
     ?software
+    (CONCAT("/software/", SUBSTR(STR(?software), 32)) AS ?softwareUrl)
     (SAMPLE(?described_by) AS ?described_by_example)
     (SAMPLE(?work) AS ?example_use)
   WHERE {

--- a/scholia/app/templates/software-index_most-used-software.sparql
+++ b/scholia/app/templates/software-index_most-used-software.sparql
@@ -6,7 +6,7 @@ WITH {
     (SAMPLE(?described_by) AS ?described_by_example)
     (SAMPLE(?work) AS ?example_use)
   WHERE {
-    ?work wdt:P2283 ?software . 
+    ?work wdt:P4510 ?software . 
     ?software wdt:P31/wdt:P279* wd:Q7397 . 
     # Restricting to work takes too long time :(    
     # ?work wdt:P31/wdt:P279* wd:Q386724 .

--- a/scholia/app/templates/topic_uses.sparql
+++ b/scholia/app/templates/topic_uses.sparql
@@ -4,7 +4,7 @@ SELECT
   ?count
   ?use ?useLabel (CONCAT("/use/", SUBSTR(STR(?use), 32)) AS ?useUrl)
   ("🔎" AS ?zoom)
-  (CONCAT("{{ q }}/use/", SUBSTR(STR(?use), 32)) AS ?zoomUrl)
+  (CONCAT(SUBSTR(STR(target:), 32), "/use/", SUBSTR(STR(?use), 32)) AS ?zoomUrl)
   ?useDescription
 
   ?example_work ?example_workLabel

--- a/scholia/app/templates/use_authors-of-works-using-the-resource.sparql
+++ b/scholia/app/templates/use_authors-of-works-using-the-resource.sparql
@@ -2,18 +2,23 @@
 
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
-SELECT ?count ?author ?authorLabel
+SELECT
+  ?count
+  ?author ?authorLabel
 WITH{
-  SELECT (COUNT(?work) AS ?count) ?author WHERE {
-    ?work (wdt:P2283 | wdt:P4510) /wdt:P279* target: .
-    ?work wdt:P50 ?author .
+  SELECT
+    (COUNT(?work) AS ?count)
+    ?author
+  WHERE {
+    ?work wdt:P4510 / wdt:P279* target: ;
+          wdt:P50 ?author .
   }
   GROUP BY ?author
-  LIMIT 10000
+  ORDER BY DESC(?count)
+  LIMIT 200
 } AS %result
 WHERE {
   INCLUDE %result
   SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,nl,no,ru,sv,zh" . }
 }
 ORDER BY DESC(?count)
-LIMIT 200

--- a/scholia/app/templates/use_authors-of-works-using-the-resource.sparql
+++ b/scholia/app/templates/use_authors-of-works-using-the-resource.sparql
@@ -9,6 +9,7 @@ WITH{
     ?work wdt:P50 ?author .
   }
   GROUP BY ?author
+  LIMIT 10000
 } AS %result
 WHERE {
   INCLUDE %result

--- a/scholia/app/templates/use_co-used.sparql
+++ b/scholia/app/templates/use_co-used.sparql
@@ -19,6 +19,7 @@ WITH {
     FILTER (?coused != target:)
   }
   GROUP BY ?coused
+  LIMIT 10000
 } AS %result
 WHERE {
   # Label the result
@@ -26,3 +27,4 @@ WHERE {
   SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }
 ORDER BY DESC(?count) 
+LIMIT 200

--- a/scholia/app/templates/use_co-used.sparql
+++ b/scholia/app/templates/use_co-used.sparql
@@ -12,14 +12,16 @@ SELECT
 WITH {
   # Find works that are using a specific software,
   # and find other software used in the found works
-  SELECT ?coused (COUNT(DISTINCT ?work) as ?count) (SAMPLE(?work) AS ?example_work)
+  SELECT
+    ?coused
+    (COUNT(DISTINCT ?work) as ?count)
+    (SAMPLE(?work) AS ?example_work)
   WHERE {
-    ?work (wdt:P2283 | wdt:P4510) / (wdt:P279*) target: .
-    ?work wdt:P2283 | wdt:P4510 ?coused .
+    ?work wdt:P4510 / wdt:P279* target: ;
+          wdt:P4510 ?coused .
     FILTER (?coused != target:)
   }
   GROUP BY ?coused
-  LIMIT 10000
 } AS %result
 WHERE {
   # Label the result
@@ -27,4 +29,3 @@ WHERE {
   SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }
 ORDER BY DESC(?count) 
-LIMIT 200

--- a/scholia/app/templates/use_recent-work-using-the-used.sparql
+++ b/scholia/app/templates/use_recent-work-using-the-used.sparql
@@ -2,21 +2,21 @@ PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
 SELECT ?publication_date 
 ?work ?workLabel (CONCAT("/work/", SUBSTR(STR(?work), 32)) AS ?workUrl)
-?quote
 WITH{
   SELECT
     (MIN(?publication_date_) AS ?publication_date) ?work (SAMPLE(?quote_) AS ?quote)
   WHERE {
     ?work p:P2283 | p:P4510 ?use_statement .
-    ?use_statement (ps:P2283 | ps:P4510) / (wdt:P279*) target: .
-    OPTIONAL { ?use_statement prov:wasDerivedFrom/pr:P1683 ?quote_ . }
+    ?use_statement (ps:P2283 | ps:P4510)  target: .
     ?work wdt:P577 ?publication_datetime .
     BIND(xsd:date(?publication_datetime) AS ?publication_date_)
   }
   GROUP BY ?work
+  LIMIT 10000         
 } AS %result
 WHERE {
   INCLUDE %result
   SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }
 ORDER BY DESC(?publication_date)
+LIMIT 200

--- a/scholia/app/templates/use_recent-work-using-the-used.sparql
+++ b/scholia/app/templates/use_recent-work-using-the-used.sparql
@@ -1,22 +1,23 @@
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
 SELECT ?publication_date 
-?work ?workLabel (CONCAT("/work/", SUBSTR(STR(?work), 32)) AS ?workUrl)
+?work ?title (CONCAT("/work/", SUBSTR(STR(?work), 32)) AS ?workUrl)
 WITH{
   SELECT
-    (MIN(?publication_date_) AS ?publication_date) ?work (SAMPLE(?quote_) AS ?quote)
+    (MIN(?publication_date_) AS ?publication_date) ?work
   WHERE {
-    ?work p:P2283 | p:P4510 ?use_statement .
-    ?use_statement (ps:P2283 | ps:P4510)  target: .
+    SERVICE bd:sample { ?work wdt:P4510 target: . bd:serviceParam bd:sample.limit 100000 } .
     ?work wdt:P577 ?publication_datetime .
     BIND(xsd:date(?publication_datetime) AS ?publication_date_)
   }
   GROUP BY ?work
-  LIMIT 10000         
+  ORDER BY DESC(?publication_date)
+  LIMIT 200
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  ?work wdt:P1476 ?title. 
+  FILTER (LANG(?title) = "en")
 }
 ORDER BY DESC(?publication_date)
 LIMIT 200

--- a/scholia/app/templates/use_recent-work-using-the-used.sparql
+++ b/scholia/app/templates/use_recent-work-using-the-used.sparql
@@ -1,23 +1,22 @@
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
-SELECT ?publication_date 
-?work ?title (CONCAT("/work/", SUBSTR(STR(?work), 32)) AS ?workUrl)
+SELECT
+  ?publication_date 
+  ?work ?workLabel (CONCAT("/work/", SUBSTR(STR(?work), 32)) AS ?workUrl)
 WITH{
   SELECT
-    (MIN(?publication_date_) AS ?publication_date) ?work
+    ?publication_datetime
+    ?work
   WHERE {
-    SERVICE bd:sample { ?work wdt:P4510 target: . bd:serviceParam bd:sample.limit 100000 } .
-    ?work wdt:P577 ?publication_datetime .
-    BIND(xsd:date(?publication_datetime) AS ?publication_date_)
+    ?work wdt:P4510 / wdt:P279* target: ;
+          wdt:P577 ?publication_datetime .
   }
-  GROUP BY ?work
-  ORDER BY DESC(?publication_date)
-  LIMIT 200
+  ORDER BY DESC(?publication_datetime)
+  LIMIT 1000
 } AS %result
 WHERE {
   INCLUDE %result
-  ?work wdt:P1476 ?title. 
-  FILTER (LANG(?title) = "en")
+  BIND(xsd:date(?publication_datetime) AS ?publication_date)
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" }
 }
 ORDER BY DESC(?publication_date)
-LIMIT 200

--- a/scholia/app/templates/use_topics-of-works-using-the-resource.sparql
+++ b/scholia/app/templates/use_topics-of-works-using-the-resource.sparql
@@ -9,9 +9,11 @@ WITH{
     ?work wdt:P921 ?topic .
   }
   GROUP BY ?topic
+  LIMIT 100000
 } AS %result
 WHERE {
   INCLUDE %result
   SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,nl,no,ru,sv,zh" . }
 }
 ORDER BY DESC(?count)
+LIMIT 200

--- a/scholia/app/templates/use_topics-of-works-using-the-resource.sparql
+++ b/scholia/app/templates/use_topics-of-works-using-the-resource.sparql
@@ -9,7 +9,7 @@ WITH{
     ?work wdt:P921 ?topic .
   }
   GROUP BY ?topic
-  LIMIT 100000
+  LIMIT 10000
 } AS %result
 WHERE {
   INCLUDE %result

--- a/scholia/app/templates/use_topics-of-works-using-the-resource.sparql
+++ b/scholia/app/templates/use_topics-of-works-using-the-resource.sparql
@@ -2,18 +2,24 @@
 
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
-SELECT ?count ?topic ?topicLabel
+SELECT
+  ?count
+  ?topic ?topicLabel
 WITH{
-  SELECT (COUNT(?work) AS ?count) ?topic WHERE {
-    ?work (wdt:P2283 | wdt:P4510) / wdt:P279* target: .
-    ?work wdt:P921 ?topic .
+  SELECT
+    (COUNT(?work) AS ?count)
+    ?topic
+  WHERE {
+    ?work wdt:P4510 / wdt:P279* target: ; 
+          wdt:P921 ?topic .
   }
   GROUP BY ?topic
-  LIMIT 10000
+  ORDER BY DESC(?count)
+  LIMIT 200
 } AS %result
 WHERE {
   INCLUDE %result
   SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,nl,no,ru,sv,zh" . }
 }
 ORDER BY DESC(?count)
-LIMIT 200
+

--- a/scholia/app/templates/use_usage-over-time.sparql
+++ b/scholia/app/templates/use_usage-over-time.sparql
@@ -2,13 +2,17 @@
 
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
-SELECT ?year (COUNT(?work) AS ?number_of_works) ?useLabel
+SELECT
+  ?year
+  (COUNT(?work) AS ?number_of_works)
+  ?useLabel
 WITH{
   SELECT
     (MIN(?year_) AS ?year) ?work ?use
   WHERE {
-    ?work (wdt:P2283 | wdt:P4510) target: .
-    ?work wdt:P577 ?publication_datetime .
+    ?use wdt:P279* target: .
+    ?work wdt:P4510 ?use ; 
+          wdt:P577 ?publication_datetime .
     BIND(STR(YEAR(?publication_datetime)) AS ?year_)
   }
   GROUP BY ?work ?use

--- a/scholia/app/templates/use_usage-over-time.sparql
+++ b/scholia/app/templates/use_usage-over-time.sparql
@@ -7,8 +7,7 @@ WITH{
   SELECT
     (MIN(?year_) AS ?year) ?work ?use
   WHERE {
-    ?work (wdt:P2283 | wdt:P4510) ?use .
-    ?use wdt:P279* target: .
+    ?work (wdt:P2283 | wdt:P4510) target: .
     ?work wdt:P577 ?publication_datetime .
     BIND(STR(YEAR(?publication_datetime)) AS ?year_)
   }

--- a/scholia/app/templates/venue.html
+++ b/scholia/app/templates/venue.html
@@ -28,6 +28,8 @@
 
 {{ sparql_to_table('citing-venues') }}
 
+{{ sparql_to_table('retractions') }}
+
 {{ sparql_to_table('articles-citing-retracted-articles') }}
 
 
@@ -177,6 +179,10 @@ page to resolve the author names.
 
   <table class="table table-hover" id="most-reused-articles-table"></table>
 </div>
+
+<h2 id="retractions">Retracted articles</h2>
+
+<table class="table table-hover" id="retractions-table"></table>
 
 <h2 id="articles-citing-retracted-articles">Articles citing retracted articles</h2>
 

--- a/scholia/app/templates/venue_retractions.sparql
+++ b/scholia/app/templates/venue_retractions.sparql
@@ -1,0 +1,14 @@
+PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
+
+SELECT DISTINCT ?work ?workLabel ?doi (COUNT(DISTINCT ?citing) AS ?citations) WHERE {
+  { ?work wdt:P31 wd:Q45182324 . }
+  UNION
+  { ?work wdt:P793 wd:Q7316896 . }
+  UNION
+  { ?work wdt:P5824 [] . }
+  OPTIONAL { ?citing wdt:P2860 ?work . }
+  ?work wdt:P1433 target: ; wdt:P356 ?doi .
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+} GROUP BY ?work ?workLabel ?doi
+  ORDER BY DESC(?citations)
+  LIMIT 100

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -1921,7 +1921,7 @@ def show_venue(q):
 
 @main.route('/venue/' + q_pattern + '/cito')
 def show_venue_cito(q):
-    """Return HTML rendering for Citation Typing Ontology annotation of citations.
+    """Return HTML rendering for Citation Typing Ontology annotation.
 
     Parameters
     ----------
@@ -1959,7 +1959,7 @@ def show_venue_use(q1, q2):
 
 @main.route('/work/' + q_pattern + '/cito')
 def show_work_cito(q):
-    """Return HTML rendering for Citation Typing Ontology annotation of citations.
+    """Return HTML rendering for Citation Typing Ontology annotation.
 
     Parameters
     ----------
@@ -1977,7 +1977,7 @@ def show_work_cito(q):
 
 @main.route('/work/' + q_pattern + '/cito/' + q2_pattern)
 def show_work_cito_intention(q, q2):
-    """Return HTML rendering for Citation Typing Ontology annotation of citations.
+    """Return HTML rendering for Citation Typing Ontology annotation.
 
     Parameters
     ----------

--- a/scholia/query.py
+++ b/scholia/query.py
@@ -1307,7 +1307,7 @@ def twitter_to_qs(twitter):
     """
     # This query matches exact and lowercased version of username
     query = """SELECT DISTINCT ?item
-               WHERE {{ VALUES ?username {{ "{twitter}" "{lower}" }} 
+               WHERE {{ VALUES ?username {{ "{twitter}" "{lower}" }}
                         ?item wdt:P2002 ?username }}""".format(
         twitter=escape_string(twitter), lower=escape_string(twitter).lower()
     )

--- a/scholia/query.py
+++ b/scholia/query.py
@@ -1114,6 +1114,7 @@ def q_to_class(q):
             'Q571',  # book
             'Q49848',  # document
             'Q191067',  # article
+            'Q871232'  # editorial
             'Q253623',  # patent
             'Q580922',  # preprint
             'Q685935',  # trade magazine
@@ -1122,7 +1123,9 @@ def q_to_class(q):
             'Q5707594',  # news article
             'Q10870555',  # report
             'Q10885494',  # scientific conference paper
-            'Q13442814',  # scientific article
+            'Q4119870'  # academic writing
+            'Q13442814',  # scholarly article
+            'Q7318358',  # review article
             'Q15621286',  # intellectual work
             'Q17928402',  # blog post
             'Q21481766',  # academic chapter
@@ -1133,6 +1136,11 @@ def q_to_class(q):
             'Q56119332',  # tweet
             'Q58632367',  # conference abstract
             'Q64548048',  # environmental impact assessment report
+            'Q1266946',  # thesis
+            'Q1907875',  # master's thesis
+            'Q187685',  # doctoral thesis
+            'Q815382'  # meta-analysis
+            'Q1778788'  # cohort study
     ]):
         class_ = 'work'
     elif set(classes).intersection([

--- a/scholia/query.py
+++ b/scholia/query.py
@@ -1306,8 +1306,8 @@ def twitter_to_qs(twitter):
 
     """
     # This query matches exact and lowercased version of username
-    query = """select ?item
-               where {{ VALUES ?username {{ "{twitter}" "{lower}" }} 
+    query = """SELECT DISTINCT ?item
+               WHERE {{ VALUES ?username {{ "{twitter}" "{lower}" }} 
                         ?item wdt:P2002 ?username }}""".format(
         twitter=escape_string(twitter), lower=escape_string(twitter).lower()
     )

--- a/scholia/query.py
+++ b/scholia/query.py
@@ -1113,17 +1113,22 @@ def q_to_class(q):
     elif set(classes).intersection([
             'Q571',  # book
             'Q49848',  # document
+            'Q187685',  # doctoral thesis
             'Q191067',  # article
-            'Q871232'  # editorial
+            'Q815382',  # meta-analysis
+            'Q871232',  # editorial
             'Q253623',  # patent
             'Q580922',  # preprint
             'Q685935',  # trade magazine
+            'Q1266946',  # thesis
+            'Q1778788',  # cohort study
+            'Q1907875',  # master's thesis
             'Q1980247',  # chapter
             'Q3331189',  # edition
+            'Q4119870',  # academic writing
             'Q5707594',  # news article
             'Q10870555',  # report
             'Q10885494',  # scientific conference paper
-            'Q4119870'  # academic writing
             'Q13442814',  # scholarly article
             'Q7318358',  # review article
             'Q15621286',  # intellectual work
@@ -1136,11 +1141,6 @@ def q_to_class(q):
             'Q56119332',  # tweet
             'Q58632367',  # conference abstract
             'Q64548048',  # environmental impact assessment report
-            'Q1266946',  # thesis
-            'Q1907875',  # master's thesis
-            'Q187685',  # doctoral thesis
-            'Q815382'  # meta-analysis
-            'Q1778788'  # cohort study
     ]):
         class_ = 'work'
     elif set(classes).intersection([

--- a/scholia/query.py
+++ b/scholia/query.py
@@ -1305,10 +1305,12 @@ def twitter_to_qs(twitter):
     True
 
     """
-    # This query only matches on exact match
+    # This query matches exact and lowercased version of username
     query = """select ?item
-               where {{ ?item wdt:P2002 "{twitter}" }}""".format(
-        twitter=escape_string(twitter))
+               where {{ VALUES ?username {{ "{twitter}" "{lower}" }} 
+                        ?item wdt:P2002 ?username }}""".format(
+        twitter=escape_string(twitter), lower=escape_string(twitter).lower()
+    )
 
     url = 'https://query.wikidata.org/sparql'
     params = {'query': query, 'format': 'json'}

--- a/scholia/scrape/ojs.py
+++ b/scholia/scrape/ojs.py
@@ -373,11 +373,17 @@ def scrape_paper_from_url(url):
     else:
         pages = _field_to_content('DC.Identifier.pageNumber')
     if pages is not None:
-        entry['pages'] = pages
-
         number_of_pages = pages_to_number_of_pages(pages)
         if number_of_pages is not None:
             entry['number_of_pages'] = number_of_pages
+
+        pages_parts = pages.split('-')
+        if len(pages_parts) == 2 and pages_parts[0] == pages_parts[1]:
+            # One-page publication
+            entry['pages'] = pages_parts[0]
+        else:
+            # Multiple pages
+            entry['pages'] = pages
 
     pdf_url = _field_to_content('citation_pdf_url')
     if pdf_url is not None:

--- a/setup.py
+++ b/setup.py
@@ -39,4 +39,9 @@ setup(
         ],
     tests_require=['pytest', 'flake8'],
     version=versioneer.get_version(),
+    entry_points={
+        "console_scripts": [
+            "scholia = scholia.__main__:main",
+        ],
+    },
 )

--- a/tests/test_scrape_ojs.py
+++ b/tests/test_scrape_ojs.py
@@ -1,0 +1,17 @@
+"""Test scholia scrape ojs module."""
+
+
+from scholia.scrape.ojs import scrape_paper_from_url
+
+
+def test_scrape_paper_from_url():
+    """Test scraping of OJS article."""
+    paper = scrape_paper_from_url(
+        'https://tidsskrift.dk/stenomusen/article/view/120902')
+    assert paper['pages'] == "11"
+    assert paper['language_q'] == 'Q9035'
+    assert paper['issue'] == '81'
+    assert paper['title'] == 'Stenomusen på tidsskrift.dk'
+    assert paper['date'] == '2020-06-15'
+    assert (paper['url'] ==
+            'https://tidsskrift.dk/stenomusen/article/view/120902')


### PR DESCRIPTION
Fixes #2070

### Description
> Please include a summary of the change, relevant motivation and context. If possible and applicable, include before and after screenshots and a URL where the changes can be seen.

Added LIMITs to most of the queries and subqueries on the use aspect
    
### Caveats

The use of LIMITS in the (usually unsorted) subqueries means that once those limits are reached (and some are already), then relevant results will not be included in the visualizations. In such cases, it may be more useful to actually have a random selection via something like 

```SPARQL
SERVICE bd:sample { ?work wdt:P4510 target: . bd:serviceParam bd:sample.limit 100000 }
```


> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [X] My changes generate no new warnings
* [X] I have not used code from external sources without attribution
* [X] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [X] There are no remaining debug statements (print, console.log, ...)

### Screenshots
Example: https://scholia.toolforge.org/use/Q1659584
![Screenshot 2022-08-04 at 23-01-22 ImageJ - Scholia](https://user-images.githubusercontent.com/465923/182952103-2a55a383-ff66-43bb-84fe-aa449a499fac.png)
