### PR TITLE
Fix #2274 extended OJS scraper for article URLs

### DIFF
--- a/scholia/scrape/ojs.py
+++ b/scholia/scrape/ojs.py
@@ -96,6 +96,10 @@ def issue_url_to_paper_urls(url):
         # This scheme is also used in version 3.2.1.4 of OJS
         # For instance, for https://tidsskrift.dk/bras/issue/view/9150
         urls = tree.xpath("//h3[@class='media-heading']/a/@href")
+    if len(urls) == 0:
+        # For instance, for
+        # https://www.journals.vu.lt/scandinavistica/issue/view/1153
+        urls = tree.xpath("//div[@class='article-summary-title']/a/@href")
     return urls
 
 


### PR DESCRIPTION
Fixes #2274

### Description
Fix #2274 extended OJS scraper for article URLs: The scraper for Open Journal System did not work for https://www.journals.vu.lt/scandinavistica/issue/view/1153
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

I have not been able to test the code locally with all of the tox rules.

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* `python -m scholia.scrape.ojs issue-url-to-quickstatements https://www.journals.vu.lt/scandinavistica/issue/view/1153` and similar now works

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
