### PR TITLE
Add message when query returns no matches

### DIFF
--- a/scholia/app/static/scholia.js
+++ b/scholia/app/static/scholia.js
@@ -285,53 +285,75 @@ function sparqlToDataTable(sparql, element, filename, options = {}) {
 
         convertedData = convertDataTableData(simpleData.data, simpleData.columns);
         columns = [];
-        for (i = 0; i < convertedData.columns.length; i++) {
-            var column = {
-                data: convertedData.columns[i],
-                title: capitalizeFirstLetter(convertedData.columns[i]).replace(/_/g, "&nbsp;"),
-                defaultContent: "",
+        if (convertedData.data.length > 0) {
+            for (i = 0; i < convertedData.columns.length; i++) {
+                var column = {
+                    data: convertedData.columns[i],
+                    title: capitalizeFirstLetter(convertedData.columns[i]).replace(/_/g, "&nbsp;"),
+                    defaultContent: "",
+                }
+                if (column['title'] == 'Count') {
+                  // check that the count is not a link
+                  if (convertedData.data[0]["count"][0] != "<") {
+                    column['render'] = $.fn.dataTable.render.number(',', '.');
+                  }
+                  if (i == 0) {
+                    column['className'] = 'dt-right';
+                  }
+                } else if (
+                  column['title'] == 'Score' ||
+                  column['title'] == 'Distance' ||
+                  /\Wper\W/.test(column['title'])
+                ) {
+                  column['render'] = $.fn.dataTable.render.number(',', '.', 2);
+                }
+                columns.push(column);
             }
-            if (column['title'] == 'Count') {
-              // check that the count is not a link
-              if (convertedData.data[0]["count"][0] != "<") {
-                column['render'] = $.fn.dataTable.render.number(',', '.');
-              }
-              if (i == 0) {
-                column['className'] = 'dt-right';
-              }
-            } else if (
-              column['title'] == 'Score' ||
-              column['title'] == 'Distance' ||
-              /\Wper\W/.test(column['title'])
-            ) {
-              column['render'] = $.fn.dataTable.render.number(',', '.', 2);
+
+            if (convertedData.data.length <= 10) {
+                paging = false;
             }
-            columns.push(column);
+
+            $(element).html(""); // remove loader
+
+            var table = $(element).DataTable({
+                data: convertedData.data,
+                columns: columns,
+                lengthMenu: [[10, 25, 100, -1], [10, 25, 100, "All"]],
+                ordering: true,
+                order: [],
+                paging: paging,
+                sDom: sDom,
+                scrollX: false,
+                language: {
+                  emptyTable: "This query yielded no results. ",
+                  sZeroRecords: "This query yielded no results."
+                }
+            });
+
+            $(element).append(datatableFooter);
+        } else {
+            $(element).html(''); // remove loader
+
+            $(element).DataTable({
+                data: [],
+                lengthChange: false,
+                searching: false,
+                paging: false,
+                ordering: true,
+                order: [],
+                sDom: sDom,
+                scrollX: false,
+                language: {
+                    emptyTable: 'This query yielded no results. ',
+                    sZeroRecords: 'This query yielded no results.',
+                },
+            });
+
+            $(element).append(datatableFooter);
         }
-	
-        if (convertedData.data.length <= 10) {
-            paging = false;
-        }
-
-        $(element).html(""); // remove loader
-
-        var table = $(element).DataTable({ 
-            data: convertedData.data,
-            columns: columns,
-            lengthMenu: [[10, 25, 100, -1], [10, 25, 100, "All"]],
-            ordering: true,
-            order: [],
-            paging: paging,
-            sDom: sDom,
-            scrollX: false,
-            language: {
-              emptyTable: "This query yielded no results. ",
-              sZeroRecords: "This query yielded no results."
-            }
-        });
-
-        $(element).append(datatableFooter);
     }).fail(function () {
+        $(element).html(''); // remove loader
         $(element).prepend(
             '<p>This query has timed out, we recommend that you follow the link to the Wikidata Query Service below to modify the query to be less intensive. </p> '
         );


### PR DESCRIPTION
Fixes #2037

### Description
> Please include a summary of the change, relevant motivation and context. If possible and applicable, include before and after screenshots and a URL where the changes can be seen.
    
This was a great bug to catch! As of now when a query with a count column returns no matches it errors and loads forever:
![image](https://user-images.githubusercontent.com/6676843/188759602-88dbaa36-416a-4571-8920-9ef9589070f1.png)

I have instead added a message to communicate to the user

![image](https://user-images.githubusercontent.com/6676843/188759541-5ac5e674-a08d-4a85-9199-a607de27b34d.png)

Additionally I have removed the loader when the query fails

### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* Test A
* Test B

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
