### PR TITLE
Fix #2139 acronym CEUR scraper

### DIFF
--- a/scholia/scrape/ceurws.py
+++ b/scholia/scrape/ceurws.py
@@ -318,8 +318,13 @@ def proceedings_url_to_proceedings(url, return_tree=False):
     response = requests.get(url)
     tree = etree.HTML(response.content)
 
-    proceedings['shortname'] = \
-        tree.xpath("//span[@class='CEURVOLACRONYM']")[0].text
+    acronym_elements = tree.xpath("//span[@class='CEURVOLACRONYM']")
+    if len(acronym_elements) == 1:
+        proceedings['shortname'] = acronym_elements[0].text
+    else:
+        acronym_elements = tree.xpath("//h1/a")
+        if len(acronym_elements) == 1:
+            proceedings['shortname'] = acronym_elements[0].text
 
     proceedings['urn'] = \
         tree.xpath("//span[@class='CEURURN']")[0].text


### PR DESCRIPTION
Fixes #2139

### Description
CEUR scrape could err when the 'CEURVOLACRONYM' was not set on the page. Now there is a workaround.
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [x]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

*  `python -m scholia.scrape.ceurws proceedings-url-to-quickstatements http://ceur-ws.org/Vol-3246/` works

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
