### PR TITLE
Link to Wikidata statistics page too

### DIFF
--- a/scholia/app/templates/index-statistics.html
+++ b/scholia/app/templates/index-statistics.html
@@ -15,7 +15,9 @@
 
     <h2 id="statistics">Statistics</h2>
 
-    Scholia uses Wikidata for all its data. What is the size of our data corpus?
+    Scholia uses Wikidata for all its data, which provides
+    <a href="https://www.wikidata.org/wiki/Wikidata:Statistics">more statistics</a>.
+    What is the size of the data corpus relevant to Scholia?
 
     <table class="table table-hover" id="statistics-table"></table>
     


### PR DESCRIPTION
Does not immediate fix something, but linking to the general Wikidata Statistics pages seems to make sense.

### Description
Adds the link and slightly rewrites the text accordingly.
    
### Caveats
I am not 100% happy with the text. Please improve the text if you feel needed.

### Testing
Visit https://scholia.toolforge.org/statistics and test the link.

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
