### PR TITLE
Enable CDK Depict, which is now available from Toolforge

### DIFF
--- a/scholia/api.py
+++ b/scholia/api.py
@@ -70,6 +70,10 @@ def entity_to_smiles(entity):
         smiles = statement['mainsnak']['datavalue']['value']
         return smiles
 
+    for statement in entity['claims'].get('P10718', []):
+        smiles = statement['mainsnak']['datavalue']['value']
+        return smiles
+
     return ''
 
 

--- a/scholia/app/templates/chemical.html
+++ b/scholia/app/templates/chemical.html
@@ -18,8 +18,6 @@
 <h1 id="h1">Chemical</h1>
 <script type="application/ld+json" id="bioschemas"></script>
 
-{% if third_parties_enabled %}
-
 <div class="card-deck mb-3">
     <div class="card mb-4 box-shadow">
 	<div class="card-body">
@@ -29,18 +27,12 @@
 
     <div class="card mb-4 box-shadow">
 	<div class="card-body">
-	    <img src="http://www.simolecule.com/cdkdepict/depict/bow/svg?smi={{smiles}}&abbr=on&hdisp=bridgehead&showtitle=false&zoom=2&annotate=cip" />
+	    <img src="http://cdkdepict.toolforge.org/depict/bow/svg?smi={{smiles}}&abbr=on&hdisp=bridgehead&showtitle=false&zoom=2&annotate=cip" />
 	</div>
     </div>
 </div>
 
-{% else %}
-
-<div id="intro"></div>
-
 <div id="wembedder"></div>
-
-{% endif %}
 
 <h2 id="structural-identifiers">Structural Information</h2>
 

--- a/scholia/app/templates/chemical.html
+++ b/scholia/app/templates/chemical.html
@@ -27,7 +27,7 @@
 
     <div class="card mb-4 box-shadow">
 	<div class="card-body">
-	    <img src="http://cdkdepict.toolforge.org/depict/bow/svg?smi={{smiles}}&abbr=on&hdisp=bridgehead&showtitle=false&zoom=2&annotate=cip" />
+	    <img src="http://cdkdepict.toolforge.org/depict/bow/svg?smi={{smiles|urlencode}}&abbr=on&hdisp=bridgehead&showtitle=false&zoom=2&annotate=cip" />
 	</div>
     </div>
 </div>


### PR DESCRIPTION
Implements solution for #1913

### Description
Previously, CDK Depict was not running on Toolforge and Scholia had the option to depict 2D structures as "third-party option" default turned off.

This patch turns it on by default.
    
### Caveats

* [x]  This change requires new dependencies (please list)

This adds a depedency on https://cdkdepict.toolforge.org/


### Testing
Open paracetamol:

* http://127.0.0.1:8100/chemical/Q57055

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
