### PR TITLE
Fix #2118 software index used wrong property

### DIFF
--- a/scholia/app/templates/software-index_most-used-software.sparql
+++ b/scholia/app/templates/software-index_most-used-software.sparql
@@ -6,7 +6,7 @@ WITH {
     (SAMPLE(?described_by) AS ?described_by_example)
     (SAMPLE(?work) AS ?example_use)
   WHERE {
-    ?work wdt:P2283 ?software . 
+    ?work wdt:P4510 ?software . 
     ?software wdt:P31/wdt:P279* wd:Q7397 . 
     # Restricting to work takes too long time :(    
     # ?work wdt:P31/wdt:P279* wd:Q386724 .


### PR DESCRIPTION
The "most used software" aspect in the software index used the P2283 propety. The more relevant property would be P4510.

Fixes #2118

### Description
Single line change in SPARQL query
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* I checked http://127.0.0.1:8100/software/

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
