### PR TITLE
Fix #1233 1-page OJS articles

### DIFF
--- a/scholia/scrape/ojs.py
+++ b/scholia/scrape/ojs.py
@@ -373,11 +373,17 @@ def scrape_paper_from_url(url):
     else:
         pages = _field_to_content('DC.Identifier.pageNumber')
     if pages is not None:
-        entry['pages'] = pages
-
         number_of_pages = pages_to_number_of_pages(pages)
         if number_of_pages is not None:
             entry['number_of_pages'] = number_of_pages
+
+        pages_parts = pages.split('-')
+        if len(pages_parts) == 2 and pages_parts[0] == pages_parts[1]:
+            # One-page publication
+            entry['pages'] = pages_parts[0]
+        else:
+            # Multiple pages
+            entry['pages'] = pages
 
     pdf_url = _field_to_content('citation_pdf_url')
     if pdf_url is not None:

--- a/tests/test_scrape_ojs.py
+++ b/tests/test_scrape_ojs.py
@@ -1,0 +1,17 @@
+"""Test scholia scrape ojs module."""
+
+
+from scholia.scrape.ojs import scrape_paper_from_url
+
+
+def test_scrape_paper_from_url():
+    """Test scraping of OJS article."""
+    paper = scrape_paper_from_url(
+        'https://tidsskrift.dk/stenomusen/article/view/120902')
+    assert paper['pages'] == "11"
+    assert paper['language_q'] == 'Q9035'
+    assert paper['issue'] == '81'
+    assert paper['title'] == 'Stenomusen på tidsskrift.dk'
+    assert paper['date'] == '2020-06-15'
+    assert (paper['url'] ==
+            'https://tidsskrift.dk/stenomusen/article/view/120902')


### PR DESCRIPTION
Now one-page OJS articles are display with only a single number

Fixes #1233

### Description
Change from, e.g., "11-11" to "11"
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [x]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* Pull request includes a new test file
* `scholia.scrape.ojs.scrape_paper_from_url("https://tidsskrift.dk/stenomusen/article/view/120902")`

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
