### PR TITLE
On taxon profile, add panel about co-occurring taxa 

### DIFF
--- a/scholia/app/templates/taxon.html
+++ b/scholia/app/templates/taxon.html
@@ -35,9 +35,9 @@
   <iframe class="embed-responsive-item" id="tree-iframe" ></iframe>
 </div>
 
-<h2 id="co-occurring-taxa">Co-occurring taxa</h2>
+<h2 id="co-occurring-taxa">Bibliographically co-occurring taxa</h2>
 
-Co-occurring taxa from the literature. Inclusion in this list does not imply biotic interactions.
+Taxa that are mentioned in the same publications. This does not imply biological interactions (for which we recommend <a href="https://www.globalbioticinteractions.org/?interactionType=interactsWith&sourceTaxon=WD%3A{{q}}">GloBI</a>), nor co-occurrence in ecological contexts.
 
 <table class="table table-hover" id="co-occurring-taxa-table"></table>
 

--- a/scholia/app/templates/taxon.html
+++ b/scholia/app/templates/taxon.html
@@ -7,6 +7,7 @@
 {{ sparql_to_table('identifiers') }}
 {{ sparql_to_table('parent-taxa') }}
 {{ sparql_to_iframe('tree') }}
+{{ sparql_to_table('co-occurring-taxa') }}
 {{ sparql_to_table('genome') }}
 {{ sparql_to_table('proteome') }}
 {{ sparql_to_table('metabolome') }}
@@ -33,6 +34,11 @@
 <div class="embed-responsive embed-responsive-16by9">
   <iframe class="embed-responsive-item" id="tree-iframe" ></iframe>
 </div>
+
+<h2 id="co-occurring-taxa">Co-occurring taxa</h2>
+
+<table class="table table-hover" id="co-occurring-taxa-table"></table>
+
 
 <h2 id="genome">Genome</h2>
 

--- a/scholia/app/templates/taxon.html
+++ b/scholia/app/templates/taxon.html
@@ -37,7 +37,7 @@
 
 <h2 id="co-occurring-taxa">Bibliographically co-occurring taxa</h2>
 
-Taxa that are mentioned in the same publications. This does not imply biological interactions (which are tracked by <a href="https://www.globalbioticinteractions.org/?interactionType=interactsWith&sourceTaxon=WD%3A{{q}}">GloBI</a>), nor co-occurrence in ecological contexts.
+Taxa that are mentioned in the same publications. This does not imply biological interactions (which are tracked by <a href="https://www.globalbioticinteractions.org/?interactionType=interactsWith&sourceTaxon=WD%3A{{q}}">GloBI</a>), nor co-occurrence in ecological or biogeographical contexts.
 
 <table class="table table-hover" id="co-occurring-taxa-table"></table>
 

--- a/scholia/app/templates/taxon.html
+++ b/scholia/app/templates/taxon.html
@@ -37,6 +37,8 @@
 
 <h2 id="co-occurring-taxa">Co-occurring taxa</h2>
 
+Co-occurring taxa from the literature. Inclusion in this list does not imply biotic interactions.
+
 <table class="table table-hover" id="co-occurring-taxa-table"></table>
 
 

--- a/scholia/app/templates/taxon.html
+++ b/scholia/app/templates/taxon.html
@@ -37,7 +37,7 @@
 
 <h2 id="co-occurring-taxa">Bibliographically co-occurring taxa</h2>
 
-Taxa that are mentioned in the same publications. This does not imply biological interactions (for which we recommend <a href="https://www.globalbioticinteractions.org/?interactionType=interactsWith&sourceTaxon=WD%3A{{q}}">GloBI</a>), nor co-occurrence in ecological contexts.
+Taxa that are mentioned in the same publications. This does not imply biological interactions (which are tracked by <a href="https://www.globalbioticinteractions.org/?interactionType=interactsWith&sourceTaxon=WD%3A{{q}}">GloBI</a>), nor co-occurrence in ecological contexts.
 
 <table class="table table-hover" id="co-occurring-taxa-table"></table>
 

--- a/scholia/app/templates/taxon_co-occurring-taxa.sparql
+++ b/scholia/app/templates/taxon_co-occurring-taxa.sparql
@@ -23,7 +23,7 @@ WITH {
 WHERE {
   # Label the results
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,ru,sv,zh" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
 }
 ORDER BY DESC(?count)
 LIMIT 200

--- a/scholia/app/templates/taxon_co-occurring-taxa.sparql
+++ b/scholia/app/templates/taxon_co-occurring-taxa.sparql
@@ -1,7 +1,7 @@
 #title: Taxa that co-occur with the target taxon in the literature
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
-SELECT ?count (CONCAT("/topics/Q41407,", SUBSTR(STR(?taxon), 32)) AS ?countUrl)
+SELECT ?count (CONCAT("/topics/",SUBSTR(STR(target:), 32), ",", SUBSTR(STR(?taxon), 32)) AS ?countUrl)
        ?taxon ?taxonLabel (CONCAT("/taxon/", SUBSTR(STR(?taxon), 32)) AS ?taxonUrl)
        ?example_work ?example_workLabel (CONCAT("/work/", SUBSTR(STR(?example_work), 32)) AS ?example_workUrl)
 WITH {

--- a/scholia/app/templates/taxon_co-occurring-taxa.sparql
+++ b/scholia/app/templates/taxon_co-occurring-taxa.sparql
@@ -1,0 +1,29 @@
+#title: Taxa that co-occur with the target taxon in the literature
+PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
+
+SELECT ?count (CONCAT("/topics/Q41407,", SUBSTR(STR(?taxon), 32)) AS ?countUrl)
+       ?taxon ?taxonLabel (CONCAT("/taxon/", SUBSTR(STR(?taxon), 32)) AS ?taxonUrl)
+       ?example_work ?example_workLabel (CONCAT("/work/", SUBSTR(STR(?example_work), 32)) AS ?example_workUrl)
+WITH {
+  SELECT (COUNT(?work) AS ?count) ?taxon (SAMPLE(?work) AS ?example_work) WHERE {
+    # Find works for the specific queried topic
+	?work wdt:P921 target: .
+    
+    # Find co-occuring topics
+    ?work wdt:P921 ?taxon .
+    
+    # Filter for taxa
+    ?taxon wdt:P105 ?taxonrank .
+    
+    # Avoid listing the queried topic itself
+    FILTER (target: != ?taxon)
+  }
+  GROUP BY ?taxon
+} AS %result
+WHERE {
+  # Label the results
+  INCLUDE %result
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,ru,sv,zh" . } 
+}
+ORDER BY DESC(?count)
+LIMIT 200


### PR DESCRIPTION
Fixes #2161

### Description

On the taxon profile, added a panel about taxa co-occurring with the target taxon in the literature.
    
### Caveats

Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [X]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing

* Good taxa to test this with:
  * Q25419 (Escherichia coli)
  * Q202864 (Zika virus)

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [X] My changes generate no new warnings
* [X] I have not used code from external sources without attribution
* [ ] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [X] There are no remaining debug statements (print, console.log, ...)
