### PR TITLE
Update event_proceedings.sparql

### DIFF
--- a/scholia/app/templates/event_proceedings.sparql
+++ b/scholia/app/templates/event_proceedings.sparql
@@ -14,7 +14,7 @@ WITH {
     (GROUP_CONCAT(DISTINCT ?topic_label; separator=", ") AS ?topics)
     (CONCAT("../topics/", GROUP_CONCAT(DISTINCT SUBSTR(STR(?topic), 32); separator=",")) AS ?topicsUrl)
   WHERE {
-    ?work wdt:P1433 / wdt:P4745 target: .
+    ?work wdt:P1433 | wdt:P4745 target: .
     OPTIONAL {
       ?work wdt:P50 ?author .
       ?author rdfs:label ?author_label . FILTER(LANG(?author_label) = "en")


### PR DESCRIPTION

### Description
Shouldn't it be a pipe instead of a slash symbol to fetch proceedings papers both if they are linked to the conference P1433 or P4745?.
    


### Testing
 e.g. (https://w.wiki/6Srr) => https://www.wikidata.org/wiki/Q117148828 is proceedings of https://www.wikidata.org/wiki/Q117090183 only linked by P4745. 


