### PR TITLE
Suggestion: fewer WDQS URLs

### DIFF
--- a/scholia/network.py
+++ b/scholia/network.py
@@ -7,6 +7,8 @@ Usage:
 
 from collections import OrderedDict
 
+from .query import SPARQL_ENDPOINT
+
 import requests
 
 
@@ -34,7 +36,7 @@ def write_pajek_from_sparql(filename, sparql):
     column1 = 'item1'
     column2 = 'item2'
 
-    url = 'https://query.wikidata.org/sparql'
+    url = SPARQL_ENDPOINT
     params = {'query': sparql, 'format': 'json'}
     response = requests.get(url, params=params)
     data = response.json()['results']['bindings']

--- a/scholia/query.py
+++ b/scholia/query.py
@@ -58,6 +58,8 @@ from simplejson import JSONDecodeError
 
 from six import u
 
+SPARQL_ENDPOINT = "https://query.wikidata.org/sparql"
+
 USER_AGENT = 'Scholia'
 
 HEADERS = {'User-Agent': USER_AGENT}
@@ -173,7 +175,7 @@ def query_to_bindings(query):
         Data as list of dicts.
 
     """
-    url = 'https://query.wikidata.org/sparql'
+    url = SPARQL_ENDPOINT
     params = {'query': query, 'format': 'json'}
     response = requests.get(url, params=params, headers=HEADERS)
     data = response.json()
@@ -284,7 +286,7 @@ def identifier_to_qs(property, identifier):
         identifier=escape_string(identifier),
     )
 
-    url = 'https://query.wikidata.org/sparql'
+    url = SPARQL_ENDPOINT
     params = {'query': query, 'format': 'json'}
     try:
         response = requests.get(url, params=params, headers=HEADERS)
@@ -336,7 +338,7 @@ def count_scientific_articles():
     query = """
         SELECT (COUNT(*) AS ?count) WHERE { [] wdt:P31 wd:Q13442814 }"""
 
-    url = 'https://query.wikidata.org/sparql'
+    url = SPARQL_ENDPOINT
     params = {'query': query, 'format': 'json'}
     response = requests.get(url, params=params, headers=HEADERS)
     data = response.json()
@@ -374,7 +376,7 @@ def doi_to_qs(doi):
     query = 'select ?work where {{ ?work wdt:P356 "{doi}" }}'.format(
         doi=escape_string(doi.upper()))
 
-    url = 'https://query.wikidata.org/sparql'
+    url = SPARQL_ENDPOINT
     params = {'query': query, 'format': 'json'}
     response = requests.get(url, params=params, headers=HEADERS)
     data = response.json()
@@ -413,7 +415,7 @@ def doi_prefix_to_qs(doi):
     query = 'select ?work where {{ ?work wdt:P1662 "{doi}" }}'.format(
         doi=escape_string(doi.upper()))
 
-    url = 'https://query.wikidata.org/sparql'
+    url = SPARQL_ENDPOINT
     params = {'query': query, 'format': 'json'}
     response = requests.get(url, params=params, headers=HEADERS)
     data = response.json()
@@ -455,7 +457,7 @@ def iso639_to_q(language):
     else:
         raise ValueError('ISO639 language code not recognized')
 
-    url = 'https://query.wikidata.org/sparql'
+    url = SPARQL_ENDPOINT
     params = {'query': query, 'format': 'json'}
     response = requests.get(url, params=params, headers=HEADERS)
     data = response.json()
@@ -496,7 +498,7 @@ def pubchem_to_qs(cid):
     query = 'select ?chemical where {{ ?chemical wdt:P662 "{cid}" }}'.format(
         cid=cid)
 
-    url = 'https://query.wikidata.org/sparql'
+    url = SPARQL_ENDPOINT
     params = {'query': query, 'format': 'json'}
     response = requests.get(url, params=params, headers=HEADERS)
     data = response.json()
@@ -557,7 +559,7 @@ def pubmed_to_qs(pmid):
     query = 'select ?work where {{ ?work wdt:P698 "{pmid}" }}'.format(
         pmid=pmid)
 
-    url = 'https://query.wikidata.org/sparql'
+    url = SPARQL_ENDPOINT
     params = {'query': query, 'format': 'json'}
     response = requests.get(url, params=params, headers=HEADERS)
     data = response.json()
@@ -590,7 +592,7 @@ def ror_to_qs(rorid):
     query = 'select ?work where {{ ?work wdt:P6782 "{rorid}" }}'.format(
         rorid=rorid)
 
-    url = 'https://query.wikidata.org/sparql'
+    url = SPARQL_ENDPOINT
     params = {'query': query, 'format': 'json'}
     response = requests.get(url, params=params, headers=HEADERS)
     data = response.json()
@@ -626,7 +628,7 @@ def uniprot_to_qs(protein):
     query = 'select ?protein where {{ ?protein wdt:P352 "{protein}" }}'.format(
         protein=protein)
 
-    url = 'https://query.wikidata.org/sparql'
+    url = SPARQL_ENDPOINT
     params = {'query': query, 'format': 'json'}
     response = requests.get(url, params=params, headers=HEADERS)
     data = response.json()
@@ -662,7 +664,7 @@ def ncbi_gene_to_qs(gene):
     query = 'select ?gene where {{ ?gene wdt:P351 "{gene}" }}'.format(
         gene=gene)
 
-    url = 'https://query.wikidata.org/sparql'
+    url = SPARQL_ENDPOINT
     params = {'query': query, 'format': 'json'}
     response = requests.get(url, params=params, headers=HEADERS)
     data = response.json()
@@ -698,7 +700,7 @@ def ncbi_taxon_to_qs(taxon):
     query = 'select ?work where {{ ?work wdt:P685 "{taxon}" }}'.format(
         taxon=taxon)
 
-    url = 'https://query.wikidata.org/sparql'
+    url = SPARQL_ENDPOINT
     params = {'query': query, 'format': 'json'}
     response = requests.get(url, params=params, headers=HEADERS)
     data = response.json()
@@ -732,7 +734,7 @@ def wikipathways_to_qs(wpid):
              '?work wdt:P2410 ?wpid }}').format(
                  wpid=wpid)
 
-    url = 'https://query.wikidata.org/sparql'
+    url = SPARQL_ENDPOINT
     params = {'query': query, 'format': 'json'}
     response = requests.get(url, params=params, headers=HEADERS)
     data = response.json()
@@ -763,7 +765,7 @@ def issn_to_qs(issn):
     query = 'select ?author where {{ ?author wdt:P236 "{issn}" }}'.format(
         issn=escape_string(issn))
 
-    url = 'https://query.wikidata.org/sparql'
+    url = SPARQL_ENDPOINT
     params = {'query': query, 'format': 'json'}
     response = requests.get(url, params=params, headers=HEADERS)
     data = response.json()
@@ -794,7 +796,7 @@ def orcid_to_qs(orcid):
     query = 'select ?author where {{ ?author wdt:P496 "{orcid}" }}'.format(
         orcid=escape_string(orcid))
 
-    url = 'https://query.wikidata.org/sparql'
+    url = SPARQL_ENDPOINT
     params = {'query': query, 'format': 'json'}
     response = requests.get(url, params=params, headers=HEADERS)
     data = response.json()
@@ -825,7 +827,7 @@ def mesh_to_qs(meshid):
     query = 'select ?cmp where {{ ?cmp wdt:P486 "{meshid}" }}'.format(
         meshid=meshid)
 
-    url = 'https://query.wikidata.org/sparql'
+    url = SPARQL_ENDPOINT
     params = {'query': query, 'format': 'json'}
     response = requests.get(url, params=params, headers=HEADERS)
     data = response.json()
@@ -859,7 +861,7 @@ def q_to_dois(q):
     """
     query = """SELECT ?doi {{ wd:{q} wdt:P356 ?doi }}""".format(q=q)
 
