### PR TITLE
Fix #2247 related table in 404 chemical show

### DIFF
--- a/scholia/app/static/scholia.js
+++ b/scholia/app/static/scholia.js
@@ -643,7 +643,7 @@ function sparqlToPathWayPageViewer(sparql, filename){
 
 function sparqlToShortInchiKey(sparql, key,  element, filename) {
     var shortkey = key.substring(0,14);
-    var new_sparql = sparql.replace("_shortkey_",shortkey);
+    var new_sparql = sparql.replaceAll("_shortkey_", shortkey);
     sparqlToDataTable(new_sparql, element, filename);
 }
 

--- a/scholia/app/templates/404-chemical.html
+++ b/scholia/app/templates/404-chemical.html
@@ -12,7 +12,10 @@
 
 {% block page_content %}
 
-There was no chemical found with InChIKey={{ inchikey }}. Maybe these related compounds are of interest (may take some time):
+
+<h2 id="related">Related</h2>
+
+There was no chemical found with InChIKey={{ inchikey }}. Maybe these related compounds are of interest:
 
 <table class="table table-hover" id="related-table"></table>
 


### PR DESCRIPTION
The PR #2224 cause a variable not to be interpolated. Furthermore the header was missing and the table does not appear if there is not a h2, h3 or h4 section header.

Fixes #2247

### Description
This should fix issues with #2224 where the related table in the 404 page for a chemical did not show.
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* http://127.0.0.1:8100/inchikey/KDXKERNSBIXSR

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [ ] My changes generate no new warnings
* [ ] I have not used code from external sources without attribution
* [ ] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [ ] There are no remaining debug statements (print, console.log, ...)
