### PR TITLE
Adds a chemical-element data panel

### DIFF
--- a/scholia/app/templates/chemical-element.html
+++ b/scholia/app/templates/chemical-element.html
@@ -4,6 +4,7 @@
 
 {% block in_ready %}
 
+{{ sparql_to_table_post('data') }}
 {{ sparql_to_table('isotopes') }}
 {{ sparql_to_table('allotropes') }}
 {{ sparql_to_table('recent-literature') }}
@@ -16,6 +17,8 @@
 <div id="intro"></div>
 
 <div id="wembedder"></div>
+
+<table class="table table-hover" id="data-table"></table>
 
 <h2 id="isotopes">Isotopes</h2>
 

--- a/scholia/app/templates/chemical-element_data.sparql
+++ b/scholia/app/templates/chemical-element_data.sparql
@@ -1,0 +1,63 @@
+PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
+
+SELECT DISTINCT ?description ?value ?valueUrl
+WHERE {
+  {
+    SELECT
+      (1 AS ?order)
+      ("Named after" AS ?description)
+      (GROUP_CONCAT(?value_; separator=", ") AS ?value)
+      (CONCAT("../topic/", GROUP_CONCAT(?q; separator=",")) AS ?valueUrl)
+    {
+      BIND(1 AS ?dummy)
+      target: wdt:P138 ?iri .
+      BIND(SUBSTR(STR(?iri), 32) AS ?q) 
+      ?iri rdfs:label ?value_string . 
+      FILTER (LANG(?value_string) = 'en')
+      BIND(COALESCE(?value_string, ?q) AS ?value_)
+    }
+    GROUP BY ?dummy
+  }
+  UNION
+  {
+    SELECT
+      (2 AS ?order)
+      ("Discoverer" AS ?description)
+      (GROUP_CONCAT(?value_; separator=", ") AS ?value)
+      (CONCAT("../topic/", GROUP_CONCAT(?q; separator=",")) AS ?valueUrl)
+    {
+      BIND(1 AS ?dummy)
+      target: wdt:P61 ?iri .
+      BIND(SUBSTR(STR(?iri), 32) AS ?q) 
+      ?iri rdfs:label ?value_string . 
+      FILTER (LANG(?value_string) = 'en')
+      BIND(COALESCE(?value_string, ?q) AS ?value_)
+    }
+    GROUP BY ?dummy
+  }
+  UNION
+  {
+    SELECT
+      (3 AS ?order)
+      ("Oxidation states" AS ?description)
+      (GROUP_CONCAT(?value_; separator=", ") AS ?value)
+    {
+      BIND(1 AS ?dummy)
+      target: wdt:P1121 ?value_ .
+    }
+    GROUP BY ?dummy
+  }
+  UNION
+  {
+    SELECT
+      (4 AS ?order)
+      ("Electron configuration" AS ?description)
+      (GROUP_CONCAT(?value_; separator=", ") AS ?value)
+    {
+      BIND(1 AS ?dummy)
+      target: wdt:P8000 ?value_ .
+    }
+    GROUP BY ?dummy
+  }
+} 
+ORDER BY ?order


### PR DESCRIPTION

### Description

The `chemical-element` aspect did not have a data panel yet. I created one now with four fields of information:

![image](https://user-images.githubusercontent.com/26721/197378978-c5961f49-61d5-4632-9f88-34dbd6adf5c5.png)

(for https://scholia.toolforge.org/chemical-element/Q623)

I ran `tox` with Python 3.9 and this gave no problems:

```
________________________________________________________________________________________________________________________________________ summary _________________________________________________________________________________________________________________________________________
  flake8: commands succeeded
  pydocstyle: commands succeeded
ERROR:  py37: InterpreterNotFound: python3.7
ERROR:  py38: InterpreterNotFound: python3.8
  py39: commands succeeded
```