### PR TITLE
There are enough articles now to have a table with recent articles with explicit CiTO annotations

### DIFF
--- a/scholia/app/templates/cito-index.html
+++ b/scholia/app/templates/cito-index.html
@@ -9,6 +9,7 @@
 {{ sparql_to_table('journal-counts') }}
 {{ sparql_to_table('statistics') }}
 {{ sparql_to_iframe('articles-by-year') }}
+{{ sparql_to_table('articles') }}
 
 {% endblock %}
 
@@ -28,6 +29,10 @@ Page with general info about CiTO annotation in Wikidata.
 <div class="embed-responsive embed-responsive-16by9">
   <iframe class="embed-responsive-item" id="articles-by-year-iframe"></iframe>
 </div>
+
+<h3 id="articles-header">Recent articles with explicit CiTO-annotation</h2>
+
+<table class="table table-hover" id="articles-table"></table>
 
 <h2 id="article-counts">Use of the various CiTO intentions</h2>
 

--- a/scholia/app/templates/cito-index_articles.sparql
+++ b/scholia/app/templates/cito-index_articles.sparql
@@ -1,0 +1,9 @@
+select distinct ?date ?work ?workLabel ?venue ?venueLabel where {
+  ?work wdt:P577 ?dates ;
+        p:P2860 / pq:P3712 / wdt:P31 wd:Q96471816 .
+  BIND(xsd:date(?dates) AS ?date)
+  ?work wdt:P31 wd:Q109229154 . bind("explicit" as ?type_)
+  ?work wdt:P1433 ?venue .
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+} ORDER BY DESC(?date)
+  LIMIT 50


### PR DESCRIPTION
A new feature and does not fix anything.

### Description
This patch add a table with recent articles with explicit CiTO annotations. If CiTO does not see further uptake, this table with get more boring over time. For now, this is a nice way to find articles with explicit CiTO annotation.
    
### Caveats

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

### Testing
This patch updates the `/cito/` page:

* https://scholia.toolforge.org/cito/

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
