### PR TITLE
Add error handling to fetch and ajax calls

### DIFF
--- a/scholia/app/static/scholia.js
+++ b/scholia/app/static/scholia.js
@@ -432,7 +432,10 @@ function sparqlToIframe(sparql, element, filename) {
                     '</a>' +
                 '</span>'
             );
-        }
+        },
+        error: function (jqXHR, textStatus, errorThrown) {
+            console.error(filename + " iFrame query failed. " + textStatus + " " + errorThrown)
+        },
     });
 }
 
@@ -665,5 +668,12 @@ function askQuery(panel, askQuery, callback) {
                 document.querySelector("li a[href='#" + elem.id + "']").parentElement.classList.add("d-none");
             }
         }
-    });
+     }).fail(function (jqXHR, textStatus, errorThrown) {
+        // hide from table of contents
+        var headings = document.querySelectorAll("#" + panel + " h2, #" + panel + " h3");
+        for (var elem of headings) {
+            document.querySelector("li a[href='#" + elem.id + "']").parentElement.classList.add("d-none");
+        }
+        console.error("Ask query failed. " + textStatus + " " + errorThrown)
+     });
 }

--- a/scholia/app/templates/404-doi.html
+++ b/scholia/app/templates/404-doi.html
@@ -21,7 +21,7 @@ try {
   if (error.message.includes("status code 404")) {
     $( '#qs' ).append( "DOI does not exist" )
   } else {
-    console.log(error)
+    console.error(error)
   }
 }
 </script>

--- a/scholia/app/templates/author-index.html
+++ b/scholia/app/templates/author-index.html
@@ -186,6 +186,9 @@ Researcher with a published record.
                 } else {
                     callback([])
                 }
+            }).fail(function (jqXHR, textStatus, errorThrown) {
+              callback(["Search failed"])
+              console.error("Search failed. " + textStatus + " " + errorThrown)
             });
             }, 200)
         }

--- a/scholia/app/templates/base.html
+++ b/scholia/app/templates/base.html
@@ -433,6 +433,8 @@ askQuery("{{ panel }}", `# tool: scholia
 		 }
 		 $("#wikiversity-extract").text(text).append(html);
 	     }).fail(function(d, textStatus, error) {
+		 var html = "Read on the <a href=\"" + wikiversityUrl + "\">English Wikiversity</a>";
+		 $("#wikiversity-extract").append(html);
 		 console.error("getJSON failed, status: " + textStatus + ", error: "+error)
 	     });
 	 }

--- a/scholia/app/templates/base.html
+++ b/scholia/app/templates/base.html
@@ -406,7 +406,9 @@ askQuery("{{ panel }}", `# tool: scholia
 	       var html = " (<a href=\"" + wikipediaUrl + "\">Read more on English Wikipedia</a>)";
 		 $("#intro").text(data.extract).append(html);
 	     }).catch(error => {
-		 console.error('Error:', error);
+		 var html = "<a href=\"" + wikipediaUrl + "\">View on English Wikipedia</a>";
+         $("#intro").append(html);
+		 console.error('Could not get summary from enwiki: ', error);
 	     });
 	 }
 

--- a/scholia/app/templates/base.html
+++ b/scholia/app/templates/base.html
@@ -344,7 +344,7 @@ askQuery("{{ panel }}", `# tool: scholia
 	             bioschemasAnnotation.smiles = smiles.replace("\"", "\'\'") ;
 		 }
 		 $( '#bioschemas' ).append( JSON.stringify(bioschemasAnnotation) );
-	     } catch(e) { console.log("Exception: " + e)
+	     } catch(e) { console.error("Exception: " + e)
 	     }
 	 } else if (item.claims.P352) { // UniProt ID
 	     try { /* Protein */
@@ -361,7 +361,7 @@ askQuery("{{ panel }}", `# tool: scholia
 	       bioschemasAnnotation.name = item.labels.en.value;
          }
 		 $( '#bioschemas' ).append( JSON.stringify(bioschemasAnnotation) );
