### PR TITLE
Fix/recognize retracted articles as articles

### DIFF
--- a/scholia/app/templates/chemical.html
+++ b/scholia/app/templates/chemical.html
@@ -46,17 +46,17 @@
 
 <table class="table table-hover" id="structural-identifiers-table"></table>
 
-<h2 id="Identifiers" id="identifiers">Identifiers</h2>
+<h2 id="identifiers">Identifiers</h2>
 
 <table class="table table-hover" id="identifiers-table"></table>
 
-<h2 id="Related" id="related">Compounds with same connectivity</h2>
+<h2 id="related">Compounds with same connectivity</h2>
 
 (Including the compound itself)
 
 <table class="table table-hover" id="related-table"></table>
 
-<h2 id="PhysChem" id="physchem-properties">Physchem Properties</h2>
+<h2 id="physchem-properties">Physchem Properties</h2>
 
 <table class="table table-hover" id="physchem-properties-table"></table>
 

--- a/scholia/query.py
+++ b/scholia/query.py
@@ -1136,6 +1136,7 @@ def q_to_class(q):
             'Q21481766',   # academic chapter
             'Q23927052',   # conference article
             'Q30070590',   # magazine article
+            'Q45182324',  # retracted article
             'Q47461344',   # written work
             'Q54670950',   # conference poster
             'Q56119332',   # tweet


### PR DESCRIPTION
Fixes #2243

### Description
Simple fix that adds `retracted article` as type that should open in `work/`.
    
### Testing

* Open https://scholia.toolforge.org/Q28264479
* Check if it opens as `work/` instead of `topic/`

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
