### PR TITLE
Updated actions/checkout and actions/setup-python

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - 
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,11 +11,11 @@ jobs:
         python-version: ["3.7", "3.8", "3.9"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install lxml dependencies
         run: sudo apt install libxml2-dev libxslt-dev
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Cython for lxml installation


### PR DESCRIPTION
Version `v3` of the GitHub Action updates the Nodejs version (from 12 to 16), see https://github.com/actions/checkout and https://github.com/actions/setup-python

Needed according to compile warnings:

![image](https://user-images.githubusercontent.com/26721/209966898-ab0afd0a-ab73-418a-8ba8-deb926b21864.png)
