### PR TITLE
Add formats, fix bugs in work export

### DIFF
--- a/scholia/app/templates/work-export.html
+++ b/scholia/app/templates/work-export.html
@@ -14,8 +14,10 @@
       ("bibtex", "BibTeX"),
       ("cff", "CFF"),
       ("data", "CSL-JSON"),
+      ("enw", "ENW"),
       ("refworks", "RefWorks"),
       ("ris", "RIS"),
+      ("wikipediaTemplate", "Wikipedia templates"),
     ] %}
       <option value="{{ id }}" style="text-align: left;">{{ label }}</option>
     {% endfor %}


### PR DESCRIPTION
Fixes #1971  
Fixes #2083  
See #1594  

### Description

  - Two additional formats are listed among the export options: EndNote .enw files, and Wikipedia templates.

![Screenshot_20221026_172908](https://user-images.githubusercontent.com/14018963/198069181-a1600067-6ba9-4f26-bf67-1927c5890e59.png)
![Screenshot_20221026_172923](https://user-images.githubusercontent.com/14018963/198069223-a964f9d4-7d15-408f-bfdb-829ae45af6cd.png)

  - Empty strings are no longer treated as valid values in QuickStatements output.

### Caveats

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [x]  This change requires new dependencies (please list): JS-only, two new Citation.js plugins (enw and wikipedia-templates)

[Bundle configuration](https://juniper-coat.glitch.me/):  

![Screenshot_20221026_171512](https://user-images.githubusercontent.com/14018963/198069086-91151901-ca1b-43d6-881a-0d4047ae0e3b.png)

*If you make changes to the Python code*
  
* [x]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing

* Go to http://127.0.0.1:8100/work/Q112075162/export
* Select ENW, check output
* Select Wikipedia Templates, check output

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
