### PR TITLE
Create vanity CLI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,4 +39,9 @@ setup(
         ],
     tests_require=['pytest', 'flake8'],
     version=versioneer.get_version(),
+    entry_points={
+        "console_scripts": [
+            "scholia = scholia.__main__:main",
+        ],
+    },
 )


### PR DESCRIPTION
This uses entrypoints to create a vanity CLI, so rather than needing to do `python -m scholia ...`, you can just do `scholia ...`. To test this code, you must reinstall Scholia, entrypoints do not get updated on editable installations without doing `pip install .` or `pip install -e .` again.

There was previous discussion about this in https://github.com/WDscholia/scholia/pull/1471 but for some reason there were issues. I'm hoping that now the project has modernized a bit that this is non-controversial.
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [x]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* Test A
* Test B

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
