### PR TITLE
Link works to their (in Wikidata existing) preprints in the data panel

### DIFF
--- a/scholia/app/templates/work_data.sparql
+++ b/scholia/app/templates/work_data.sparql
@@ -242,5 +242,17 @@ WHERE {
     BIND(COALESCE(?value_string, ?q) AS ?value)
     BIND(CONCAT("../work/", ?q) AS ?valueUrl)
   }
+  UNION
+  {
+    BIND(32 AS ?order)
+    BIND("Preprint" AS ?description)
+    { ?preprint p:P31 ?statement .
+      ?statement pq:P642 ?work .
+    BIND(SUBSTR(STR(?preprint), 32) AS ?pubqid)
+    ?preprint rdfs:label ?value_string .
+    FILTER (LANG(?value_string) = 'en')
+    BIND(COALESCE(?value_string, ?pubqid) AS ?value)
+    BIND(CONCAT("../work/", ?pubqid) AS ?valueUrl)}
+  }
 } 
 ORDER BY ?order


### PR DESCRIPTION
Fixes #2147

I added a row to the data panel that shows a link to the preprint. It uses the pattern `wdt:P31 'preprint'` with the `of` qualifier (in reverse).

The result should now look for `/work/Q114821829` like:

![image](https://user-images.githubusercontent.com/26721/197381483-96ef68a9-2ed0-40e0-83be-c394ea6605e3.png)
