### PR TITLE
Added the number of datasets with explicit CiTO annotations

### DIFF
--- a/scholia/app/templates/cito-index_statistics.sparql
+++ b/scholia/app/templates/cito-index_statistics.sparql
@@ -40,6 +40,11 @@ WITH {
                  wdt:P1433 ?venue .
   }
 } AS %citoJournalsExplicit
+WITH {
+  SELECT (COUNT(DISTINCT ?citoDataset) AS ?count) WHERE {
+    ?citoDataset wdt:P31 wd:Q117357566 .
+  }
+} AS %citoDatasets
 WHERE {
   {
     INCLUDE %annotions
@@ -74,6 +79,11 @@ WHERE {
   {
     INCLUDE %citoArticles
     BIND("Number of article with explicit CiTO annotation" AS ?description)
+  }
+  UNION
+  {
+    INCLUDE %citoDatasets
+    BIND("Number of data sets with explicit CiTO annotation" AS ?description)
   }
   UNION
   {


### PR DESCRIPTION
New feature.

### Description
Besides journal articles and individual annotations, there are also datasets with explicit CiTO annotation, e.g. as the outcome of a literature study. This addition uses a new Wikidata item for datasets with explicit CiTO annotation, allowing us a way to track them. There are three that I currently know of, two of which are in Wikidata.
    
### Caveats

None that I can think of.

### Testing

* open https://scholia.toolforge.org/cito/ and notice the extra line:

![image](https://user-images.githubusercontent.com/26721/229305581-fe985c3f-b8fd-418d-9d67-fa8e59208465.png)

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
