### PR TITLE
Added another query to list the number of retracted articles

### DIFF
--- a/scholia/app/templates/index-statistics_statistics.sparql
+++ b/scholia/app/templates/index-statistics_statistics.sparql
@@ -25,7 +25,8 @@ WHERE {
 { {SELECT (COUNT(*) AS ?c) WHERE {[] wdt:P2093 []} } BIND("Author name strings" AS ?d)} UNION
 { {SELECT (COUNT(*) AS ?c) WHERE {[] wdt:P2427 []} } BIND("Items with a GRID ID" AS ?d)} UNION
 { {SELECT (COUNT(*) AS ?c) WHERE {[] wdt:P2860 []} } BIND("Citations" AS ?d)} UNION
-{ {SELECT (COUNT(*) AS ?c) WHERE {[] wdt:P31 wd:Q13442814.} } BIND("Scholarly articles" AS ?d)}
+{ {SELECT (COUNT(*) AS ?c) WHERE {[] wdt:P31 wd:Q13442814.} } BIND("Scholarly articles" AS ?d)} UNION
+{ {SELECT (COUNT(DISTINCT ?work) AS ?c) WHERE { { ?work wdt:P31 wd:Q45182324 . } UNION { ?work wdt:P793 wd:Q7316896 . } UNION { ?work wdt:P5824 [] . } } } BIND("Retracted articles" AS ?d)}
 BIND (?c AS ?count)
 BIND (?d AS ?description)
 }


### PR DESCRIPTION
Fixes [# (issue number, if applicable) ](https://github.com/WDscholia/scholia/issues/2085)

### Description

Make a small addition to the Statistics table to list the number of retracted articles.
    
### Caveats

I ran the query and it does not add significant time to the query and still runs within about 1.2 seconds.

Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

### Testing

I ran the query on the WDQS.

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
