### PR TITLE
Fix #2120 link in software index

### DIFF
--- a/scholia/app/templates/software-index_most-used-software.sparql
+++ b/scholia/app/templates/software-index_most-used-software.sparql
@@ -1,8 +1,13 @@
-SELECT ?count ?software ?softwareLabel ?described_by_example ?described_by_exampleLabel ?example_use ?example_useLabel
+SELECT
+  ?count
+  ?software ?softwareLabel ?softwareUrl
+  ?described_by_example ?described_by_exampleLabel
+  ?example_use ?example_useLabel
 WITH {
   SELECT
     (COUNT(DISTINCT ?work) AS ?count)
     ?software
+    (CONCAT("/software/", SUBSTR(STR(?software), 32)) AS ?softwareUrl)
     (SAMPLE(?described_by) AS ?described_by_example)
     (SAMPLE(?work) AS ?example_use)
   WHERE {


### PR DESCRIPTION
"Software" column in "most used software" panel on the software index page did not direct to the appropriate 'software' aspect. It now does.

Fixes #2120

### Description
Include a explicit ?softwareUrl for the link.
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* Checked http://127.0.0.1:8100/software/

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
