### PR TITLE
Disease index page and OMIM redirect

### DIFF
--- a/scholia/app/templates/disease-index.html
+++ b/scholia/app/templates/disease-index.html
@@ -4,20 +4,62 @@
 
 {% block page_content %}
 
-<h1>Disease</h1>
+<h1>Diseases</h1>
 
-Diseases.
+<div class="container">
 
-<h2>Examples</h2>
+    <h2>Examples</h2>
 
-<ul>
-    <li><a href="Q41112">Schizophrenia</a></li>
-    <li><a href="Q431643">Microcephaly</a></li>
-    <li><a href="Q917357">Rett syndrome</a></li>
-    <li><a href="Q8071861">Zika fever</a></li>
-    <li><a href="Q10863074">Fatty liver disease</a></li>
-</ul>
+    <div class="card-deck mb-3">
+	<div class="card mb-4 box-shadow">
+
+            <div class="card-header">
+		<h4 class="my-0 font-weight-normal">Single items</h4>
+            </div>
+            <div class="card-body">
+		<dl>
+		    <dt><a href="Q41112">Schizophrenia</a></dt>
+		    <dd>
+			A mental disorder characterized by continuous or relapsing episodes of psychosis.
+		    </dd>
+
+		    <dt><a href="Q431643">Microcephaly</a></dt>
+		    <dd>
+			A medical condition involving a smaller-than-normal head.
+		    </dd>
+
+		    <dt><a href="Q917357">Rett syndrome</a></dt>
+		    <dd>
+			A genetic disorder that typically becomes apparent after 6–18 months of age and almost exclusively in females.
+		    </dd>
+
+		    <dt><a href="Q8071861">Zika fever</a></dt>
+		    <dd>
+			An infectious disease caused by the Zika virus.
+		    </dd>
+
+		    <dt><a href="Q10863074">Fatty liver disease</a></dt>
+		    <dd>
+			A condition where excess fat builds up in the liver.
+		    </dd>
+		</dl>
+            </div>
+
+	</div>
+
+     <div class="card mb-4 box-shadow">
+	    <div class="card-header">
+		    <h4 class="my-0 font-weight-normal">Redirecting</h4>
+	    </div>
+	    <div class="card-body">
+		<p>If you know the identifier, then Scholia can make a lookup based on the identifier:</p>
+
+		<dl>
+		    <dt><a href="../omim/137580">omim/137580</a></dt>
+		    <dd>Look up OMIM ID 137580. This will redirect to Tourette syndrome.</dd>
+		</dl>
+	    </div>
+    </div>
+</div>
 
 {% endblock %}
-
-  

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -16,7 +16,7 @@ from ..arxiv import metadata_to_quickstatements, string_to_arxiv
 from ..arxiv import get_metadata as get_arxiv_metadata
 from ..query import (arxiv_to_qs, cas_to_qs, atomic_symbol_to_qs, doi_to_qs,
                      doi_prefix_to_qs, github_to_qs, biorxiv_to_qs,
-                     chemrxiv_to_qs,
+                     chemrxiv_to_qs, omim_to_qs,
                      identifier_to_qs, inchikey_to_qs, issn_to_qs, orcid_to_qs,
                      viaf_to_qs, q_to_class, q_to_dois, random_author,
                      twitter_to_qs, cordis_to_qs, mesh_to_qs, pubmed_to_qs,
@@ -1082,6 +1082,23 @@ def redirect_mesh(meshid):
         method = 'app.show_' + class_
         return redirect(url_for(method, q=q), code=302)
     return render_template('404.html', error=could_not_find("MeSH ID"))
+
+
+@main.route('/omim/<omimID>')
+def redirect_omim(omimID):
+    """Detect and redirect for OMIM identifiers.
+
+    Parameters
+    ----------
+    omim : str
+        OMIM identifier.
+
+    """
+    qs = omim_to_qs(omimID)
+    if len(qs) > 0:
+        q = qs[0]
+        return redirect(url_for('app.show_author', q=q), code=302)
+    return render_template('404.html', error=could_not_find("OMIM ID"))
 
 
 @main.route('/orcid/<orcid>')

--- a/scholia/query.py
+++ b/scholia/query.py
@@ -18,6 +18,7 @@ Usage:
   scholia.query mesh-to-q <meshid>
   scholia.query ncbi-gene-to-q <gene>
   scholia.query ncbi-taxon-to-q <taxon>
+  scholia.query omim-to-q <omimID>
   scholia.query orcid-to-q <orcid>
   scholia.query pubchem-to-q <cid>
   scholia.query pubmed-to-q <pmid>
@@ -769,6 +770,37 @@ def issn_to_qs(issn):
     data = response.json()
 
     return [item['author']['value'][31:]
+            for item in data['results']['bindings']]
+
+
+def omim_to_qs(omimID):
+    """Convert OMIM identifier to Wikidata ID.
+
+    Parameters
+    ----------
+    omim : str
+        OMIM identifier
+
+    Returns
+    -------
+    qs : list of str
+        List of strings with Wikidata IDs.
+
+    Examples
+    --------
+    >>> omim_to_qs('181500') == ['Q41112']
+    True
+
+    """
+    query = 'select ?disease where {{ ?disease wdt:P492 "{omimID}" }}'.format(
+        omimID=escape_string(omimID))
+
+    url = 'https://query.wikidata.org/sparql'
+    params = {'query': query, 'format': 'json'}
+    response = requests.get(url, params=params, headers=HEADERS)
+    data = response.json()
+
+    return [item['disease']['value'][31:]
             for item in data['results']['bindings']]
 
 
@@ -1754,6 +1786,11 @@ def main():
 
     elif arguments['ncbi-taxon-to-q']:
         qs = ncbi_taxon_to_qs(arguments['<taxon>'])
+        if len(qs) > 0:
+            print(qs[0])
+
+    elif arguments['omim-to-q']:
+        qs = omim_to_qs(arguments['<omimID>'])
         if len(qs) > 0:
             print(qs[0])
 


### PR DESCRIPTION
Addresses #924

### Description
Adds a modern index page and redirection for OMIM identifiers:

![image](https://github.com/WDscholia/scholia/assets/26721/2a3b66f3-5452-4c61-8317-249d2bab698b)
    
### Caveats
Only implements one of the suggested redirects.

Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [x]  This change requires a documentation update
    * [x]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [x]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
* Go to http://127.0.0.1:8100/disease/ and check if it looks like the above screenshot
* Click the redirect which should lead to https://scholia.toolforge.org/topic/Q191779

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
