### PR TITLE
Fix #2136 for negative academic age

### DIFF
--- a/scholia/app/templates/work_list-of-authors.sparql
+++ b/scholia/app/templates/work_list-of-authors.sparql
@@ -41,7 +41,7 @@ WHERE {
     SELECT ?author_ (MAX(?academic_age_) AS ?academic_age) {
       target: wdt:P50 ?author_ ;
                  wdt:P577 ?publication_date .
-      [] wdt:P31 wd:Q13442814 ;
+      [] wdt:P31 / wdt:P279* wd:Q55915575 ;
          wdt:P50 ?author_ ;
          wdt:P577 ?other_publication_date .
       BIND(YEAR(?publication_date) - YEAR(?other_publication_date) AS ?academic_age_)


### PR DESCRIPTION
Extended the definition of when the academic age begins: Before it was a scholar article, now it is a subclass of scholarly work, so, e.g., conference articles also counts.

Fixes #2136

### Description
See above
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* http://127.0.0.1:8100/work/Q24319057

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
