### PR TITLE
Map "scholarly letter/reply" items to work aspect

### DIFF
--- a/scholia/query.py
+++ b/scholia/query.py
@@ -1141,6 +1141,7 @@ def q_to_class(q):
             'Q56119332',  # tweet
             'Q58632367',  # conference abstract
             'Q64548048',  # environmental impact assessment report
+            'Q110716513', # scholarly letter/reply
     ]):
         class_ = 'work'
     elif set(classes).intersection([


### PR DESCRIPTION
### Description
Map items of type [Q110716513](http://www.wikidata.org/entity/Q110716513) (scholarly letter/reply) to the "work" aspect, instead of the default "topic" aspect.
For example, when searched for, [Q28661563](http://www.wikidata.org/entity/Q28661563) should take you to [/**work**/](https://scholia.toolforge.org/work/Q28661563), instead of [/**topic**/](https://scholia.toolforge.org/topic/Q28661563).

* See [this discussion](https://www.wikidata.org/wiki/Wikidata_talk:WikiProject_Source_MetaData/Archive_6#Letters_to_the_editor) for more information on the type.
* See [this list](https://w.wiki/6G3W) to assess type usage.

While the current usage is very small (67 items at the time of writing), it has still proved to be useful and I expect increased adoption in the future. At the moment, most of these items are maintained by [WikiProject YDIH](https://www.wikidata.org/wiki/Wikidata:WikiProject_Younger_Dryas_impact_hypothesis) so the best place to see the usefulness of this type is in the [YDIH Scholia profile](https://scholia.toolforge.org/topic/Q1092095#publications-per-year) (look at the year 2010).

### Caveats
I am not sure if this mapping needs to be added anywhere else in the codebase

### Testing
I have tested this change using Gitpod

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
