### PR TITLE
Added a table with the journal receiving annotated citations

### DIFF
--- a/scholia/app/templates/cito-index.html
+++ b/scholia/app/templates/cito-index.html
@@ -7,6 +7,7 @@
 
 {{ sparql_to_table('article-counts') }}
 {{ sparql_to_table('journal-counts') }}
+{{ sparql_to_table('cited-journal-counts') }}
 {{ sparql_to_table('statistics') }}
 {{ sparql_to_iframe('articles-by-year') }}
 
@@ -39,6 +40,10 @@ in the total number of citations and in a number of different articles.
 <h2 id="journal-counts">Journals and how many CiTO-annotated citations they have</h2>
 
 <table class="table table-hover" id="journal-counts-table"></table>
+
+<h2 id="cited-journal-counts">Cited journals and how many CiTO-annotated citations they received</h2>
+
+<table class="table table-hover" id="cited-journal-counts-table"></table>
 
 {% endblock %}
 

--- a/scholia/app/templates/cito-index_cited-journal-counts.sparql
+++ b/scholia/app/templates/cito-index_cited-journal-counts.sparql
@@ -1,0 +1,11 @@
+SELECT ?citedJournal ?citedJournalLabel (CONCAT("/venue/", SUBSTR(STR(?citedJournal), 32), "#cito") AS ?journalUrl)
+(COUNT(DISTINCT ?citationStatement) AS ?citations) 
+(COUNT(DISTINCT ?citedArticle) AS ?articles) WHERE {
+  ?citingArticle p:P2860 ?citationStatement .
+  ?citationStatement pq:P3712 ?intention ;
+                     ps:P2860 ?citedArticle .
+  ?citedArticle wdt:P1433 ?citedJournal .
+  ?intention wdt:P31 wd:Q96471816 .
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+} GROUP BY ?citedJournal ?citedJournalLabel
+  ORDER BY DESC(?citations)


### PR DESCRIPTION
New feature.

### Description
We already had a table [Journals and how many CiTO-annotated citations they have](https://scholia.toolforge.org/cito/#journal-counts) table, and this patch adds the equivalent table for cited journals.
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

### Testing

* Check http://127.0.0.1:8100/cito/#cited-journal-counts (the number of rows should match the the top table, ~165)

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
