### PR TITLE
Fix #2278 US patent handling

### DIFF
--- a/scholia/app/templates/work_data.sparql
+++ b/scholia/app/templates/work_data.sparql
@@ -10,6 +10,16 @@ WHERE {
   }
   UNION
   {
+    BIND(1.5 AS ?order)
+    BIND("Type" AS ?description)
+    ?work wdt:P31 ?iri .
+    BIND(SUBSTR(STR(?iri), 32) AS ?q) 
+    ?iri rdfs:label ?value_string . 
+    FILTER (LANG(?value_string) = 'en')
+    BIND(COALESCE(?value_string, ?q) AS ?value)
+  }
+  UNION
+  {
     SELECT
       (2 AS ?order)
       ("Authors" AS ?description)

--- a/scholia/query.py
+++ b/scholia/query.py
@@ -1136,6 +1136,7 @@ def q_to_class(q):
             'Q21481766',   # academic chapter
             'Q23927052',   # conference article
             'Q30070590',   # magazine article
+            'Q43305660',  # United States patent
             'Q45182324',  # retracted article
             'Q47461344',   # written work
             'Q54670950',   # conference poster


### PR DESCRIPTION
A US patent now defaults to 'work' aspect
The type of the work is now shown in the top data panel

Fixes #2278

### Description
> Please include a summary of the change, relevant motivation and context. If possible and applicable, include before and after screenshots and a URL where the changes can be seen.
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

Completes two environments. Two of my other environments does not work.

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* http://127.0.0.1:8100/Q118062753

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
