### PR TITLE
Fix #2178, #2168 and #2177 in quickstatement

### DIFF
--- a/scholia/qs.py
+++ b/scholia/qs.py
@@ -3,7 +3,32 @@
 
 from six import u
 
-from .utils import escape_string
+import re
+
+
+def normalize_string(string):
+    """Normalize string for Quickstatements.
+
+    Strip initial and trailing spaces and convert multiple whitespaces to a
+    single whitespace.
+
+    Parameters
+    ----------
+    string : str
+        String to be normalized.
+
+    Returns
+    -------
+    normalized_string : str
+        Normalized string.
+
+    Examples
+    --------
+    >>> normalize_string(' Finn  Nielsen ')
+    'Finn Nielsen'
+
+    """
+    return re.sub(r'\s+', ' ', string).strip()
 
 
 def paper_to_quickstatements(paper):
@@ -39,34 +64,31 @@ def paper_to_quickstatements(paper):
     """
     qs = u("CREATE\n")
 
+    # Language
+    iso639 = paper.get('iso639', 'en')
+
     if 'title' in paper and paper['title']:
-        title = escape_string(paper['title'])
-
         # "Label must be no more than 250 characters long"
-        short_title = escape_string(title)[:250]
-        while short_title.endswith("\\"):
-            short_title = short_title[:-1]
+        short_title = normalize_string(paper['title'])[:250]
 
+        # Label
         qs += u('LAST\tLen\t"{}"\n').format(short_title)
+
+        # Title property
+        qs += u('LAST\tP1476\t{}:"{}"\n').format(iso639, short_title)
 
     # Instance of scientific article
     qs += 'LAST\tP31\tQ13442814\n'
 
-    # Title
-    iso639 = 'en'
-    if 'iso639' in paper:
-        iso639 = paper['iso639']
-    if 'title' in paper and paper['title']:
-        qs += u('LAST\tP1476\t{}:"{}"\n').format(iso639, title)
-
     # DOI
     if 'doi' in paper:
-        qs += u('LAST\tP356\t"{}"\n').format(escape_string(paper['doi']))
+        qs += u('LAST\tP356\t"{}"\n').format(paper['doi'])
 
     # Authors
     if 'authors' in paper:
         for n, author in enumerate(paper['authors'], start=1):
-            qs += u('LAST\tP2093\t"{}"\tP1545\t"{}"\n').format(author, n)
+            qs += u('LAST\tP2093\t"{}"\tP1545\t"{}"\n').format(
+                normalize_string(author), n)
 
     # Published in
     if 'date' in paper:
@@ -90,14 +112,14 @@ def paper_to_quickstatements(paper):
 
     # Volume
     if 'volume' in paper:
-        qs += u('LAST\tP478\t"{}"\n').format(escape_string(paper['volume']))
+        qs += u('LAST\tP478\t"{}"\n').format(paper['volume'])
 
     # Issue
     if 'issue' in paper:
-        qs += u('LAST\tP433\t"{}"\n').format(escape_string(paper['issue']))
+        qs += u('LAST\tP433\t"{}"\n').format(paper['issue'])
 
     if 'pages' in paper:
-        qs += u('LAST\tP304\t"{}"\n').format(escape_string(paper['pages']))
+        qs += u('LAST\tP304\t"{}"\n').format(paper['pages'])
 
     if 'number_of_pages' in paper:
         qs += u('LAST\tP1104\t{}\n').format(paper['number_of_pages'])
@@ -154,25 +176,21 @@ def proceedings_to_quickstatements(proceedings):
     """
     qs = u("CREATE\n")
 
-    if 'title' in proceedings and proceedings['title']:
-        title = escape_string(proceedings['title'])
-
-        # "Label must be no more than 250 characters long"
-        short_title = escape_string(title)[:250]
-        while short_title.endswith("\\"):
-            short_title = short_title[:-1]
-
-        qs += u('LAST\tLen\t"{}"\n').format(short_title)
-
-    # Instance of proceedings
-    qs += 'LAST\tP31\tQ1143604\n'
-
     # Language
     iso639 = proceedings.get('iso639', 'en')
 
-    # Title
     if 'title' in proceedings and proceedings['title']:
-        qs += u('LAST\tP1476\t{}:"{}"\n').format(iso639, title)
+        # "Label must be no more than 250 characters long"
+        short_title = proceedings['title'][:250]
+
+        # Label
+        qs += u('LAST\tLen\t"{}"\n').format(short_title)
+
+        # Title property
+        qs += u('LAST\tP1476\t{}:"{}"\n').format(iso639, short_title)
+
+    # Instance of proceedings
+    qs += 'LAST\tP31\tQ1143604\n'
 
     if 'shortname' in proceedings:
         qs += u('LAST\tP1813\t{}:"{}"\n').format(
@@ -184,7 +202,7 @@ def proceedings_to_quickstatements(proceedings):
 
     # DOI
     if 'doi' in proceedings:
-        qs += u('LAST\tP356\t"{}"\n').format(escape_string(proceedings['doi']))
+        qs += u('LAST\tP356\t"{}"\n').format(proceedings['doi'])
 
     # Authors
     if 'authors' in proceedings:
@@ -215,17 +233,14 @@ def proceedings_to_quickstatements(proceedings):
 
     # Volume
     if 'volume' in proceedings:
-        qs += u('LAST\tP478\t"{}"\n').format(
-            escape_string(proceedings['volume']))
+        qs += u('LAST\tP478\t"{}"\n').format(proceedings['volume'])
 
     # Issue
     if 'issue' in proceedings:
-        qs += u('LAST\tP433\t"{}"\n').format(
-            escape_string(proceedings['issue']))
+        qs += u('LAST\tP433\t"{}"\n').format(proceedings['issue'])
 
     if 'pages' in proceedings:
-        qs += u('LAST\tP304\t"{}"\n').format(
-            escape_string(proceedings['pages']))
+        qs += u('LAST\tP304\t"{}"\n').format(proceedings['pages'])
 
     if 'number_of_pages' in proceedings:
         qs += u('LAST\tP1104\t{}\n').format(proceedings['number_of_pages'])


### PR DESCRIPTION
In OJS scrape, and and possibly other cases, strings to quickstatements may have a tab or trailing spaces that will confuse quickstatements. This commit normalize the string for title and author before generating the quickstatement line. Furthermore if the string contains double quotes the previous code generated wrong quickstatements with a wrong kind of escape. No escape seems to be necessary and it has been removed.

Fixes #2178, , #2168 and #2177

### Description
> Please include a summary of the change, relevant motivation and context. If possible and applicable, include before and after screenshots and a URL where the changes can be seen.
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* Test a few examples that did not work before.

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
