### PR TITLE
Renamed the "Related Compounds" section into "Compounds with same connectivity"

### DIFF
--- a/scholia/app/templates/chemical.html
+++ b/scholia/app/templates/chemical.html
@@ -50,7 +50,7 @@
 
 <table class="table table-hover" id="identifiers-table"></table>
 
-<h2 id="Related" id="related">Related Compounds</h2>
+<h2 id="Related" id="related">Compounds with same connectivity</h2>
 
 (Including the compound itself)
 


### PR DESCRIPTION
Fixes #1942

### Description
Renames the section as suggested in the issue.
    
### Caveats

None.

### Testing

* check https://scholia.toolforge.org/chemical/Q3613679#Related

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [ ] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [ ] There are no remaining debug statements (print, console.log, ...)
