### PR TITLE
Adding chemical classes found in taxa

### DIFF
--- a/scholia/app/templates/chemical-class.html
+++ b/scholia/app/templates/chemical-class.html
@@ -9,6 +9,7 @@
 {{ sparql_to_table('related-chemicals') }}
 {{ sparql_to_table('recent-literature') }}
 {{ sparql_to_iframe('publications-per-year') }}
+{{ sparql_to_table('found-in-taxon') }}
 
 {% endblock %}
 
@@ -40,6 +41,10 @@
 <div class="embed-responsive embed-responsive-16by9">
   <iframe class="embed-responsive-item" id="publications-per-year-iframe" ></iframe>
 </div>
+
+<h2 id="found-in-taxon">Taxa in which the chemical class was found</h2>
+
+<table class="table table-hover" id="found-in-taxon-table"></table>
 
 {% endblock %}
     

--- a/scholia/app/templates/chemical-class_found-in-taxon.sparql
+++ b/scholia/app/templates/chemical-class_found-in-taxon.sparql
@@ -1,0 +1,15 @@
+PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
+
+SELECT DISTINCT ?taxon ?taxonLabel (CONCAT("/taxon/", SUBSTR(STR(?taxon), 32)) AS ?taxonUrl) (COUNT(DISTINCT(?chemical)) AS ?count) WHERE {
+  ?chemical wdt:P31/wdt:P279* target: ;
+            p:P703 ?taxonStatement .
+  ?taxonStatement ps:P703 ?taxon .
+  OPTIONAL {
+      ?taxonStatement prov:wasDerivedFrom/pr:P248 ?source .
+      OPTIONAL { ?source wdt:P356 ?DOI . }
+    }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+} 
+  GROUP BY ?taxon ?taxonLabel
+  ORDER BY DESC(?count)
+  LIMIT 250


### PR DESCRIPTION
### Description
The changes include a new table on the `chemical class` page.
Motivation is to access taxa producing specific chemical classes.
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* No specific tests, just the ones of the CI

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
