### PR TITLE
Authenticate the new Mastodon account

### DIFF
--- a/scholia/app/templates/index.html
+++ b/scholia/app/templates/index.html
@@ -5,6 +5,7 @@
 <meta name="description" content="View scholarly profiles from Wikidata for topics, people, organizations, species, chemicals, etc.">
 <meta property="og:title" content="Scholia">
 <meta property="og:description" content="Scholia is a service that creates visual scholarly profiles for topic, people, organizations, species, chemicals, etc using bibliographic and other information in Wikidata." />
+<link href="https://wikis.world/@wdscholia" rel="me">
 {% endblock %}
 
 <!-- don't show nav search on index.html -->


### PR DESCRIPTION
Following the normal procedure, adding a `<link rel="me">`  line to authenticate our link to the Mastodon account.

See more at, for example, https://til.simonwillison.net/mastodon/verifying-github-on-mastodon