### PR TITLE
Use the wikibase:mwapi to find InChIKeys

### DIFF
--- a/scholia/app/templates/404-chemical_related.sparql
+++ b/scholia/app/templates/404-chemical_related.sparql
@@ -1,5 +1,12 @@
 SELECT ?mol ?molLabel ?InChIKey ?CAS ?ChemSpider ?PubChem_CID WITH {
   SELECT ?mol ?InChIKey WHERE {
+    SERVICE wikibase:mwapi {
+        bd:serviceParam wikibase:endpoint "www.wikidata.org";
+        wikibase:api "Search";
+        mwapi:srsearch "_shortkey_ haswbstatement:P235";
+        mwapi:srlimit "max".
+        ?mol wikibase:apiOutputItem mwapi:title.
+      }
     ?mol wdt:P235 ?InChIKey .
     FILTER (regex(str(?InChIKey), "^_shortkey_"))
   }


### PR DESCRIPTION
Fixes #2223

### Description
This patch add the use of the `wikibase:mwapi` to speed up the query by at least on order of magnitude.
    
### Caveats

None observed.

### Testing
Compare old versus new:

* old: https://w.wiki/6Drq
* new: https://w.wiki/6Dro

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [ ] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
