### PR TITLE
added ordinal to event-series_events and series_in-series query

### DIFF
--- a/scholia/app/templates/event-series_events.sparql
+++ b/scholia/app/templates/event-series_events.sparql
@@ -3,6 +3,7 @@ PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 # title: List of event and proceedings for a specific event series
 SELECT DISTINCT 
   (SAMPLE(?years) AS ?year)
+  (SAMPLE(?ordinal) AS ?ordinal)
   (SAMPLE(?short_names) AS ?short_name)
   ?event ?eventLabel (CONCAT("/event/", SUBSTR(STR(?event), 32)) AS ?eventUrl)
   ?proceedings ?proceedingsLabel (CONCAT("/venue/", SUBSTR(STR(?proceedings), 32)) AS ?proceedingsUrl)
@@ -18,6 +19,9 @@ WHERE {
     }
     OPTIONAL {
       ?proceedings wdt:P4745 ?event
+    }
+    OPTIONAL{
+      ?event p:P179/pq:P1545 ?ordinal
     }
   }
   UNION

--- a/scholia/app/templates/series_in-series.sparql
+++ b/scholia/app/templates/series_in-series.sparql
@@ -1,13 +1,21 @@
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
-SELECT ?publication_date ?number_of_papers ?short_name ?collection ?collectionLabel
+SELECT ?publication_date ?number_of_papers ?short_name ?ordinal ?collection ?collectionLabel
 WITH {
-  SELECT (COUNT(?work) AS ?number_of_papers) (MIN(?datetimes) AS ?publication_datetime) (SAMPLE(?short_name_) AS ?short_name) ?collection
+  SELECT
+    (COUNT(?work) AS ?number_of_papers)
+    (MIN(?datetimes) AS ?publication_datetime)
+    (SAMPLE(?short_name_) AS ?short_name)
+    ?collection
+    (SAMPLE(?ordinal) AS ?ordinal)
   WHERE {
     ?collection wdt:P179 target: .
     OPTIONAL { ?work wdt:P1433 ?collection . }
     OPTIONAL { ?collection wdt:P1813 ?short_name_ . }
     OPTIONAL { ?collection wdt:P577 ?datetimes . }
+    OPTIONAL{
+      ?collection p:P179/pq:P1545 ?ordinal.
+    }
   }
   GROUP BY ?collection
 } AS %result


### PR DESCRIPTION

Fixes #1699

### Description
Added [series ordinal (P1545)](https://www.wikidata.org/wiki/Property:P1545) to the [event-series_events.sparql](https://github.com/WDscholia/scholia/blob/master/scholia/app/templates/event-series_events.sparql) and [series_in-series.sparql](https://github.com/WDscholia/scholia/blob/master/scholia/app/templates/series_in-series.sparql) query.

#### Examples
##### event-series

| Before | After |
| --- | --- |
|![image](https://user-images.githubusercontent.com/45004115/213420962-6cbfa553-7e18-48ce-a85b-10f36a214be3.png)|![Screenshot 2023-01-19 at 10-48-01 Extended Semantic Web Conference - Scholia](https://user-images.githubusercontent.com/45004115/213417475-c6538121-760d-4d20-bb89-0bb688eb1c66.png)|

##### series
| Before | After |
| --- | --- |
|![Screenshot 2023-01-19 at 11-37-03 Advances in Neural Information Processing Systems - Scholia](https://user-images.githubusercontent.com/45004115/213420586-67c94c5c-f99d-451e-96fe-fc30bfd5b3f6.png)|![Screenshot 2023-01-19 at 10-45-55 Advances in Neural Information Processing Systems - Scholia](https://user-images.githubusercontent.com/45004115/213418808-df3b1422-ea1c-440e-99dc-7a0c4b47cf83.png)|

    
### Caveats
Extended SPARQL query, thus query execution time might be affected but the changes were of low complexity.


### Testing
Changes were only applied to SPARQL queries, thus testing through executing the queries

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
