### PR TITLE
Adds an 'event' data table, with link to the event series

### DIFF
--- a/scholia/app/templates/event.html
+++ b/scholia/app/templates/event.html
@@ -5,6 +5,7 @@
  
 {% block in_ready %}
 
+{{ sparql_to_table_post('data') }}
 {{ sparql_to_table('people') }}
 {{ sparql_to_table('proceedings') }}
 {{ sparql_to_table('presentations') }}
@@ -28,6 +29,7 @@
 
 <div id="details"></div>
 
+<table class="table table-hover" id="data-table"></table>
 
 <h2 id="people">People</h2>
 

--- a/scholia/app/templates/event_data.sparql
+++ b/scholia/app/templates/event_data.sparql
@@ -1,0 +1,40 @@
+PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
+
+SELECT DISTINCT ?description ?value ?valueUrl
+WHERE {
+  BIND(target: AS ?work)
+  {
+    BIND(1 AS ?order)
+    BIND("Part of series" AS ?description)
+    ?work wdt:P179 ?iri .
+    BIND(SUBSTR(STR(?iri), 32) AS ?q) 
+    ?iri rdfs:label ?value_string . 
+    FILTER (LANG(?value_string) = 'en')
+    BIND(COALESCE(?value_string, ?q) AS ?value)
+    BIND(CONCAT("../event-series/", ?q) AS ?valueUrl)
+  }
+  UNION
+  {
+    BIND(2 AS ?order)
+    BIND("Short name" AS ?description)
+    ?work wdt:P1813 ?value .
+  }
+  UNION
+  {
+    SELECT
+      (3 AS ?order)
+      ("Organizers" AS ?description)
+      (GROUP_CONCAT(?value_; separator=", ") AS ?value)
+      (CONCAT("../authors/", GROUP_CONCAT(?q; separator=",")) AS ?valueUrl)
+    {
+      BIND(1 AS ?dummy)
+      target: wdt:P664 ?iri .
+      BIND(SUBSTR(STR(?iri), 32) AS ?q) 
+      ?iri rdfs:label ?value_string .
+      FILTER (LANG(?value_string) = 'en')
+      BIND(COALESCE(?value_string, ?q) AS ?value_)
+    }
+    GROUP BY ?dummy
+  }
+} 
+ORDER BY ?order


### PR DESCRIPTION
Fixes #2206 

### Description
Adds a data table with event series, short name, and organizers.
    
### Caveats
I can imagine more info will be requested in the future to be added in the data table, like start/end data, venue, etc.

### Testing
Run the patched Scholia locally and go to http://127.0.0.1:8100/event/Q48027575

It should look like this:

![image](https://user-images.githubusercontent.com/26721/209654610-f384e7ba-446c-43be-926a-e72c9d4eb33e.png)

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [ ] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [ ] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
