### PR TITLE
Fix #2282 Change doctest for identifier change

### DIFF
--- a/scholia/query.py
+++ b/scholia/query.py
@@ -273,9 +273,9 @@ def identifier_to_qs(property, identifier):
     Examples
     --------
     >>> property = "P10283"  # Property identifier for OpenAlex ID
-    >>> identifier = "A2736231928"  # Corresponding to Q20980928 (Finn Nielsen)
+    >>> identifier = "A303257169"  # Corresponding to Q20980928 (E Willighagen)
     >>> qs = identifier_to_qs(property, identifier)
-    >>> qs == ['Q20980928']
+    >>> qs == ['Q20895241']
     True
 
     """
@@ -523,7 +523,7 @@ def openalex_to_qs(openalex):
 
     Examples
     --------
-    >>> openalex_to_qs('A2736231928') == ['Q20980928']
+    >>> openalex_to_qs('A303257169') == ['Q20895241']
     True
 
     """


### PR DESCRIPTION
The OpenAlex identifier for an author was changed in Wikidata. That identifier was used in a doctest for Scholia, so the doctest failed. This fix change the test to another person with an apparently more stable OpenAlex identifier.

Fixes #2282

### Description
The OpenAlex identifier for an author was changed in Wikidata.
That identifier was used in a doctest for Scholia, so the doctest
failed. This fix change the test to another person with an
apparently more stable OpenAlex identifier.

### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

Not tested!

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* python3.7 -m pytest --doctest-modules scholia/query.py
* python3.10 -m pytest --doctest-modules scholia/query.py

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