-    url = 'https://query.wikidata.org/sparql'
+    url = SPARQL_ENDPOINT
     params = {'query': query, 'format': 'json'}
     response = requests.get(url, params=params, headers=HEADERS)
     data = response.json()
@@ -894,7 +896,7 @@ def q_to_label(q, language='en'):
         FILTER (LANG(?label) = "{language}") }}""".format(
         q=q, language=language)
 
-    url = 'https://query.wikidata.org/sparql'
+    url = SPARQL_ENDPOINT
     params = {'query': query, 'format': 'json'}
     response = requests.get(url, params=params, headers=HEADERS)
     data = response.json()
@@ -954,7 +956,7 @@ def search_article_titles(q, search_string=None):
     # addition during query.
     article_count = count_scientific_articles() + 1000
 
-    url = 'https://query.wikidata.org/sparql'
+    url = SPARQL_ENDPOINT
 
     batch_size = 500000
     loops = article_count // batch_size + 1
@@ -1026,7 +1028,7 @@ def viaf_to_qs(viaf):
     query = 'select ?author where {{ ?author wdt:P214 "{viaf}" }}'.format(
         viaf=escape_string(viaf))
 
-    url = 'https://query.wikidata.org/sparql'
+    url = SPARQL_ENDPOINT
     params = {'query': query, 'format': 'json'}
     response = requests.get(url, params=params, headers=HEADERS)
     data = response.json()
@@ -1060,7 +1062,7 @@ def q_to_class(q):
     query = 'SELECT ?class {{ wd:{q} wdt:P31 ?class }}'.format(
         q=escape_string(q))
 
-    url = 'https://query.wikidata.org/sparql'
+    url = SPARQL_ENDPOINT
     params = {'query': query, 'format': 'json'}
     response = requests.get(url, params=params, headers=HEADERS)
     try:
@@ -1295,7 +1297,7 @@ def q_to_class(q):
         query = 'select ?class where {{ wd:{q} wdt:P279+ ?class }}'.format(
             q=escape_string(q))
 
-        url = 'https://query.wikidata.org/sparql'
+        url = SPARQL_ENDPOINT
         params = {'query': query, 'format': 'json'}
         response = requests.get(url, params=params, headers=HEADERS)
         data = response.json()
@@ -1343,7 +1345,7 @@ def twitter_to_qs(twitter):
         twitter=escape_string(twitter), lower=escape_string(twitter).lower()
     )
 
-    url = 'https://query.wikidata.org/sparql'
+    url = SPARQL_ENDPOINT
     params = {'query': query, 'format': 'json'}
     response = requests.get(url, params=params, headers=HEADERS)
     data = response.json()
@@ -1376,7 +1378,7 @@ def github_to_qs(github):
                where {{ ?item wdt:P2037 "{github}" }}""".format(
         github=escape_string(github))
 
