### PR TITLE
Adds a panel to list the retracted articles in this journal

### DIFF
--- a/scholia/app/templates/venue.html
+++ b/scholia/app/templates/venue.html
@@ -28,6 +28,8 @@
 
 {{ sparql_to_table('citing-venues') }}
 
+{{ sparql_to_table('retractions') }}
+
 {{ sparql_to_table('articles-citing-retracted-articles') }}
 
 
@@ -177,6 +179,10 @@ page to resolve the author names.
 
   <table class="table table-hover" id="most-reused-articles-table"></table>
 </div>
+
+<h2 id="retractions">Retracted articles</h2>
+
+<table class="table table-hover" id="retractions-table"></table>
 
 <h2 id="articles-citing-retracted-articles">Articles citing retracted articles</h2>
 

--- a/scholia/app/templates/venue_retractions.sparql
+++ b/scholia/app/templates/venue_retractions.sparql
@@ -1,0 +1,14 @@
+PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
+
+SELECT DISTINCT ?work ?workLabel ?doi (COUNT(DISTINCT ?citing) AS ?citations) WHERE {
+  { ?work wdt:P31 wd:Q45182324 . }
+  UNION
+  { ?work wdt:P793 wd:Q7316896 . }
+  UNION
+  { ?work wdt:P5824 [] . }
+  OPTIONAL { ?citing wdt:P2860 ?work . }
+  ?work wdt:P1433 target: ; wdt:P356 ?doi .
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+} GROUP BY ?work ?workLabel ?doi
+  ORDER BY DESC(?citations)
+  LIMIT 100


### PR DESCRIPTION
Implements #2088 

### Description
   
Adds a panel to list the retracted articles in this journal

### Caveats

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
No code changes.

### Testing

Tox tests with Python3.9 show no problems:

```
_________________________________________________________________________________________________________________________________________ summary _________________________________________________________________________________________________________________________________________
  flake8: commands succeeded
  pydocstyle: commands succeeded
ERROR:  py37: InterpreterNotFound: python3.7
ERROR:  py38: InterpreterNotFound: python3.8
  py39: commands succeeded
```

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
