### PR TITLE
removed ```FILTER EXISTS``` clause

### DIFF
--- a/scholia/app/templates/organization_page-production.sparql
+++ b/scholia/app/templates/organization_page-production.sparql
@@ -14,7 +14,7 @@ WHERE {
       (SAMPLE(?pages) / COUNT(?researcher_of_paper) AS ?pages_per_author)
     WHERE {
       # Find authors associated with organization
-      FILTER EXISTS { ?researcher wdt:P108 | wdt:P463 | (wdt:P1416 / wdt:P361*) target: . }
+      ?researcher wdt:P108 | wdt:P463 | (wdt:P1416 / wdt:P361*) target: . 
       
       ?work (wdt:P50|wdt:P2093) ?researcher_of_paper .
       


### PR DESCRIPTION
Fixes #2208 

### Description
Removed the ```FILTER EXISTS``` clause from
[organization_page-production.sparql](https://github.com/WDscholia/scholia/blob/master/scholia/app/templates/organization_page-production.sparql) 
    
### Caveats

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [X]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Screenshots
* https://scholia.toolforge.org/organization/Q3530296#page-production (i.e. before)
![Screenshot from 2022-12-29 00-04-35](https://user-images.githubusercontent.com/465923/209883294-1ee2c90e-2a5d-4c89-a3ea-4f3a1d7b9ef3.png)
* local (i.e. after)
![Screenshot from 2022-12-29 00-05-04](https://user-images.githubusercontent.com/465923/209883280-b7c0f506-c642-4126-a1b6-010e76678c16.png)


### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [ ] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