-    url = 'https://query.wikidata.org/sparql'
+    url = SPARQL_ENDPOINT
     params = {'query': query, 'format': 'json'}
     response = requests.get(url, params=params, headers=HEADERS)
     data = response.json()
@@ -1409,7 +1411,7 @@ def inchikey_to_qs(inchikey):
                where {{ ?item wdt:P235 "{inchikey}" }}""".format(
         inchikey=escape_string(inchikey))
 
-    url = 'https://query.wikidata.org/sparql'
+    url = SPARQL_ENDPOINT
     params = {'query': query, 'format': 'json'}
     response = requests.get(url, params=params, headers=HEADERS)
     data = response.json()
@@ -1442,7 +1444,7 @@ def cordis_to_qs(cordis):
                where {{ ?item wdt:P3400 "{cordis}" }}""".format(
         cordis=escape_string(cordis))
 
-    url = 'https://query.wikidata.org/sparql'
+    url = SPARQL_ENDPOINT
     params = {'query': query, 'format': 'json'}
     response = requests.get(url, params=params, headers=HEADERS)
     data = response.json()
@@ -1475,7 +1477,7 @@ def cas_to_qs(cas):
                where {{ ?item wdt:P231 "{cas}" }}""".format(
         cas=cas)
 
-    url = 'https://query.wikidata.org/sparql'
+    url = SPARQL_ENDPOINT
     params = {'query': query, 'format': 'json'}
     response = requests.get(url, params=params, headers=HEADERS)
     data = response.json()
@@ -1509,7 +1511,7 @@ def lipidmaps_to_qs(lmid):
     query = """select ?item
                where {{ ?item wdt:P2063 "{lmid}" }}""".format(
         lmid=lmid)
-    url = 'https://query.wikidata.org/sparql'
+    url = SPARQL_ENDPOINT
     params = {'query': query, 'format': 'json'}
     response = requests.get(url, params=params, headers=HEADERS)
     data = response.json()
@@ -1542,7 +1544,7 @@ def atomic_number_to_qs(atomic_number):
                WHERE {{ ?item wdt:P31 wd:Q11344 ; wdt:P1086 ?number .
                  FILTER (STR(?number) = "{atomic_number}") }}""".format(
         atomic_number=atomic_number)
-    url = 'https://query.wikidata.org/sparql'
+    url = SPARQL_ENDPOINT
     params = {'query': query, 'format': 'json'}
     response = requests.get(url, params=params, headers=HEADERS)
     data = response.json()
@@ -1574,7 +1576,7 @@ def atomic_symbol_to_qs(symbol):
     query = """SELECT ?item
                WHERE {{ ?item wdt:P246 "{symbol}" }}""".format(
         symbol=symbol)
-    url = 'https://query.wikidata.org/sparql'
+    url = SPARQL_ENDPOINT
     params = {'query': query, 'format': 'json'}
     response = requests.get(url, params=params, headers=HEADERS)
     data = response.json()
@@ -1608,7 +1610,7 @@ def website_to_qs(url):
     query = 'SELECT ?work WHERE {{ ?work wdt:P856 <{url}> }}'.format(
         url=url.strip())
 
-    url_ = 'https://query.wikidata.org/sparql'
+    url_ = SPARQL_ENDPOINT
     params = {'query': query, 'format': 'json'}
     response = requests.get(url_, params=params, headers=HEADERS)
     data = response.json()

--- a/scholia/rss.py
+++ b/scholia/rss.py
@@ -49,6 +49,8 @@ from re import sub
 
 from six import u
 
