### PR TITLE
Thought: Do not list people that no longer work at the affiliation

### DIFF
--- a/scholia/app/templates/organization_employees-and-affiliated.sparql
+++ b/scholia/app/templates/organization_employees-and-affiliated.sparql
@@ -13,10 +13,18 @@ WITH {
   } 
 } AS %researchers
 WITH {
+  SELECT DISTINCT ?researcher ?until WHERE {
+    INCLUDE %researchers
+    MINUS { ?researcher p:P108 ?statement . ?statement ps:P108 target: ; pq:P582 ?until . FILTER ( ?until < NOW() ) }
+    MINUS { ?researcher p:P463 ?statement . ?statement ps:P463 target: ; pq:P582 ?until . FILTER ( ?until < NOW() ) }
+    MINUS { ?researcher p:P1416 ?statement . ?statement ps:P1416 target: ; pq:P582 ?until . FILTER ( ?until < NOW() ) }
+  } 
+} AS %researchers2
+WITH {
   SELECT
     (COUNT(?work) AS ?number_of_works_) ?researcher
   WHERE {
-    INCLUDE %researchers
+    INCLUDE %researchers2
 
     # No biological pathways; they skew the statistics too much 
     MINUS { ?work wdt:P31 wd:Q4915012 } 
@@ -33,5 +41,5 @@ WHERE {
   OPTIONAL { ?researcher wikibase:sitelinks ?wikis_ }
   SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,nl,no,ru,sv,zh" . } 
 }
-GROUP BY ?researcher ?researcherLabel ?researcherDescription 
+GROUP BY ?researcher ?researcherLabel ?researcherDescription
 ORDER BY DESC(?works)


### PR DESCRIPTION
@fnielsen, @Daniel-Mietchen, this is just a thought, but instead of filing an issue, I wanted to show some code. Therefore a PR. But it's really only a discussion point / question.

The current `organization` aspect shows everyone who ever has been linked to the affiliation. And since it is sorted by citations count (should we keep that at all?), people who published a lot after they left the institute may give an distorted picture of the organization.

So, I have been playing with the idea of using the `end time` qualifier. This patch shows the use of that.

But there are caveats. For example, this query probably does not handle situation well where someone is *back* at the organization (and currently working there), but since those would be different statements, it might just do it right.

What do you think?