### PR TITLE
Fix #2079 Too long doc lines

### DIFF
--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -1921,7 +1921,7 @@ def show_venue(q):
 
 @main.route('/venue/' + q_pattern + '/cito')
 def show_venue_cito(q):
-    """Return HTML rendering for Citation Typing Ontology annotation of citations.
+    """Return HTML rendering for Citation Typing Ontology annotation.
 
     Parameters
     ----------
@@ -1959,7 +1959,7 @@ def show_venue_use(q1, q2):
 
 @main.route('/work/' + q_pattern + '/cito')
 def show_work_cito(q):
-    """Return HTML rendering for Citation Typing Ontology annotation of citations.
+    """Return HTML rendering for Citation Typing Ontology annotation.
 
     Parameters
     ----------
@@ -1977,7 +1977,7 @@ def show_work_cito(q):
 
 @main.route('/work/' + q_pattern + '/cito/' + q2_pattern)
 def show_work_cito_intention(q, q2):
-    """Return HTML rendering for Citation Typing Ontology annotation of citations.
+    """Return HTML rendering for Citation Typing Ontology annotation.
 
     Parameters
     ----------


### PR DESCRIPTION
Fixes #2079

### Description
Fixes styling errors
    
### Caveats
There are still some test errors in tox for python3.8 and python3.9

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
`pycodestyle scholia` runs ok. 

`tox py38` does not run ok



### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [ ] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
