### PR TITLE
Add Python 3.10 to the testing workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ python =
   3.7: py37
   3.8: py38
   3.9: py39
+  3.10: py310
 
 
 [testenv:py27]
@@ -43,6 +44,14 @@ deps=
 
 [testenv:py39]
 commands = 
+    python -m pytest --doctest-modules scholia
+    python -m pytest tests
+deps=
+    pytest
+    -rrequirements.txt
+
+[testenv:py310]
+commands =
     python -m pytest --doctest-modules scholia
     python -m pytest tests
 deps=

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8, pydocstyle, py37, py38, py39
+envlist = flake8, pydocstyle, py37, py38, py39, py310
 
 
 [gh-actions]


### PR DESCRIPTION
Work in progress. This PR adds Python 3.10 so that we have a clear overview of the problems, fix them one by one, until all is solved.

Intention: Fixes #2183

### Description
Scholia is reported to not compile/run with Python 3.10. 
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [x]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [x]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
No new code is introduced.

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
