### PR TITLE
Match the column header with the description (and query)

### DIFF
--- a/scholia/app/templates/protein_participates-in.sparql
+++ b/scholia/app/templates/protein_participates-in.sparql
@@ -1,13 +1,13 @@
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
-SELECT ?type ?complex ?complexLabel
+SELECT ?type ?complex_or_process ?complex_or_processLabel
 WITH {
-  SELECT DISTINCT ?type ?complex WHERE {
+  SELECT DISTINCT ?type ?complex_or_process WHERE {
     VALUES ?part { target: }
     VALUES ?process { wd:Q2996394 wd:Q4915012 }
-    { ?part ^wdt:P527 ?complex . ?complex wdt:P31 wd:Q22325163 ; BIND ("complex" AS ?type ) }
+    { ?part ^wdt:P527 ?complex_or_process . ?complex_or_process wdt:P31 wd:Q22325163 ; BIND ("complex" AS ?type ) }
     UNION
-    { ?part ^wdt:P527 ?complex . ?complex wdt:P31 ?process ; BIND ("biological process" AS ?type ) }
+    { ?part ^wdt:P527 ?complex_or_process . ?complex_or_process wdt:P31 ?process ; BIND ("biological process" AS ?type ) }
   }
 } AS %result
 WHERE {


### PR DESCRIPTION
Fixes #1606

### Description
The column header was still mentioning just "complex" but now matches the description.

### Caveats

None reported.

### Testing
* visit `/protein/Q88656943` and notice that the 2nd column header now writes `Complex or process`:

![image](https://user-images.githubusercontent.com/26721/218250321-ec4a2168-f7ed-40b0-a28c-324e149fb205.png)

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
