### PR TITLE
New property for crystal structures, new statistics

### DIFF
--- a/scholia/app/templates/chemical-index_statistics.sparql
+++ b/scholia/app/templates/chemical-index_statistics.sparql
@@ -15,7 +15,7 @@ WITH {
   SELECT (COUNT(*) AS ?count) WHERE { [] wdt:P235 []. }
 } AS %inchikeys
 WITH {
-  SELECT (COUNT(*) AS ?count) WHERE { [] wdt:P3636 []. }
+  SELECT (COUNT(*) AS ?count) WHERE { [] wdt:P3636 | wdt:P11375 []. }
 } AS %crystalStructures
 WITH {
   SELECT (COUNT(*) AS ?count) WHERE { [] wdt:P6689 []. }


### PR DESCRIPTION
### Description
Small patch: when calculating the number of crystal structures, compounds with a CSD Refcode can be counted too. This property was accepted this week.
    
### Caveats
Potentially, a more complex makes the query not run fast enough, but this does not seem to be the case
(not noticeable ).

### Testing
Visit https://scholia.toolforge.org/chemical/ (before/after)

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [ x I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
