### PR TITLE
Speeding up 'Compounds with same connectivity' query on the chemical/ pages too

### DIFF
--- a/scholia/app/templates/chemical_related.sparql
+++ b/scholia/app/templates/chemical_related.sparql
@@ -19,6 +19,7 @@ SELECT ?mol ?molLabel ?InChIKey ?CAS ?ChemSpider ?PubChem_CID WITH {
       }
     ?mol wdt:P235 ?InChIKey .
     FILTER (regex(str(?InChIKey), ?filter))
+    FILTER (?InChIKey != ?queryKey)
   }
 } AS %MOLS2 {
   INCLUDE %MOLS2

--- a/scholia/app/templates/chemical_related.sparql
+++ b/scholia/app/templates/chemical_related.sparql
@@ -1,12 +1,29 @@
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
 # title: related chemical structures
-SELECT ?mol ?molLabel ?InChIKey ?CAS ?ChemSpider ?PubChem_CID WHERE {
-  target: wdt:P235 ?queryKey .
-  ?mol wdt:P235 ?InChIKey .
+SELECT ?mol ?molLabel ?InChIKey ?CAS ?ChemSpider ?PubChem_CID WITH {
+  SELECT ?queryKey ?srsearch ?filter WHERE {
+    target: wdt:P235 ?queryKey .
+    BIND (CONCAT(substr($queryKey,1,14), " haswbstatement:P235") AS ?srsearch)
+    BIND (CONCAT("^", substr($queryKey,1,14)) AS ?filter)
+  }
+} AS %MOLS WITH {
+  SELECT ?mol ?InChIKey WHERE {
+    INCLUDE %MOLS
+    SERVICE wikibase:mwapi {
+        bd:serviceParam wikibase:endpoint "www.wikidata.org";
+        wikibase:api "Search";
+        mwapi:srsearch ?srsearch;
+        mwapi:srlimit "max".
+        ?mol wikibase:apiOutputItem mwapi:title.
+      }
+    ?mol wdt:P235 ?InChIKey .
+    FILTER (regex(str(?InChIKey), ?filter))
+  }
+} AS %MOLS2 {
+  INCLUDE %MOLS2
   OPTIONAL { ?mol wdt:P231 ?CAS }
   OPTIONAL { ?mol wdt:P661 ?ChemSpider }
   OPTIONAL { ?mol wdt:P662 ?PubChem_CID }
-  FILTER (regex(str(?InChIKey), concat("^", substr($queryKey,1,14), "-")))
   SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
 }


### PR DESCRIPTION
Earlier this year we improved the speed of the InChIKey 404 page (https://github.com/WDscholia/scholia/commit/eec1eebf226de1fed9d1978f8c4ed350a74b7793), and this patch migrates that idea to the `chemical/` aspect.

### Description
This patch uses `wikibase:mwapi` to significantly speed up the listing of chemical structures with the same chemical connectivity. This happens in three steps (using SELECT-WITH-WITH-WHERE). The first step asks for the InChIKey for the target chemical and prepares the search strings. The second step uses the prepared search strings to use `wikibase:mwapi` to find related InChIKeys and a `FILTER` to remove false positives. The last steps adds looking up some additional information for the found chemicals.
    
### Caveats

One caveat is the further dependency on the Blazegraph backend, but that's not new.

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

### Testing

* Compare '[Compounds with same connectivity](https://scholia.toolforge.org/chemical/Q9154808#related)' section before and after the patch: the results must be identical

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [X] I have not used code from external sources without attribution
* [X] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [X] There are no remaining debug statements (print, console.log, ...)
