### PR TITLE
Implemented random work

### DIFF
--- a/scholia/app/templates/work-index.html
+++ b/scholia/app/templates/work-index.html
@@ -17,6 +17,13 @@
 
 Scientific articles, conference articles, books, ...
 
+<p>
+    <div class="btn-group">
+	<a title="Sample a random work among all works. This query takes several seconds."
+	   href="random"
+	   class="btn btn-primary">Random work</a>
+    </div>
+</p>
 
 <div class="container">
 

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -22,7 +22,7 @@ from ..query import (arxiv_to_qs, cas_to_qs, atomic_symbol_to_qs, doi_to_qs,
                      twitter_to_qs, cordis_to_qs, mesh_to_qs, pubmed_to_qs,
                      lipidmaps_to_qs, ror_to_qs, wikipathways_to_qs,
                      pubchem_to_qs, atomic_number_to_qs, ncbi_taxon_to_qs,
-                     ncbi_gene_to_qs, uniprot_to_qs)
+                     ncbi_gene_to_qs, uniprot_to_qs, random_work)
 from ..utils import sanitize_q, remove_special_characters_url
 from ..wikipedia import q_to_bibliography_templates
 
@@ -2042,6 +2042,20 @@ def show_work_export(q):
 
     """
     return render_template('work-export.html', q=q)
+
+
+@main.route('/work/random')
+def show_work_random():
+    """Redirect to random work.
+
+    Returns
+    -------
+    reponse : werkzeug.wrappers.Response
+        Redirect
+
+    """
+    q = random_work()
+    return redirect(url_for('app.show_work', q=q), code=302)
 
 
 @main.route('/cito/' + q_pattern)

--- a/scholia/query.py
+++ b/scholia/query.py
@@ -24,6 +24,7 @@ Usage:
   scholia.query q-to-label <q>
   scholia.query q-to-class <q>
   scholia.query random-author
+  scholia.query random-work
   scholia.query ror-to-q <rorid>
   scholia.query twitter-to-q <twitter>
   scholia.query uniprot-to-q <protein>
@@ -1668,6 +1669,50 @@ def random_author():
     return q
 
 
+def random_work():
+    """Return random work.
+
+    Sample a scientific work randomly from Wikidata by a call to the Wikidata
+    Query Service.
+
+    Returns
+    -------
+    q : str
+        Wikidata identifier.
+
+    Notes
+    -----
+    The work returned is not necessarily a scholarly work.
+
+    The algorithm uses a somewhat hopeful randomization and if no work is
+    found it falls back on Q21146099.
+
+    Examples
+    --------
+    >>> q = random_work()
+    >>> q.startswith('Q')
+    True
+
+    """
+    # Generate 100 random Q-items and hope that one of them is a work with an
+    # work
+    values = " ".join("wd:Q{}".format(randrange(1, 100000000))
+                      for _ in range(100))
+
+    query = """SELECT ?work {{
+                 VALUES ?work {{ {values} }}
+                 ?work wdt:P50 ?author .
+               }}
+               LIMIT 1""".format(values=values)
+    bindings = query_to_bindings(query)
+    if len(bindings) > 0:
+        q = bindings[0]['work']['value'][31:]
+    else:
+        # Fallback
+        q = "Q21146099"
+    return q
+
+
 def main():
     """Handle command-line interface."""
     from docopt import docopt
@@ -1802,6 +1847,10 @@ def main():
 
     elif arguments['random-author']:
         q = random_author()
+        print(q)
+
+    elif arguments['random-work']:
+        q = random_work()
         print(q)
 
     elif arguments['twitter-to-q']:


### PR DESCRIPTION
Fixes #284

### Description
Adds the `Random` button for works.
    
### Caveats

* The default comes from the `/work/` index page
* I wonder if the `random_x` method can be generalized

### Testing

* Open http://127.0.0.1:8100/work/random twice
* Check the presence of the blue `Random` button on http://127.0.0.1:8100/work/

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [ ] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [ ] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [ ] There are no remaining debug statements (print, console.log, ...)
