### PR TITLE
Faster query: applied WITH/AS/WHERE to postpone looking up labels and author info

### DIFF
--- a/scholia/app/templates/venue_recently-published-works.sparql
+++ b/scholia/app/templates/venue_recently-published-works.sparql
@@ -3,23 +3,27 @@
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
 SELECT
-  (MIN(?publication_date_) AS ?publication_date)
+  ?publication_date
   ?work ?workLabel
   (GROUP_CONCAT(DISTINCT ?author_label; separator=", ") AS ?authors)
   (CONCAT("../authors/", GROUP_CONCAT(DISTINCT SUBSTR(STR(?author), 32); separator=",")) AS ?authorsUrl)
-WHERE {
-  ?work wdt:P1433 target: .
-  OPTIONAL {
-    ?work wdt:P577 ?publication_datetime . 
-    BIND(xsd:date(?publication_datetime) AS ?publication_date_)
-  }
+WITH {
+  SELECT DISTINCT ?work (MIN(?publication_date_) AS ?publication_date) WHERE {
+    ?work wdt:P1433 target: .
+    OPTIONAL {
+      ?work wdt:P577 ?publication_datetime .
+      BIND(xsd:date(?publication_datetime) AS ?publication_date_)
+    }
+  } GROUP BY ?work
+    ORDER BY DESC(?publication_date)
+    LIMIT 1000
+} AS %ARTICLES WHERE {
+  INCLUDE %ARTICLES
   OPTIONAL {
     ?work wdt:P50 ?author .
     ?author rdfs:label ?author_label .
     FILTER (LANG(?author_label) = 'en')
   }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
-}
-GROUP BY ?work ?workLabel
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+} GROUP BY ?publication_date ?work ?workLabel
 ORDER BY DESC(?publication_date)
-LIMIT 1000


### PR DESCRIPTION
Not a fix, just a more performant query. The problem was that the list of recent articles for [Nature](https://scholia.toolforge.org/venue/Q180445#recently-published-works):

![image](https://github.com/WDscholia/scholia/assets/26721/e5951404-f313-484d-915d-6a38e780cbb1)

### Description
This patch applies our common solution of WITH/AS in the SPARQL query.
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

### Testing
* https://scholia.toolforge.org/venue/Q180445#recently-published-works should now complete in under 20 seconds

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [ ] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
