### PR TITLE
Fix #2109 add Portugese to Wikipedia mention table

### DIFF
--- a/scholia/app/templates/work_wikipedia-mentions.sparql
+++ b/scholia/app/templates/work_wikipedia-mentions.sparql
@@ -66,6 +66,22 @@ WHERE {
       BIND(wd:Q8447 AS ?wikipedia)
     }     
   }
+  UNION
+  {
+    SELECT ?title_ ?titleUrl ?item ?wikipedia {
+      SERVICE wikibase:mwapi {
+        bd:serviceParam wikibase:endpoint "pt.wikipedia.org" ;
+                        wikibase:api "Generator" ;
+			mwapi:generator "search" ;
+                        mwapi:gsrsearch '{{ q }}{% for doi in dois %} OR "{{ doi }}"{% endfor %}' ;
+                        mwapi:gsrlimit "200" .
+        ?title_ wikibase:apiOutput mwapi:title .
+	?item wikibase:apiOutputItem mwapi:item .
+      }
+      BIND(URI(CONCAT("https://pt.wikipedia.org/wiki/", ENCODE_FOR_URI(REPLACE(?title_, " ", "_")))) AS ?titleUrl)
+      BIND(wd:Q11921 AS ?wikipedia)
+    }     
+  }
   hint:Prior hint:runFirst "true" .
   BIND(CONCAT(?title_, "&nbsp;↗") AS ?title)
   SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }


### PR DESCRIPTION
This change still does not search across all Wikipedia, but only adds one more Wikipedia to search.

Fixes #2109

### Description
This is only a partially implementation of #2109. Only Portuguese Wikipedia is added to search.
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* http://127.0.0.1:8100/work/Q22242083#wikipedia-mentions

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
