### PR TITLE
Add sponsors to event aspect

### DIFF
--- a/scholia/app/templates/event.html
+++ b/scholia/app/templates/event.html
@@ -15,7 +15,8 @@
 {{ sparql_to_table('uses') }}
 {{ sparql_to_iframe('co-authors') }}
 {{ sparql_to_iframe('timeline') }}
- 
+{{ sparql_to_table('sponsors') }}
+
 {% endblock %}
 
 
@@ -38,6 +39,10 @@
 <div class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" id="co-authors-iframe"></iframe>
 </div>
+
+<h2 id="sponsors">Sponsors</h2>
+
+<table class="table table-hover" id="sponsors-table"></table>
 
 
 <h2 id="timeline">Timeline</h2>

--- a/scholia/app/templates/event_sponsors.sparql
+++ b/scholia/app/templates/event_sponsors.sparql
@@ -1,0 +1,7 @@
+PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
+
+SELECT ?item ?itemLabel ?itemDescription
+WHERE {
+  target: wdt:P859 ?item .
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+}


### PR DESCRIPTION
### Description

This pull request lists sponsors on the event aspect using the following SPARQL:

```sparql
PREFIX target: <http://www.wikidata.org/entity/{{ q }}>

SELECT ?item ?itemLabel ?itemDescription
WHERE {
  target: wdt:P859 ?item .
  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
}
```

This PR does not change any python nor javascript code. It adds a new `h2`-level header for sponsors under "people". The following example shows the sponsors for the 16th Annual International Biocuration Conference (https://www.wikidata.org/wiki/Q111430238):

<img width="1471" alt="Screenshot 2022-12-02 at 00 46 20" src="https://user-images.githubusercontent.com/5069736/205182743-65e9281c-4a71-44bd-a2bc-ef383e4b9100.png">

### Caveats

Not sure what other properties of a sponsor might be nice to include on this page.

Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* Test A
* Test B

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