+from .query import SPARQL_ENDPOINT
+
 
 WORK_ITEM_RSS = u("""
     <item>
@@ -307,7 +309,7 @@ def wb_get_author_latest_works(q):
                 'type="application/rss+xml" />\n'
 
     query = AUTHOR_WORKS_SPARQL_QUERY.format(q=q)
-    url = 'https://query.wikidata.org/sparql'
+    url = SPARQL_ENDPOINT
     params = {'query': query, 'format': 'json'}
     response = requests.get(url, params=params)
 

--- a/scholia/scrape/ceurws.py
+++ b/scholia/scrape/ceurws.py
@@ -30,7 +30,7 @@ from lxml import etree
 import requests
 
 from ..qs import paper_to_quickstatements, proceedings_to_quickstatements
-from ..query import iso639_to_q
+from ..query import iso639_to_q, SPARQL_ENDPOINT as WDQS_URL
 from ..utils import escape_string, pages_to_number_of_pages
 
 
@@ -55,10 +55,6 @@ SELECT ?paper WHERE {{
   BIND(COALESCE(?full_text_url, ?url) AS ?paper)
 }}
 """)
-
-
-# SPARQL Endpoint for Wikidata Query Service
-WDQS_URL = 'https://query.wikidata.org/sparql'
 
 
 def url_to_volume(url):

--- a/scholia/scrape/nips.py
+++ b/scholia/scrape/nips.py
@@ -48,7 +48,7 @@ import requests
 
 from ..qs import paper_to_quickstatements
 from ..utils import escape_string
-
+from ..query import SPARQL_ENDPOINT as WDQS_URL
 
 PAPER_TO_Q_QUERY = u("""
 SELECT ?paper WHERE {{
@@ -63,8 +63,6 @@ SELECT ?paper WHERE {{
 URL_BASE = "https://papers.nips.cc"
 
 USER_AGENT = "Scholia"
-
-WDQS_URL = 'https://query.wikidata.org/sparql'
 
 # Year should be the nominal year, - not the year of publication
 YEAR_TO_Q = {

--- a/scholia/scrape/ojs.py
+++ b/scholia/scrape/ojs.py
@@ -32,7 +32,7 @@ from lxml import etree
 import requests
 
 from ..qs import paper_to_quickstatements
-from ..query import iso639_to_q, issn_to_qs
+from ..query import iso639_to_q, issn_to_qs, SPARQL_ENDPOINT as WDQS_URL
 from ..utils import escape_string, pages_to_number_of_pages
 
 
@@ -57,10 +57,6 @@ SELECT ?paper WHERE {{
   BIND(COALESCE(?full_text_url, ?url) AS ?paper)
 }}
 """)
-
-
-# SPARQL Endpoint for Wikidata Query Service
-WDQS_URL = 'https://query.wikidata.org/sparql'
 
 
 def issue_url_to_paper_urls(url):

--- a/scholia/text.py
+++ b/scholia/text.py
@@ -30,6 +30,8 @@ from os.path import exists, expanduser, join
 
 from six.moves import cPickle as pickle
 
+from .query import SPARQL_ENDPOINT
+
 import re
 
 import json
@@ -160,7 +162,7 @@ class TextToTopicQText():
 
         """
         response = requests.get(
-            'https://query.wikidata.org/sparql',
+            SPARQL_ENDPOINT,
             params={'query': TOPIC_LABELS_SPARQL, 'format': 'json'},
             headers=self.headers)
 
@@ -170,7 +172,7 @@ class TextToTopicQText():
             # In some cases a timeout may occur in the middle of a response,
             # making the JSON returned invalid.
             response = requests.get(
-                'https://query.wikidata.org/sparql',
+                SPARQL_ENDPOINT,
                 params={'query': TOPIC_LABELS_SPARQL, 'format': 'json'},
                 headers=self.headers)
             try:

--- a/scholia/wikipedia.py
+++ b/scholia/wikipedia.py
@@ -29,6 +29,8 @@ import requests
 
 from six import b, u
 
+from .query import SPARQL_ENDPOINT
+
 
 BIBLIOGRAPHY_SPARQL_QUERY = """
 select ?work ?title ?venueLabel ?date ?volume ?issue ?pages
@@ -103,7 +105,7 @@ def q_to_bibliography_templates(q):
 
     """
     query = BIBLIOGRAPHY_SPARQL_QUERY.format(q=q)
-    url = 'https://query.wikidata.org/sparql'
+    url = SPARQL_ENDPOINT
     params = {'query': query, 'format': 'json'}
     response = requests.get(url, params=params)
     data = response.json()


### PR DESCRIPTION
Addresses #2250 

### Description
It moves the WDQS SPARQL endpoint URL to a central place. 
    
### Caveats
There are many alternatives possible, including a configuration file. Or another location.

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

* [x]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Run Scholia functionality, the web UI, but also the command line utilities (I tested them, but you want to verify that).

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [ ] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
