### PR TITLE
Panel for the author curation page to list articles that are not used as reference for any statement

### DIFF
--- a/scholia/app/templates/author-curation.html
+++ b/scholia/app/templates/author-curation.html
@@ -55,10 +55,10 @@ the authors.
 <h2 id="missing-use-as-reference">Articles not used as statement reference</h2>
 
 <p>Works authored by <span class="self">{{ q }}</span> that are not used as "stated in" reference
-to a statement. You can improve the Wikidata by finding an unsource statement
-in Wikidata that is supported by any of the listed articles by scrolling that
+to a statement. You can improve Wikidata by finding an unsourced statement
+in Wikidata that is supported by any of the listed articles by scrolling to that
 statement and clicking "+ add reference" and adding a <a href="https://www.wikidata.org/wiki/Property:P248">"stated in" (P248)</a>
-with the supporting article as value.</p>
+with the supporting article's Wikidata identifier (QID) as value.</p>
 
 <table class="table table-hover" id="missing-use-as-reference-table"></table>
 

--- a/scholia/app/templates/author-curation.html
+++ b/scholia/app/templates/author-curation.html
@@ -46,7 +46,7 @@ the authors.
 
 <h2 id="missing-topic">Authored works with missing topics</h2>
 
-<p>Works authored by {{q}} that do not have topics listed in Wikidata. You can improve the data by clicking the link
+<p>Works authored by <span class="self">{{q}}</span> that do not have topics listed in Wikidata. You can improve the data by clicking the link
   on the right, scrolling to "+ add statement" and adding a <a href="https://www.wikidata.org/wiki/Property:P921">"main subject" (P921)</a> if you know it:</p>
 
 <table class="table table-hover" id="missing-topic-table"></table>
@@ -54,7 +54,7 @@ the authors.
 
 <h2 id="missing-use-as-reference">Articles not used as statement reference</h2>
 
-<p>Works authored by {{q}} that are not used as "stated in" reference
+<p>Works authored by <span class="self">{{ q }}</span> that are not used as "stated in" reference
 to a statement. You can improve the Wikidata by finding an unsource statement
 in Wikidata that is supported by any of the listed articles by scrolling that
 statement and clicking "+ add reference" and adding a <a href="https://www.wikidata.org/wiki/Property:P248">"stated in" (P248)</a>

--- a/scholia/app/templates/author-curation.html
+++ b/scholia/app/templates/author-curation.html
@@ -8,6 +8,7 @@
 {{ sparql_to_table('missing-coauthor-items') }}
 {{ sparql_to_table('missing-citing-author-items') }}
 {{ sparql_to_table('missing-topic') }}
+{{ sparql_to_table('missing-use-as-reference') }}
 
 {% endblock %}
 
@@ -49,6 +50,17 @@ the authors.
   on the right, scrolling to "+ add statement" and adding a <a href="https://www.wikidata.org/wiki/Property:P921">"main subject" (P921)</a> if you know it:</p>
 
 <table class="table table-hover" id="missing-topic-table"></table>
+
+
+<h2 id="missing-use-as-reference">Articles not used as statement reference</h2>
+
+<p>Works authored by {{q}} that are not used as "stated in" reference
+to a statement. You can improve the Wikidata by finding an unsource statement
+in Wikidata that is supported by any of the listed articles by scrolling that
+statement and clicking "+ add reference" and adding a <a href="https://www.wikidata.org/wiki/Property:P248">"stated in" (P248)</a>
+with the supporting article as value.</p>
+
+<table class="table table-hover" id="missing-use-as-reference-table"></table>
 
 <hr>
 

--- a/scholia/app/templates/author-curation_missing-use-as-reference.sparql
+++ b/scholia/app/templates/author-curation_missing-use-as-reference.sparql
@@ -1,6 +1,6 @@
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
-SELECT ?citations ?work ?workLabel
+SELECT ?citations ?work ?workLabel (CONCAT("/work/", SUBSTR(STR(?work), 32)) AS ?workUrl)
 WITH {
   SELECT ?work (COUNT(DISTINCT ?statement) AS ?count) WHERE {
     ?work wdt:P50 target: .

--- a/scholia/app/templates/author-curation_missing-use-as-reference.sparql
+++ b/scholia/app/templates/author-curation_missing-use-as-reference.sparql
@@ -1,0 +1,23 @@
+PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
+
+SELECT ?citations ?work ?workLabel
+WITH {
+  SELECT ?work (COUNT(DISTINCT ?statement) AS ?count) WHERE {
+    ?work wdt:P50 target: .
+	OPTIONAL { ?statement prov:wasDerivedFrom/pr:P248 ?work . }
+  } GROUP BY ?work
+} AS %works
+WITH {
+  SELECT (COUNT(?work1) as ?citations) ?work WHERE {
+    INCLUDE %works
+    FILTER (?count = 0)
+    # Works cited
+    OPTIONAL { ?work1 wdt:P2860 ?work }.
+  }
+  GROUP BY ?work
+} AS %result
+WHERE {
+  INCLUDE %result
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+} ORDER BY DESC(?citations)
+  LIMIT 200

--- a/scholia/app/templates/base.html
+++ b/scholia/app/templates/base.html
@@ -108,6 +108,7 @@ askQuery("{{ panel }}", `# tool: scholia
 	 if ('en' in item.labels) {
 	     var title = item.labels.en.value
 	     $("#h1").text(title);
+	     $(".self").text(title);
        $("title").text(title + " - Scholia");
 
 	     {% if request.path.endswith("curation") or request.path.endswith("curation/") %}


### PR DESCRIPTION
Fixes #2213 

### Description
This patch adds a panel to an author curation page, listing works for that author that do not support any
statements.
    
### Caveats
No caveats I can foresee.

### Testing
Test is with any author with multiple articles. The output should look something like this:

![image](https://user-images.githubusercontent.com/26721/210073907-3626d774-9232-4d2f-bcb2-845237de7694.png)

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [ ] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
