### PR TITLE
1438 scraper for ceur workshop proceedings

### DIFF
--- a/scholia/app/templates/work_list-of-authors.sparql
+++ b/scholia/app/templates/work_list-of-authors.sparql
@@ -41,7 +41,7 @@ WHERE {
     SELECT ?author_ (MAX(?academic_age_) AS ?academic_age) {
       target: wdt:P50 ?author_ ;
                  wdt:P577 ?publication_date .
-      [] wdt:P31 wd:Q13442814 ;
+      [] wdt:P31 / wdt:P279* wd:Q55915575 ;
          wdt:P50 ?author_ ;
          wdt:P577 ?other_publication_date .
       BIND(YEAR(?publication_date) - YEAR(?other_publication_date) AS ?academic_age_)

--- a/scholia/qs.py
+++ b/scholia/qs.py
@@ -119,3 +119,135 @@ def paper_to_quickstatements(paper):
         qs += 'LAST\tP1433\t{}\n'.format(paper['published_in_q'])
 
     return qs
+
+
+def proceedings_to_quickstatements(proceedings):
+    """Convert proceedings to Quickstatements.
+
+    Convert a paper represented as a dict in to Magnus Manske's
+    Quickstatement format for entry into Wikidata.
+
+    Parameters
+    ----------
+    proceedings : dict
+        Scraped paper represented as a dict.
+
+    Returns
+    -------
+    qs : str
+        Quickstatements as a string
+
+    References
+    ----------
+    https://quickstatements.toolforge.org
+
+    Notes
+    -----
+    title, authors (list), date, doi, year, language_q, volume, issue, pages,
+    number_of_pages, url, full_text_url, published_in_q are recognized.
+
+    `date` takes precedence over `year`.
+
+    The label is shortened to 250 characters due if the title is longer than
+    that due to a limitation in Wikidata.
+
+    """
+    qs = u("CREATE\n")
+
+    if 'title' in proceedings and proceedings['title']:
+        title = escape_string(proceedings['title'])
+
+        # "Label must be no more than 250 characters long"
+        short_title = escape_string(title)[:250]
+        while short_title.endswith("\\"):
+            short_title = short_title[:-1]
+
+        qs += u('LAST\tLen\t"{}"\n').format(short_title)
+
+    # Instance of proceedings
+    qs += 'LAST\tP31\tQ1143604\n'
+
+    # Language
+    iso639 = proceedings.get('iso639', 'en')
+
+    # Title
+    if 'title' in proceedings and proceedings['title']:
+        qs += u('LAST\tP1476\t{}:"{}"\n').format(iso639, title)
+
+    if 'shortname' in proceedings:
+        qs += u('LAST\tP1813\t{}:"{}"\n').format(
+            iso639, proceedings['shortname'])
+        qs += u('LAST\tA{}\t"{}"\n').format(
+            iso639, proceedings['shortname'])
+        qs += u('LAST\tDen\t"proceedings from {}"\n').format(
+            proceedings['shortname'])
+
+    # DOI
+    if 'doi' in proceedings:
+        qs += u('LAST\tP356\t"{}"\n').format(escape_string(proceedings['doi']))
+
+    # Authors
+    if 'authors' in proceedings:
+        for n, author in enumerate(proceedings['authors'], start=1):
+            qs += u('LAST\tP2093\t"{}"\tP1545\t"{}"\n').format(author, n)
+
+    # Published in
+    if 'date' in proceedings:
+        # Day precision
+        if len(proceedings['date']) == 4:
+            # Only year available
+            qs += 'LAST\tP577\t+{}-00-00T00:00:00Z/9\n'.format(
+                proceedings['date'])
+        elif len(proceedings['date']) == 7:
+            # Year and month only
+            qs += 'LAST\tP577\t+{}-00T00:00:00Z/10\n'.format(
+                proceedings['date'])
+        elif len(proceedings['date']) == 10:
+            # Year, month and day available
+            qs += 'LAST\tP577\t+{}T00:00:00Z/11\n'.format(proceedings['date'])
+        else:
+            # Unknown date format
+            pass
+
+    elif 'year' in proceedings:
+        # Year precision
+        qs += 'LAST\tP577\t+{}-00-00T00:00:00Z/9\n'.format(proceedings['year'])
+
+    # Volume
+    if 'volume' in proceedings:
+        qs += u('LAST\tP478\t"{}"\n').format(
+            escape_string(proceedings['volume']))
+
+    # Issue
+    if 'issue' in proceedings:
+        qs += u('LAST\tP433\t"{}"\n').format(
+            escape_string(proceedings['issue']))
+
+    if 'pages' in proceedings:
+        qs += u('LAST\tP304\t"{}"\n').format(
+            escape_string(proceedings['pages']))
+
+    if 'number_of_pages' in proceedings:
+        qs += u('LAST\tP1104\t{}\n').format(proceedings['number_of_pages'])
+
+    # Language
+    if 'language_q' in proceedings:
+        qs += 'LAST\tP407\t{}\n'.format(proceedings['language_q'])
+
+    # Homepage
+    if 'url' in proceedings:
+        qs += 'LAST\tP856\t"{}"\n'.format(proceedings['url'])
+
+    # Fulltext URL
+    if 'full_text_url' in proceedings:
+        qs += 'LAST\tP953\t"{}"\n'.format(proceedings['full_text_url'])
+
+    # Published in
+    if 'published_in_q' in proceedings and proceedings['published_in_q']:
+        qs += 'LAST\tP1433\t{}\n'.format(proceedings['published_in_q'])
+
+    # URN-NBN
+    if 'urn' in proceedings:
+        qs += 'LAST\tP4109\t"{}"\n'.format(proceedings['urn'])
+
+    return qs

--- a/scholia/scrape/ceurws.py
+++ b/scholia/scrape/ceurws.py
@@ -1,0 +1,373 @@
+r"""Scraping CEUR Workshop Proceedings.
+
+Usage:
+  scholia.scrape.ceurws proceedings-url-to-quickstatements [options] <url>
+
+Options:
+  --iso639=iso639  Overwrite default iso639 [default: en]
+  -o --output=file  Output filename, default output to stdout
+  --oe=encoding     Output encoding [default: utf-8]
+
+Examples
+--------
+$ python -m scholia.scrape.ceurws proceedings-url-to-quickstatements \
+    http://ceur-ws.org/Vol-3235/
+
+"""
+
+
+import os
+import os.path
+
+import re
+
+import signal
+
+from six import b, u
+
+from lxml import etree
+
+import requests
+
+from ..qs import paper_to_quickstatements, proceedings_to_quickstatements
+from ..query import iso639_to_q
+from ..utils import escape_string
+
+
+USER_AGENT = 'Scholia'
+
+HEADERS = {'User-Agent': USER_AGENT}
+
+PAPER_TO_Q_QUERY = u("""
+SELECT ?paper WHERE {{
+  OPTIONAL {{ ?label rdfs:label "{label}"@en . }}
+  OPTIONAL {{ ?title wdt:P1476 "{title}"@en . }}
+  OPTIONAL {{ ?full_text_url wdt:P953 <{url}> . }}
+  OPTIONAL {{ ?url wdt:P856 <{url}> . }}
+  BIND(COALESCE(?full_text_url, ?url, ?label, ?title, ?doi) AS ?paper)
+}}
+""")
+
+SHORT_TITLED_PAPER_TO_Q_QUERY = u("""
+SELECT ?paper WHERE {{
+  OPTIONAL {{ ?full_text_url wdt:P953 <{url}> . }}
+  OPTIONAL {{ ?url wdt:P856 <{url}> . }}
+  BIND(COALESCE(?full_text_url, ?url) AS ?paper)
+}}
+""")
+
+
+# SPARQL Endpoint for Wikidata Query Service
+WDQS_URL = 'https://query.wikidata.org/sparql'
+
+
+def url_to_volume(url):
+    """Extract volume from CEUR WS URL.
+
+    Parameters
+    ----------
+    url : str
+        URL to a CEUR WS proceedings.
+
+    Returns
+    -------
+    str : str or None
+        String representing volume number.
+
+    Example
+    -------
+    >>> url = "http://ceur-ws.org/Vol-3235/"
+    >>> url_to_volume(url)
+    '3235'
+
+    """
+    volumes = re.findall(r'Vol-(\d+)', url)
+    if len(volumes) == 1:
+        return volumes[0]
+    else:
+        return None
+
+
+def tree_to_papers(tree, proceedings, proceedings_q, iso639='en'):
+    """Extract the set of individual CEUR WD papers.
+
+    Parameters
+    ----------
+    tree : etree.HTML
+        Object with parsed HTML.
+    proceedings : dict
+        Dictionary with proceedings
+    proceedings_q : str
+        String with Q-identifier for proceedings
+    iso639 : str, optional
+        ISO 639 language specification. The default is 'en'.
+
+    Returns
+    -------
+    papers : list of dictionaries
+        List with papers as dictionaries.
+
+    """
+    n = 1
+    papers = []
+    toc_elements = tree.xpath('//div[@class="CEURTOC"]')
+    if len(toc_elements) == 0:
+        # Cannot find papers
+        return papers
+    paper_elements = toc_elements[0].xpath(".//li")
+    for element in paper_elements:
+        title_elements = element.xpath(".//span[@class='CEURTITLE']")
+        if len(title_elements) == 0:
+            # Probably a preface
+            continue
+        paper = {
+            'published_in_q': proceedings_q,
+            'date': proceedings['date'],
+            'full_text_url': os.path.join(
+                proceedings['url'],
+                element.xpath(".//a")[0].attrib['href']),
+            'title':
+            re.sub(r'\s+', ' ',
+                   title_elements[0].text),
+            'authors': [author_element.text
+                        for author_element in
+                        element.xpath(".//span[@class='CEURAUTHOR']")],
+        }
+        if iso639 is not None:
+            paper['iso639'] = iso639
+            paper['language_q'] = iso639_to_q(iso639)
+        papers.append(paper)
+        n += 1
+    return papers
+
+
+def proceedings_url_to_quickstatements(url, iso639='en'):
+    """Return Quickstatements for a CEUR WD.
+
+    From a CEUR Workshop Proceedings URL extract metadata for the proceedings
+    and the individual papers and format them in the Quickstatement format for
+    entry in Wikidata.
+
+    Parameters
+    ----------
+    url : str
+        URL for a CEUR Workshop Series proceedings.
+    iso639 : str, optional
+        String with ISO639 code. Default is 'en', meaning English.
+
+    Returns
+    -------
+    qs : str
+        String with quickstatements.
+
+    """
+    proceedings, tree = proceedings_url_to_proceedings(url, return_tree=True)
+
+    # Check if proceedings is already in Wikidata
+    q = paper_to_q(proceedings)
+    if q:
+        qs = "# {} is https://www.wikidata.org/entity/{}\n".format(url, q)
+        papers = tree_to_papers(tree, proceedings, proceedings_q=q,
+                                iso639=iso639)
+        for paper in papers:
+
+            # Check if paper is already in Wikidata
+            q = paper_to_q(paper)
+            if q:
+                qs += "# {} is https://www.wikidata.org/entity/{}\n".format(
+                    paper['full_text_url'], q)
+            else:
+                qs += paper_to_quickstatements(paper)
+                qs += '\n'
+    else:
+        if iso639 is not None:
+            proceedings['iso639'] = iso639
+            proceedings['language_q'] = iso639_to_q(iso639)
+
+        qs = proceedings_to_quickstatements(proceedings)
+    return qs
+
+
+def paper_to_q(paper):
+    """Find Q identifier for paper.
+
+    Parameters
+    ----------
+    paper : dict
+        Paper represented as dictionary.
+
+    Returns
+    -------
+    q : str or None
+        Q identifier in Wikidata. None is returned if the paper is not found.
+
+    Notes
+    -----
+    This function might be used to test if a scraped CEUR WS paper is already
+    present in Wikidata.
+
+    The match on title is using an exact query, meaning that any variation in
+    lowercase/uppercase will not find the Wikidata item. If the title is
+    shorter than 21 character then only the URL is used to match.
+
+    Examples
+    --------
+    >>> paper = {
+    ...     'title': ('Wikibase as an Infrastructure for Community Documents: '
+    ...               'The example of the Disability Wiki Platform'),
+    ...     'full_text_url': 'http://ceur-ws.org/Vol-3235/paper14.pdf'}
+    >>> paper_to_q(paper)
+    'Q114774462'
+
+    """
+    if 'full_text_url' in paper:
+        url = paper['full_text_url']
+    elif 'url' in paper:
+        url = paper['url']
+    else:
+        raise Exception("`url` field missing in paper dictionary")
+
+    if 'title' in paper and len(paper['title']) > 20:
+        title = escape_string(paper['title'])
+
+        query = PAPER_TO_Q_QUERY.format(
+            label=title, title=title,
+            url=url)
+    else:
+        # The title is too short to match. Too many wrong matches.
+        query = SHORT_TITLED_PAPER_TO_Q_QUERY.format(
+            url=url)
+
+    response = requests.get(WDQS_URL,
+                            params={'query': query, 'format': 'json'},
+                            headers=HEADERS)
+    data = response.json()['results']['bindings']
+
+    if len(data) == 0 or not data[0]:
+        # Not found
+        return None
+
+    return str(data[0]['paper']['value'][31:])
+
+
+def paper_url_to_q(url):
+    """Return Q identifier based on URL.
+
+    From CEUR WS URL query Wikidata Query Service to find the Wikidata Q
+    identifier.
+
+    Parameters
+    ----------
+    url : str
+        URL to CEUR WD paper.
+
+    Returns
+    -------
+    q : str or None
+        Q identifier for Wikidata or None if not found.
+
+    Examples
+    --------
+    >>> url ='http://ceur-ws.org/Vol-3235/paper14.pdf'
+    >>> paper_url_to_q(url)
+    'Q114774462'
+
+    """
+    paper = {'full_text_url': url}
+    q = paper_to_q(paper)
+    return q
+
+
+def proceedings_url_to_proceedings(url, return_tree=False):
+    """Scrape OJS paper from URL.
+
+    Arguments
+    ---------
+    url : str
+        URL to paper as a string
+    return_tree : Bool
+        Whether to return HTML etree.
+
+    Returns
+    -------
+    proceedings : dict
+        Paper represented as a dictionary.
+    tree : etree.HTML
+        Object with parse HTML.
+
+    Example
+    -------
+    >>> url = 'http://ceur-ws.org/Vol-3235/'
+    >>> proceedings = proceedings_url_to_proceedings(url)
+    >>> proceedings['shortname'] == 'SEMPDW 2022'
+    True
+    >>> proceedings['volume'] == '3235'
+    True
+    >>> proceedings['urn'] == 'urn:nbn:de:0074-3235-0'
+    True
+    >>> proceedings['title'].startswith('Proceedings of Poster and Demo Track')
+    True
+
+    """
+    proceedings = {
+        'url': url,
+        'volume': url_to_volume(url),
+    }
+
+    # Download a paper from ceur-ws.org
+    response = requests.get(url)
+    tree = etree.HTML(response.content)
+
+    proceedings['shortname'] = \
+        tree.xpath("//span[@class='CEURVOLACRONYM']")[0].text
+
+    proceedings['urn'] = \
+        tree.xpath("//span[@class='CEURURN']")[0].text
+
+    proceedings['title'] = \
+        tree.xpath("//span[@class='CEURFULLTITLE']")[0].text
+
+    proceedings['date'] = \
+        tree.xpath("//span[@class='CEURPUBDATE']")[0].text
+
+    proceedings['published_in_q'] = 'Q27230297'
+
+    if return_tree:
+        return (proceedings, tree)
+    else:
+        return proceedings
+
+
+def main():
+    """Handle command-line interface."""
+    from docopt import docopt
+
+    arguments = docopt(__doc__)
+
+    if arguments['--iso639']:
+        iso639 = arguments['--iso639']
+    else:
+        iso639 = None
+
+    if arguments['--output']:
+        output_filename = arguments['--output']
+        output_file = os.open(output_filename, os.O_RDWR | os.O_CREAT)
+    else:
+        # stdout
+        output_file = 1
+    output_encoding = arguments['--oe']
+
+    # Ignore broken pipe errors
+    signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+
+    if arguments['proceedings-url-to-quickstatements']:
+        url = arguments['<url>']
+        qs = proceedings_url_to_quickstatements(url, iso639=iso639)
+        os.write(output_file, qs.encode(output_encoding) + b('\n'))
+
+    else:
+        assert False
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes #1438

### Description
Scraper for CEUR Workshop Series. The scraper has not been tested on all volumes. Perhaps early proceedings will fail.
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [x]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* For instance `python -m scholia.scrape.ceurws proceedings-url-to-quickstatements http://ceur-ws.org/Vol-2982/`

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
