### PR TITLE
Fix ORCID URL after structure was changed

### DIFF
--- a/scholia/app/templates/author_most-citing-authors.sparql
+++ b/scholia/app/templates/author_most-citing-authors.sparql
@@ -6,7 +6,7 @@ SELECT
   ?citing_author ?citing_authorLabel
 
   # Either show the ORCID iD or construct part of a URL to search on the ORCID homepage
-  (COALESCE(?orcid_, CONCAT("orcid-search/quick-search/?searchQuery=", ENCODE_FOR_URI(?citing_authorLabel))) AS ?orcid)
+  (COALESCE(?orcid_, CONCAT("orcid-search/search/?searchQuery=", ENCODE_FOR_URI(?citing_authorLabel))) AS ?orcid)
 WITH {
   SELECT (COUNT(?citing_work) AS ?count) ?citing_author WHERE {
     ?work wdt:P50 target: .

--- a/scholia/app/templates/dataset_list-of-authors.sparql
+++ b/scholia/app/templates/dataset_list-of-authors.sparql
@@ -24,7 +24,7 @@ WHERE {
     }
     OPTIONAL { ?author_ wdt:P496 ?orcid_ . }
     # Either show the ORCID iD or construct part of a URL to search on the ORCID homepage
-    BIND(COALESCE(?orcid_, CONCAT("orcid-search/quick-search/?searchQuery=", ENCODE_FOR_URI(?author))) AS ?orcid)
+    BIND(COALESCE(?orcid_, CONCAT("orcid-search/search/?searchQuery=", ENCODE_FOR_URI(?author))) AS ?orcid)
     OPTIONAL {
       ?author_ schema:description ?authorDescription .
       FILTER (LANG(?authorDescription) = "en")

--- a/scholia/app/templates/topic_authors.sparql
+++ b/scholia/app/templates/topic_authors.sparql
@@ -5,7 +5,7 @@ PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 SELECT
   ?count
   ?author ?authorLabel ?authorDescription (CONCAT("/author/", SUBSTR(STR(?author), 32)) AS ?authorUrl)
-  (COALESCE(?orcid_, CONCAT("orcid-search/quick-search/?searchQuery=", ?authorLabel)) AS ?orcid) 
+  (COALESCE(?orcid_, CONCAT("orcid-search/search/?searchQuery=", ?authorLabel)) AS ?orcid) 
 WITH {
   SELECT
     ?author

--- a/scholia/app/templates/wikiproject_authors.sparql
+++ b/scholia/app/templates/wikiproject_authors.sparql
@@ -5,7 +5,7 @@ PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 SELECT
   ?count
   ?author ?authorLabel ?authorDescription (CONCAT("/author/", SUBSTR(STR(?author), 32)) AS ?authorUrl)
-  (COALESCE(?orcid_, CONCAT("orcid-search/quick-search/?searchQuery=", ?authorLabel)) AS ?orcid) 
+  (COALESCE(?orcid_, CONCAT("orcid-search/search/?searchQuery=", ?authorLabel)) AS ?orcid) 
 WITH {
   SELECT
     ?author

--- a/scholia/app/templates/work-curation_missing-orcid.sparql
+++ b/scholia/app/templates/work-curation_missing-orcid.sparql
@@ -5,7 +5,7 @@ SELECT DISTINCT
   (CONCAT("/author/", SUBSTR(STR(?author), 32)) AS ?authorUrl)
 
   ("ORCID search ↗" AS ?orcid_search)
-  (CONCAT("https://orcid.org/orcid-search/quick-search/?searchQuery=", ENCODE_FOR_URI(?authorLabel)) AS ?orcid_searchUrl)
+  (CONCAT("https://orcid.org/orcid-search/search/?searchQuery=", ENCODE_FOR_URI(?authorLabel)) AS ?orcid_searchUrl)
 
 WHERE {
   target: wdt:P50 ?author .


### PR DESCRIPTION
Fixing same issue as Daniel's PR here https://github.com/arthurpsmith/author-disambiguator/pull/187

### Description
> Please include a summary of the change, relevant motivation and context. If possible and applicable, include before and after screenshots and a URL where the changes can be seen.
    
ORCID changed their search URL so we need to use a different structure. I searched for all occurrences in the repository and fixed them

### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* Test A
* Test B

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [ ] My changes generate no new warnings
* [ ] I have not used code from external sources without attribution
* [ ] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
