### PR TITLE
arXiv classification P820 as qualifier to arXiv ID P818

### DIFF
--- a/scholia/arxiv.py
+++ b/scholia/arxiv.py
@@ -125,13 +125,14 @@ def metadata_to_quickstatements(metadata):
     # arXiv ID
     qs += u'LAST\tP818\t"{}"'.format(metadata['arxiv'])
     # No line break, to accommodate the following qualifiers
-    
+ 
     # arXiv classifications such as "cs.LG", as qualifier to arXiv ID
-    # This does not yet handle errors that may arise when classifications are missing.
+    # This does not yet handle errors that may arise when classifications 
+    # are missing.
     for classification in metadata['arxiv_classifications']:
         qs += u'\tP820\t"{}"'.format(
             classification.replace('"', '\"'))
-    
+
     # Line break for the P818 statement
     qs += u"\n"
 

--- a/scholia/arxiv.py
+++ b/scholia/arxiv.py
@@ -127,8 +127,6 @@ def metadata_to_quickstatements(metadata):
     # No line break, to accommodate the following qualifiers
 
     # arXiv classifications such as "cs.LG", as qualifier to arXiv ID
-    # This does not yet handle errors that may arise when classifications
-    # are missing.
     for classification in metadata['arxiv_classifications']:
         qs += u'\tP820\t"{}"'.format(
             classification.replace('"', '\"'))

--- a/scholia/arxiv.py
+++ b/scholia/arxiv.py
@@ -121,6 +121,20 @@ def metadata_to_quickstatements(metadata):
     """
     qs = u"CREATE\n"
     qs += u'LAST\tP31\tQ13442814\n'
+
+    # arXiv ID
+    qs += u'LAST\tP818\t"{}"'.format(metadata['arxiv'])
+    # No line break, to accommodate the following qualifiers
+    
+    # arXiv classifications such as "cs.LG", as qualifier to arXiv ID
+    # This does not yet handle errors that may arise when classifications are missing.
+    for classification in metadata['arxiv_classifications']:
+        qs += u'\tP820\t"{}"'.format(
+            classification.replace('"', '\"'))
+    
+    # Line break for the P818 statement
+    qs += u"\n"
+
     qs += u'LAST\tLen\t"{}"\n'.format(metadata['title'].replace('"', '\"'))
     qs += u'LAST\tP1476\ten:"{}"\n'.format(
         metadata['title'].replace('"', '\"'))
@@ -137,15 +151,6 @@ def metadata_to_quickstatements(metadata):
     # DOI based on arXiv identifier
     qs += u'LAST\tP356\t"10.48550/ARXIV.{}"\n'.format(
             metadata['arxiv'])
-
-    # arXiv ID
-    qs += u'LAST\tP818\t"{}"'.format(metadata['arxiv'])
-
-    # arXiv classifications such as "cs.LG", as qualifier to arXiv ID
-    for classification in metadata['arxiv_classifications']:
-        qs += u'\tP820\t"{}"'.format(
-            classification.replace('"', '\"'))
-    qs += u"\n"
 
     for n, authorname in enumerate(metadata['authornames'], start=1):
         qs += u'LAST\tP2093\t"{}"\tP1545\t"{}"\n'.format(

--- a/scholia/arxiv.py
+++ b/scholia/arxiv.py
@@ -125,9 +125,9 @@ def metadata_to_quickstatements(metadata):
     # arXiv ID
     qs += u'LAST\tP818\t"{}"'.format(metadata['arxiv'])
     # No line break, to accommodate the following qualifiers
- 
+
     # arXiv classifications such as "cs.LG", as qualifier to arXiv ID
-    # This does not yet handle errors that may arise when classifications 
+    # This does not yet handle errors that may arise when classifications
     # are missing.
     for classification in metadata['arxiv_classifications']:
         qs += u'\tP820\t"{}"'.format(

--- a/scholia/arxiv.py
+++ b/scholia/arxiv.py
@@ -120,7 +120,6 @@ def metadata_to_quickstatements(metadata):
 
     """
     qs = u"CREATE\n"
-    qs += u'LAST\tP818\t"{}"\n'.format(metadata['arxiv'])
     qs += u'LAST\tP31\tQ13442814\n'
     qs += u'LAST\tLen\t"{}"\n'.format(metadata['title'].replace('"', '\"'))
     qs += u'LAST\tP1476\ten:"{}"\n'.format(
@@ -139,9 +138,12 @@ def metadata_to_quickstatements(metadata):
     qs += u'LAST\tP356\t"10.48550/ARXIV.{}"\n'.format(
             metadata['arxiv'])
 
+    # arXiv ID
+    qs += u'LAST\tP818\t"{}"'.format(metadata['arxiv'])
+
     # arXiv classifications such as "cs.LG"
     for classification in metadata['arxiv_classifications']:
-        qs += u'LAST\tP820\t"{}"\n'.format(
+        qs += u'\tP820\t"{}"\n'.format(
             classification.replace('"', '\"'))
 
     for n, authorname in enumerate(metadata['authornames'], start=1):

--- a/scholia/arxiv.py
+++ b/scholia/arxiv.py
@@ -141,10 +141,11 @@ def metadata_to_quickstatements(metadata):
     # arXiv ID
     qs += u'LAST\tP818\t"{}"'.format(metadata['arxiv'])
 
-    # arXiv classifications such as "cs.LG"
+    # arXiv classifications such as "cs.LG", as qualifier to arXiv ID
     for classification in metadata['arxiv_classifications']:
-        qs += u'\tP820\t"{}"\n'.format(
+        qs += u'\tP820\t"{}"'.format(
             classification.replace('"', '\"'))
+    qs += u"\n"
 
     for n, authorname in enumerate(metadata['authornames'], start=1):
         qs += u'LAST\tP2093\t"{}"\tP1545\t"{}"\n'.format(


### PR DESCRIPTION
Fixes #2232

### Description

Converted P820 claims from stand-alone statements to qualifiers on P818 statements
    
### Caveats

Errors in the P820 part (e.g. missing classifications) might affect the P818 statement. This is not handled yet.

Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [x]  This change requires a documentation update
    * [x]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [x]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing

1. Check out recent arXiv papers (e.g. via [this query](https://arxiv.org/search/advanced?advanced=&terms-0-operator=AND&terms-0-term=climate&terms-0-field=title&classification-physics_archives=all&classification-include_cross_list=include&date-filter_by=past_12&date-year=&date-from_date=&date-to_date=&date-date_type=submitted_date&abstracts=show&size=50&order=-announced_date_first)), pick one that looks suitable for Wikidata and copy its arXiv ID (```2301.04253``` in my case)
1. Paste that arXiv ID into ```arxiv-to-quickstatements``` and hit the "Extract metadata" button
1. Check the resulting QuickStatements: P820 shows up on the same line as P818

Before:

![Screenshot from 2023-01-28 02-19-59](https://user-images.githubusercontent.com/465923/215234528-dfca3539-1ee9-421b-b6c7-558125526489.png)


After:
![Screenshot from 2023-01-28 02-20-20](https://user-images.githubusercontent.com/465923/215234484-8fa5764a-eef2-4504-9375-b748ee4e0de0.png)


### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [ ] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
