### PR TITLE
Removed redundant @id attributes

### DIFF
--- a/scholia/app/templates/chemical.html
+++ b/scholia/app/templates/chemical.html
@@ -46,17 +46,17 @@
 
 <table class="table table-hover" id="structural-identifiers-table"></table>
 
-<h2 id="Identifiers" id="identifiers">Identifiers</h2>
+<h2 id="identifiers">Identifiers</h2>
 
 <table class="table table-hover" id="identifiers-table"></table>
 
-<h2 id="Related" id="related">Compounds with same connectivity</h2>
+<h2 id="related">Compounds with same connectivity</h2>
 
 (Including the compound itself)
 
 <table class="table table-hover" id="related-table"></table>
 
-<h2 id="PhysChem" id="physchem-properties">Physchem Properties</h2>
+<h2 id="physchem-properties">Physchem Properties</h2>
 
 <table class="table table-hover" id="physchem-properties-table"></table>
 


### PR DESCRIPTION
Fixes #2226

### Description
The HTML had two `@id` attributes on various elements.
    
### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
