### PR TITLE
Map subclassed items of drink to the topic aspect

### DIFF
--- a/scholia/query.py
+++ b/scholia/query.py
@@ -1303,6 +1303,10 @@ def q_to_class(q):
                    for item in data['results']['bindings']]
 
         if set(parents).intersection([
+                'Q40050',  # drink
+                ]):
+            class_ = 'topic'
+        elif set(parents).intersection([
                 'Q11173',  # chemical compound
                 'Q79529',  # chemical substance
                 ]):


### PR DESCRIPTION
### Description
Currently, [drinks](http://www.wikidata.org/entity/Q40050) are mapped to the 'chemical-class' aspect; I think that items with this parent would be better off defaulting to the 'topic' aspect. This commit makes that so.
    
### Caveats
There may be instances where this would not be ideal, but I'm not aware of any. Thoughts by people more familiar with  chemistry would be much appreciated!

### Testing
I have tested this change using Gitpod.
Local changes can be tested with this URL (using [whisky](http://www.wikidata.org/entity/Q281) as an example):
* http://127.0.0.1:8100/Q281

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
