### PR TITLE
Fix #2143 and fix #2141 CEUR scraping errors

### DIFF
--- a/scholia/scrape/ojs.py
+++ b/scholia/scrape/ojs.py
@@ -33,7 +33,7 @@ import requests
 
 from ..qs import paper_to_quickstatements
 from ..query import iso639_to_q, issn_to_qs
-from ..utils import escape_string
+from ..utils import escape_string, pages_to_number_of_pages
 
 
 USER_AGENT = 'Scholia'
@@ -125,36 +125,6 @@ def issue_url_to_quickstatements(url, iso639=None):
     for paper_url in paper_urls:
         qs += paper_url_to_quickstatements(paper_url, iso639=iso639) + "\n"
     return qs
-
-
-def pages_to_number_of_pages(pages):
-    """Compute number of pages based on pages represented as string.
-
-    Parameters
-    ----------
-    pages : str
-        Pages represented as a string.
-
-    Returns
-    -------
-    number_of_pages : int or None
-        Number of pages returned as an integer. If the conversion is not
-        possible then None is returned.
-
-    Examples
-    --------
-    >>> pages_to_number_of_pages('61-67')
-    7
-
-    """
-    number_of_pages = None
-    page_elements = pages.split('-')
-    if len(page_elements) == 2:
-        try:
-            number_of_pages = int(page_elements[1]) - int(page_elements[0]) + 1
-        except ValueError:
-            pass
-    return number_of_pages
 
 
 def paper_to_q(paper):

--- a/scholia/utils.py
+++ b/scholia/utils.py
@@ -109,3 +109,33 @@ def remove_special_characters_url(url):
     encode_string = decoded_url.encode("ascii", "ignore")
     formatted_string = encode_string.decode("utf-8").replace(" ", "")
     return formatted_string
+
+
+def pages_to_number_of_pages(pages):
+    """Compute number of pages based on pages represented as string.
+
+    Parameters
+    ----------
+    pages : str
+        Pages represented as a string.
+
+    Returns
+    -------
+    number_of_pages : int or None
+        Number of pages returned as an integer. If the conversion is not
+        possible then None is returned.
+
+    Examples
+    --------
+    >>> pages_to_number_of_pages('61-67')
+    7
+
+    """
+    number_of_pages = None
+    page_elements = pages.split('-')
+    if len(page_elements) == 2:
+        try:
+            number_of_pages = int(page_elements[1]) - int(page_elements[0]) + 1
+        except ValueError:
+            pass
+    return number_of_pages


### PR DESCRIPTION
CEUR WS scraper did not scrape authors on http://ceur-ws.org/Vol-1191/ CEUR WS scraper now extract pages and computes number of pages An extract error appeared for http://ceur-ws.org/Vol-3240/. This is corrected.

Fixes #2143 and fixes #2141

### Description
See above
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [x]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* `python -m scholia.scrape.ceurws proceedings-url-to-quickstatements http://ceur-ws.org/Vol-3240/`

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
