### PR TITLE
replace {{ q }} expression with target: expression in topic_uses.sparql

### DIFF
--- a/scholia/app/templates/topic_uses.sparql
+++ b/scholia/app/templates/topic_uses.sparql
@@ -4,7 +4,7 @@ SELECT
   ?count
   ?use ?useLabel (CONCAT("/use/", SUBSTR(STR(?use), 32)) AS ?useUrl)
   ("🔎" AS ?zoom)
-  (CONCAT("{{ q }}/use/", SUBSTR(STR(?use), 32)) AS ?zoomUrl)
+  (CONCAT(SUBSTR(STR(target:), 32), "/use/", SUBSTR(STR(?use), 32)) AS ?zoomUrl)
   ?useDescription
 
   ?example_work ?example_workLabel


### PR DESCRIPTION
Fixes # (issue number, if applicable) 

### Description
This is a simple replacement of one expression with another that achieve identical functionality in terms of the Scholia content to be displayed but differ in that the new version makes it easier to adapt the query to another QID.

### Caveats

There are probably a number of similar cases throughout the code base, which I have not explored.

Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* Go to https://scholia.toolforge.org/topic/Q202864#uses
Table looks as expected:
![image](https://user-images.githubusercontent.com/465923/193451201-2f99b340-09ab-4607-b3a2-da259404cf7a.png)

Click on "Wikidata Query Service" and check query source code
![image](https://user-images.githubusercontent.com/465923/193451150-3b8d2609-ec02-4749-97d9-e70f8db26117.png)

* Go to /topic/Q202864#uses while on branch ```Reuse-target-in-topic-uses-2111```
Table looks as expected:
![image](https://user-images.githubusercontent.com/465923/193451346-c665a61e-ae65-4779-ad35-0d26a930a30f.png)

Click on "Wikidata Query Service" and check query source code
![image](https://user-images.githubusercontent.com/465923/193451432-fa03c7a8-c317-4716-96a4-0b7301a8c2d3.png)

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [ ] My changes generate no new warnings
* [ ] I have not used code from external sources without attribution
* [ ] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [ ] There are no remaining debug statements (print, console.log, ...)
