### PR TITLE
Report venue is CiTO annotation source

### DIFF
--- a/scholia/app/templates/cito-index_articles-by-year.sparql
+++ b/scholia/app/templates/cito-index_articles-by-year.sparql
@@ -1,17 +1,20 @@
 #defaultView:BarChart
 select ?year (count(?work) as ?number_of_publications) ?role where {
   {
-    select ?work (min(?years) as ?year) ?type_ where {
+    select ?work (min(?years) as ?year) ?type_ ?venue where {
       ?work wdt:P577 ?dates ;
             p:P2860 / pq:P3712 / wdt:P31 wd:Q96471816 .
       bind(str(year(?dates)) as ?years) .
-      OPTIONAL { ?work wdt:P31 wd:Q109229154 . bind("explicit" as ?type_) }
+      OPTIONAL {
+        ?work wdt:P31 wd:Q109229154 . bind("explicit" as ?type_)
+        ?work wdt:P1433 / rdfs:label ?venue . FILTER (LANG(?venue) = "en")
+      }
     }
-    group by ?work ?type_
+    group by ?work ?type_ ?venue
   }
   bind(
     coalesce(
-      if(bound(?type_), 'in article',
+      if(bound(?type_), ?venue,
       'other source')
     ) as ?role
   )


### PR DESCRIPTION
Right now, this query report the number of articles with CiTO annotation over time and since recently typed by whether or not the article itself provided explicit citation intentions:

![image](https://user-images.githubusercontent.com/26721/204089989-117d2ce2-59e9-4f72-ade6-8d395374c547.png)

This patch updates this to not report `in article` but report the venue with the explicit annotations in the article. The point of this is to visualize the uptake of explicit annotation by venues:

![image](https://user-images.githubusercontent.com/26721/204089949-dc8bee45-b143-4d00-a7d4-da7dc3ab8b04.png)

(I can imagine that in the future when this has become commonplace, we will depict this quite differently again)