### PR TITLE
adding LIMITs to use-curation_missing-author-items.sparql 

### DIFF
--- a/scholia/app/templates/use-curation_missing-author-items.sparql
+++ b/scholia/app/templates/use-curation_missing-author-items.sparql
@@ -39,6 +39,7 @@ WITH {
         [] wdt:P2093 ?author ;
            (wdt:P2283 | wdt:P4510) / wdt:P279* wd:{{ q }} .
       }
+      LIMIT 100000
     }
     UNION
     {
@@ -47,6 +48,7 @@ WITH {
         [] wdt:P2860 / wdt:P2093 ?author ;
            (wdt:P2283 | wdt:P4510) / wdt:P279* wd:{{ q }} .
       }
+      LIMIT 100000
     }
   }
   GROUP BY ?author

--- a/scholia/app/templates/use-curation_missing-author-items.sparql
+++ b/scholia/app/templates/use-curation_missing-author-items.sparql
@@ -39,7 +39,7 @@ WITH {
         [] wdt:P2093 ?author ;
            (wdt:P2283 | wdt:P4510) / wdt:P279* wd:{{ q }} .
       }
-      LIMIT 100000
+      LIMIT 10000
     }
     UNION
     {
@@ -48,7 +48,7 @@ WITH {
         [] wdt:P2860 / wdt:P2093 ?author ;
            (wdt:P2283 | wdt:P4510) / wdt:P279* wd:{{ q }} .
       }
-      LIMIT 100000
+      LIMIT 10000
     }
   }
   GROUP BY ?author

--- a/scholia/app/templates/use-curation_missing-author-items.sparql
+++ b/scholia/app/templates/use-curation_missing-author-items.sparql
@@ -17,6 +17,7 @@ WITH {
   SELECT DISTINCT ?work WHERE {
     ?work (wdt:P2283 | wdt:P4510) / wdt:P279* wd:{{ q }} .
   }
+  LIMIT 100000
 } AS %works
 WITH {
   SELECT
@@ -61,5 +62,5 @@ WHERE {
   # Label the result
   SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }
-ORDER BY DESC(?count) DESC(?score)
+ORDER BY DESC(?score) DESC(?count) 
 LIMIT 500


### PR DESCRIPTION
Fixes #2194

### Description
This adds some SPARQL limits to the query in order to improve performance within the constraints of the Wikidata Query Service. Also slightly rearranged the result ordering to emphasize the use-related author string curation over curation of the strings more generally.

![Screenshot 2022-12-08 at 04-04-59 ImageJ - Scholia](https://user-images.githubusercontent.com/465923/206346888-ef3f772d-b658-4bec-940e-835f60b55b48.png)

    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

Comparse https://scholia.toolforge.org/use/Q1659584/curation#missing-author-items with the results produced by this branch.

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [X] My changes generate no new warnings
* [X] I have not used code from external sources without attribution
* [ ] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [X] There are no remaining debug statements (print, console.log, ...)
