### PR TITLE
Add co-occurring WikiProject panel

### DIFF
--- a/scholia/app/templates/wikiproject.html
+++ b/scholia/app/templates/wikiproject.html
@@ -6,7 +6,7 @@
 
 {{ sparql_to_table("maintained") }}
 {{ sparql_to_table("focus") }}
-{{ sparql_to_table('co-occurring-wikiprojects') }}
+{{ sparql_to_table('co-occurring') }}
 
 {{ sparql_to_iframe('context') }}
 {{ sparql_to_table('recently-published-works') }}

--- a/scholia/app/templates/wikiproject.html
+++ b/scholia/app/templates/wikiproject.html
@@ -6,6 +6,7 @@
 
 {{ sparql_to_table("maintained") }}
 {{ sparql_to_table("focus") }}
+{{ sparql_to_table('co-occurring-wikiprojects') }}
 
 {{ sparql_to_iframe('context') }}
 {{ sparql_to_table('recently-published-works') }}
@@ -40,6 +41,10 @@
 <div class="embed-responsive embed-responsive-16by9">
   <iframe class="embed-responsive-item" id="context-iframe"></iframe>
 </div>
+
+<h2 id="co-occurring-wikiprojects">Co-occurring WikiProjects</h2>
+
+<table class="table table-hover" id="co-occurring-wikiprojects-table"></table>
 
 <h2 id="works">Works</h2>
 

--- a/scholia/app/templates/wikiproject_co-occurring.sparql
+++ b/scholia/app/templates/wikiproject_co-occurring.sparql
@@ -1,0 +1,27 @@
+#defaultView:Table
+
+PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
+
+SELECT ?count
+       ?wikiproject ?wikiprojectLabel (CONCAT("/wikiproject/", SUBSTR(STR(?wikiproject), 32)) AS ?wikiprojectUrl)
+       ?example_work ?example_workLabel (CONCAT("/work/", SUBSTR(STR(?example_work), 32)) AS ?example_workUrl)
+WITH {
+  SELECT (COUNT(?work) AS ?count) ?wikiproject (SAMPLE(?work) AS ?example_work) WHERE {
+    # Find works for the specific queried wikiproject
+	  VALUES ?p { wdt:P6104 wdt:P5008 }
+	  SERVICE bd:sample { ?work ?p target: . bd:serviceParam bd:sample.limit 100000 }
+    
+    # Find co-occuring wikiprojects
+    ?work ?p ?wikiproject .
+    
+    # Avoid listing the queried wikiproject
+      FILTER (target: != ?wikiproject)
+  }
+  GROUP BY ?wikiproject
+} AS %result
+WHERE {
+  # Label the results
+  INCLUDE %result
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+}
+ORDER BY DESC(?count)

--- a/scholia/app/templates/wikiproject_topics.sparql
+++ b/scholia/app/templates/wikiproject_topics.sparql
@@ -9,7 +9,6 @@ WITH {
   SELECT (COUNT(?work) AS ?count) ?topic (SAMPLE(?work) AS ?example_work) WHERE {
     # Find works for the specific queried topic
 	  VALUES ?p { wdt:P6104 wdt:P5008 }
-    # Find works for the specific queried topic
 	  SERVICE bd:sample { ?work ?p target: . bd:serviceParam bd:sample.limit 10000 }
     
     # Find co-occuring topics


### PR DESCRIPTION
Daniel mentioned that it would be useful to see co-occurring WikiProjects like we do with co-occurring topics on the topics aspect

### Description
> Please include a summary of the change, relevant motivation and context. If possible and applicable, include before and after screenshots and a URL where the changes can be seen.

#### WikiProject Invasion Biology    
![image](https://github.com/WDscholia/scholia/assets/6676843/a1599e77-5bba-4c14-827d-d3e5766ef703)

#### WikiProject Covid-19
![image](https://github.com/WDscholia/scholia/assets/6676843/23071923-1307-4757-9196-21b0f3af5ba7)

#### WikiProject Film
![image](https://github.com/WDscholia/scholia/assets/6676843/85a59fe6-4280-435b-b9b7-840096337837)



### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* Test A
* Test B

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [ ] My changes generate no new warnings
* [ ] I have not used code from external sources without attribution
* [ ] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [ ] There are no remaining debug statements (print, console.log, ...)
