### PR TITLE
Add identifiers table for genes

### DIFF
--- a/scholia/app/templates/gene.html
+++ b/scholia/app/templates/gene.html
@@ -4,6 +4,7 @@
 
 {% block in_ready %}
 
+{{ sparql_to_table('identifiers') }}
 {{ sparql_to_table('transcripts') }}
 {{ sparql_to_table('proteins') }}
 {{ sparql_to_table('orthologs') }}
@@ -17,6 +18,10 @@
 <script type="application/ld+json" id="bioschemas"></script>
 
 <div id="intro"></div>
+
+<h2 id="transcripts">Identifiers</h2>
+
+<table class="table table-hover" id="identifiers-table"></table>
 
 <h2 id="transcripts">Transcripts</h2>
 

--- a/scholia/app/templates/gene_identifiers.sparql
+++ b/scholia/app/templates/gene_identifiers.sparql
@@ -1,0 +1,29 @@
+PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
+
+# title: identifiers for this chemical
+SELECT
+  ?Identifier ?IdentifierLabel
+  ?Value (SAMPLE(?idUrls) as ?ValueUrl)
+  ?IdentifierDescription
+WITH {
+  SELECT ?Identifier ?Value ?formatterurl WHERE {
+    target: ?IDdir ?Value .
+    ?Identifier wikibase:directClaim ?IDdir ;
+            wdt:P31 wd:Q42415497 .
+    OPTIONAL { 
+      ?Identifier wdt:P1630 ?formatterurl .
+    }
+  } LIMIT 500
+} AS %RESULTS {
+  {
+    SELECT * WHERE {
+      INCLUDE %RESULTS
+      FILTER (?Identifier != wd:P234)
+      BIND(IRI(REPLACE(?formatterurl, '\\\\$1', str(?Value))) AS ?idUrls).
+    }
+  }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+}
+GROUP BY ?Identifier ?IdentifierLabel ?IdentifierDescription ?Value
+ORDER BY ASC(?IdentifierLabel)
+

--- a/scholia/app/templates/gene_identifiers.sparql
+++ b/scholia/app/templates/gene_identifiers.sparql
@@ -1,6 +1,6 @@
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
-# title: identifiers for this chemical
+# title: identifiers for this gene
 SELECT
   ?Identifier ?IdentifierLabel
   ?Value (SAMPLE(?idUrls) as ?ValueUrl)
@@ -18,7 +18,6 @@ WITH {
   {
     SELECT * WHERE {
       INCLUDE %RESULTS
-      FILTER (?Identifier != wd:P234)
       BIND(IRI(REPLACE(?formatterurl, '\\\\$1', str(?Value))) AS ?idUrls).
     }
   }


### PR DESCRIPTION
### Description
This PR adds a table for gene identifiers, similar to the table in the `chemical` aspect. E.g. https://scholia.toolforge.org/gene/Q14859578 (http://127.0.0.1:8100/gene/Q14859578):

Before:
![Screenshot_20230503_204242](https://user-images.githubusercontent.com/14018963/236013269-e98c29ed-b227-4879-993b-76cb673de28a.png)

After:
![Screenshot_20230503_204807](https://user-images.githubusercontent.com/14018963/236014452-313968de-10ef-4900-8643-01a2addb66b9.png)

### Caveats

`tox` is failing, but that is seemingly due to https://www.wikidata.org/w/index.php?title=Q20980928&diff=prev&oldid=1884075303.

### Testing

* Go to http://127.0.0.1:8100/gene/Q14859578
* Check other genes

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