-	     } catch(e) { console.log("Exception: " + e)
+	     } catch(e) { console.error("Exception: " + e)
 	     }
 	 } else if (item.claims.P351 || item.claims.P594) { // NCBI Gene or Ensembl
 	     try { /* Gene */
@@ -387,7 +387,7 @@ askQuery("{{ panel }}", `# tool: scholia
 	             bioschemasAnnotation.sameAs[counter] = "http://identifiers.org/ensembl/" + ensembl;
 		 }
 		 $( '#bioschemas' ).append( JSON.stringify(bioschemasAnnotation) );
-	     } catch(e) { console.log("Exception: " + e)
+	     } catch(e) { console.error("Exception: " + e)
 	     }
 	 }
 	 

--- a/scholia/app/templates/base.html
+++ b/scholia/app/templates/base.html
@@ -550,8 +550,12 @@ askQuery("{{ panel }}", `# tool: scholia
             if (data.results.bindings.length > 1) {
               addDropdownList("aspect-chooser", 'aspectMenuList', currentSubAspect, data)
             }
-          })
+          }).fail(function (jqXHR, textStatus, errorThrown) {
+            console.error("Subaspect chooser failed to generate. " + textStatus + " " + errorThrown)
+          });
         }
+      }).fail(function (jqXHR, textStatus, errorThrown) {
+        console.error("Aspect chooser failed to generate. " + textStatus + " " + errorThrown)
       });
 
       function createDropdownButton(parent, id, currentAspect, data, q) {        
@@ -643,7 +647,10 @@ askQuery("{{ panel }}", `# tool: scholia
 		 });
 	     });
 	     $( '#wembedder' ).append( '<hr>' );
-	 }
+	 },
+	 error: function (jqXHR, textStatus, errorThrown) {
+         console.error("Wembedder failed. " + textStatus + " " + errorThrown)
+	 },
      });
   {% endif %}
 
@@ -692,6 +699,9 @@ askQuery("{{ panel }}", `# tool: scholia
             } else {
               callback([])
             }
+          }).fail(function (jqXHR, textStatus, errorThrown) {
+            callback(["Search failed"])
+            console.error("Search failed. " + textStatus + " " + errorThrown)
           });
         }, 200)
       }

--- a/scholia/app/templates/base.html
+++ b/scholia/app/templates/base.html
@@ -676,7 +676,7 @@ askQuery("{{ panel }}", `# tool: scholia
       resolver: 'custom',
       events: {
         search: debounce((searchTerm, callback) => {
-          var url = "https://www.wikdata.org/w/api.php?callback=?";
+          var url = "https://www.wikidata.org/w/api.php?callback=?";
           var settings = {
             dataType: 'jsonp',
             data: {

--- a/scholia/app/templates/base.html
+++ b/scholia/app/templates/base.html
@@ -676,7 +676,7 @@ askQuery("{{ panel }}", `# tool: scholia
       resolver: 'custom',
       events: {
         search: debounce((searchTerm, callback) => {
-          var url = "https://www.wikidata.org/w/api.php?callback=?";
+          var url = "https://www.wikdata.org/w/api.php?callback=?";
           var settings = {
             dataType: 'jsonp',
             data: {

--- a/scholia/app/templates/use.html
+++ b/scholia/app/templates/use.html
@@ -17,7 +17,7 @@
 <h1 id="h1">Use</h1>
 
 <div id="intro"></div>
-
+<br>
 <div id="wikiversity-extract"></div>
 
 <h2 id="recent-work-using-the-used">Recent work using the resource</h2>


### PR DESCRIPTION
Fixes #1661

### Description
> Please include a summary of the change, relevant motivation and context. If possible and applicable, include before and after screenshots and a URL where the changes can be seen.
    
**Before and afters**

1. If summary fails, display enwiki link
![image](https://user-images.githubusercontent.com/6676843/199057517-8feb1167-72aa-496d-8f80-1e621d386a72.png)

2. Wikiversity
![image](https://user-images.githubusercontent.com/6676843/199060189-66ec0586-ccfd-4e16-b673-80285b0a6674.png)

3. If search is unresponsive it will say "Search failed" in the autocomplete rather than showing nothing
4. If ask query fails it will hide the panels rather than showing them
3. Use `console.error` rather than `console.log` for error messages
5. Make sure all ajax calls have a `.fail` or `error:`

### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* Checked error cases except the bioschemas things where I only changed it to console.error

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
