### PR TITLE
Exclude this 'preprint' field when the 'preprint of' field is

### DIFF
--- a/scholia/app/templates/work_data.sparql
+++ b/scholia/app/templates/work_data.sparql
@@ -191,7 +191,7 @@ WHERE {
   {
     BIND(15 AS ?order)
     BIND("⚠️ Preprint" AS ?description)
-    { ?work wdt:P31 wd:Q580922 . }
+    { ?work p:P31 ?statement . ?statement ps:P31 wd:Q580922 . MINUS { ?statement pq:P642 [] } }
   }
   UNION
   {


### PR DESCRIPTION
Fixes #2146 

### Description
The updated query checks if the `of` qualifier is given used in the 'preprint of' field.

How to check:
* control that now only the 'preprint of' is visible: `/work/Q98577324`
* check to see the 'Preprint' lines shows up when no `of` is given: `/work/Q1324573`

### Screenshots

Screenshots of the expected behavior:

![image](https://user-images.githubusercontent.com/26721/197381047-07b3f327-662a-4c76-8c00-80b99261aa04.png)

![image](https://user-images.githubusercontent.com/26721/197381038-496d9fa7-6233-4de9-aa56-1b8415991c9f.png)

### Caveats

I cannot think of caveats.