### PR TITLE
Color counts by citation annotation source

### DIFF
--- a/scholia/app/templates/cito-index_articles-by-year.sparql
+++ b/scholia/app/templates/cito-index_articles-by-year.sparql
@@ -1,11 +1,20 @@
 #defaultView:BarChart
-select ?year (count(?work) as ?number_of_publications) where {
-  select ?work (min(?years) as ?year) where {
-    ?work wdt:P577 ?dates ;
-          p:P2860 / pq:P3712 / wdt:P31 wd:Q96471816 .
-    bind(str(year(?dates)) as ?years) .
+select ?year (count(?work) as ?number_of_publications) ?role where {
+  {
+    select ?work (min(?years) as ?year) ?type_ where {
+      ?work wdt:P577 ?dates ;
+            p:P2860 / pq:P3712 / wdt:P31 wd:Q96471816 .
+      bind(str(year(?dates)) as ?years) .
+      OPTIONAL { ?work wdt:P31 wd:Q109229154 . bind("explicit" as ?type_) }
+    }
+    group by ?work ?type_
   }
-  group by ?work
+  bind(
+    coalesce(
+      if(bound(?type_), 'in article',
+      'other source')
+    ) as ?role
+  )
 }
-group by ?year
+group by ?year ?role
 order by ?year


### PR DESCRIPTION
Updated query that colors by where the CiTO annotation comes from. Two options right now: 1. from the article itself, and 2. from other sources.

Before:

![image](https://user-images.githubusercontent.com/26721/196040862-e6f9d3b4-cf08-441a-a4bc-f56d966383a1.png)

After:

![image](https://user-images.githubusercontent.com/26721/196040843-200c4e12-0df0-4ec1-9d69-740354c633c9.png)
