### PR TITLE
WDQS-compatible titles

### DIFF
--- a/scholia/app/templates/chemical_identifiers.sparql
+++ b/scholia/app/templates/chemical_identifiers.sparql
@@ -1,6 +1,6 @@
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
-# title: identifiers for this chemical
+#title: identifiers for this chemical
 SELECT
   ?Identifier ?IdentifierLabel
   ?Value (SAMPLE(?idUrls) as ?ValueUrl)

--- a/scholia/app/templates/chemical_physchem-properties.sparql
+++ b/scholia/app/templates/chemical_physchem-properties.sparql
@@ -1,6 +1,6 @@
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
-# title: physicochemical properties of this chemical
+#title: physicochemical properties of this chemical
 SELECT DISTINCT ?propEntity ?propEntityLabel ?value ?units ?unitsLabel ?qualifiers ?source ?sourceLabel ?doi
 WITH {
   SELECT DISTINCT ?propEntity ?value ?units ?source ?doi (GROUP_CONCAT(?qualifierStr; separator=", ") AS ?qualifiers) WHERE {

--- a/scholia/app/templates/chemical_publications-per-year.sparql
+++ b/scholia/app/templates/chemical_publications-per-year.sparql
@@ -1,7 +1,7 @@
 #defaultView:BarChart
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
-# title: publications per year for this chemical
+#title: publications per year for this chemical
 # Inspired from LEGOLAS - http://abel.lis.illinois.edu/legolas/
 # Shubhanshu Mishra, Vetle Torvik
 select ?year (count(?work) as ?number_of_publications) where {

--- a/scholia/app/templates/chemical_recent-literature.sparql
+++ b/scholia/app/templates/chemical_recent-literature.sparql
@@ -1,4 +1,4 @@
-# title: recent literature about this chemical
+#title: recent literature about this chemical
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
 SELECT ?date ?work ?workLabel ?type ?via ?topics

--- a/scholia/app/templates/chemical_related.sparql
+++ b/scholia/app/templates/chemical_related.sparql
@@ -1,6 +1,6 @@
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
-# title: related chemical structures
+#title: related chemical structures
 SELECT ?mol ?molLabel ?InChIKey ?CAS ?ChemSpider ?PubChem_CID WITH {
   SELECT ?queryKey ?srsearch ?filter WHERE {
     target: wdt:P235 ?queryKey .

--- a/scholia/app/templates/chemical_relates.sparql
+++ b/scholia/app/templates/chemical_relates.sparql
@@ -1,6 +1,6 @@
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
-# title: related chemical structures
+#title: related chemical structures
 SELECT ?mol ?molLabel ?InChIKey ?CAS ?ChemSpider ?PubChem_CID WHERE {
   target: wdt:P235 ?queryKey .
   ?mol wdt:P235 ?InChIKey .

--- a/scholia/app/templates/chemical_structural-identifiers.sparql
+++ b/scholia/app/templates/chemical_structural-identifiers.sparql
@@ -1,6 +1,6 @@
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
-# title: structural identifiers for this chemical structure
+#title: structural identifiers for this chemical structure
 SELECT
   ?Structural_identifier ?Structural_identifierLabel
   ?idLit (SAMPLE(?idUrls) as ?idUrl)

--- a/scholia/app/templates/clinical-trial-index_recent-clinical-trials.sparql
+++ b/scholia/app/templates/clinical-trial-index_recent-clinical-trials.sparql
@@ -1,4 +1,4 @@
-# title: Clinical trials sorted according to date
+#title: Clinical trials sorted according to date
 SELECT ?start_date ?trial ?trialLabel
 WITH {
   SELECT * WHERE { 

--- a/scholia/app/templates/country_co-organizations.sparql
+++ b/scholia/app/templates/country_co-organizations.sparql
@@ -1,4 +1,4 @@
-# title: Co-organizations for a specific country
+#title: Co-organizations for a specific country
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
 #defaultView:Map

--- a/scholia/app/templates/country_locations-as-topics.sparql
+++ b/scholia/app/templates/country_locations-as-topics.sparql
@@ -1,4 +1,4 @@
-# title: Locations as topics for a specific country
+#title: Locations as topics for a specific country
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
 #defaultView:Map{"markercluster":true}.

--- a/scholia/app/templates/country_narrative-locations.sparql
+++ b/scholia/app/templates/country_narrative-locations.sparql
@@ -1,4 +1,4 @@
-# title: Narrative locations for a specific country
+#title: Narrative locations for a specific country
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
 #defaultView:Map{"markercluster":true}.

--- a/scholia/app/templates/country_organizations.sparql
+++ b/scholia/app/templates/country_organizations.sparql
@@ -1,4 +1,4 @@
-# title: Organizations for a specific country
+#title: Organizations for a specific country
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
 SELECT

--- a/scholia/app/templates/event-series_events.sparql
+++ b/scholia/app/templates/event-series_events.sparql
@@ -1,6 +1,6 @@
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
-# title: List of event and proceedings for a specific event series
+#title: List of event and proceedings for a specific event series
 SELECT DISTINCT 
   (SAMPLE(?years) AS ?year)
   (SAMPLE(?ordinal) AS ?ordinal)

--- a/scholia/app/templates/gene_identifiers.sparql
+++ b/scholia/app/templates/gene_identifiers.sparql
@@ -1,6 +1,6 @@
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
-# title: identifiers for this gene
+#title: identifiers for this gene
 SELECT
   ?Identifier ?IdentifierLabel
   ?Value (SAMPLE(?idUrls) as ?ValueUrl)

--- a/scholia/app/templates/location-topic_nearby-researchers.sparql
+++ b/scholia/app/templates/location-topic_nearby-researchers.sparql
@@ -1,7 +1,7 @@
 PREFIX target1: <http://www.wikidata.org/entity/{{ q1 }}>
 PREFIX target2: <http://www.wikidata.org/entity/{{ q2 }}>
 
-# title: Nearby researchers that work with a specific topic and near a specified geographical entity
+#title: Nearby researchers that work with a specific topic and near a specified geographical entity
 SELECT
   ?score
   ?author ?authorLabel (CONCAT("/author/", SUBSTR(STR(?author), 32)) AS ?authorUrl)

--- a/scholia/app/templates/location_nearby-organizations.sparql
+++ b/scholia/app/templates/location_nearby-organizations.sparql
@@ -1,6 +1,6 @@
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
-# title: Nearby academic institutions around a specified geographic entity.
+#title: Nearby academic institutions around a specified geographic entity.
 SELECT
   ?distance ?unit ?unitLabel
   ?organization ?organizationLabel ?organizationDescription (CONCAT("/organization/", SUBSTR(STR(?organization), 32)) AS ?organizationUrl)

--- a/scholia/app/templates/organization_employees-and-affiliated.sparql
+++ b/scholia/app/templates/organization_employees-and-affiliated.sparql
@@ -1,4 +1,4 @@
-# title: Employees and affiliated with a specified organization
+#title: Employees and affiliated with a specified organization
 
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 

--- a/scholia/app/templates/project_statistics.sparql
+++ b/scholia/app/templates/project_statistics.sparql
@@ -1,4 +1,4 @@
-# title: Statistics for projects identifiers
+#title: Statistics for projects identifiers
 SELECT ?count ?description {
   {
     { SELECT (COUNT(*) AS ?count) WHERE { [] wdt:P3400 []. } }

--- a/scholia/app/templates/sponsor_authors-on-sponsored-works.sparql
+++ b/scholia/app/templates/sponsor_authors-on-sponsored-works.sparql
@@ -1,4 +1,4 @@
-# title: Authors on works sponsored or funded from a specific entity.
+#title: Authors on works sponsored or funded from a specific entity.
 
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 

--- a/scholia/app/templates/sponsor_co-sponsors.sparql
+++ b/scholia/app/templates/sponsor_co-sponsors.sparql
@@ -1,6 +1,6 @@
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
-# title: Co-funders to a specific funder including an example funded work
+#title: Co-funders to a specific funder including an example funded work
 SELECT ?count 
 ?sponsor ?sponsorLabel (CONCAT("/sponsor/", SUBSTR(STR(?sponsor), 32)) AS ?sponsorUrl)
 ?example_work ?example_workLabel (CONCAT("/work/", SUBSTR(STR(?example_work), 32)) AS ?example_workUrl)

--- a/scholia/app/templates/sponsor_project-budgets.sparql
+++ b/scholia/app/templates/sponsor_project-budgets.sparql
@@ -1,4 +1,4 @@
-# title: Scatterplot of project budgets associated with a funder
+#title: Scatterplot of project budgets associated with a funder
 
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 

--- a/scholia/app/templates/topics_authors.sparql
+++ b/scholia/app/templates/topics_authors.sparql
@@ -1,4 +1,4 @@
-# title: Authors for specific topics
+#title: Authors for specific topics
 SELECT
   ?score
   ?author ?authorLabel (CONCAT("/author/", SUBSTR(STR(?author), 32)) AS ?authorUrl)

--- a/scholia/app/templates/topics_list-of-topics.sparql
+++ b/scholia/app/templates/topics_list-of-topics.sparql
@@ -1,4 +1,4 @@
-# title: List of topics
+#title: List of topics
 SELECT
   ?topic ?topicLabel ?topicDescription (CONCAT("/topic/", SUBSTR(STR(?topic), 32)) AS ?topicUrl)
   ?example_work ?example_workLabel (CONCAT("/work/", SUBSTR(STR(?example_work), 32)) AS ?example_workUrl)

--- a/scholia/app/templates/topics_list-of-works.sparql
+++ b/scholia/app/templates/topics_list-of-works.sparql
@@ -1,4 +1,4 @@
-# title: List of works on any combination of specific topics
+#title: List of works on any combination of specific topics
 SELECT
   ?count 
   (MIN(?publication_date_) AS ?publication_date)

--- a/scholia/app/templates/uses_authors.sparql
+++ b/scholia/app/templates/uses_authors.sparql
@@ -1,4 +1,4 @@
-# title: Authors for specific uses
+#title: Authors for specific uses
 SELECT
   ?uses ?works
   ?author ?authorLabel (CONCAT("/author/", SUBSTR(STR(?author), 32)) AS ?authorUrl)

--- a/scholia/app/templates/uses_list-of-uses.sparql
+++ b/scholia/app/templates/uses_list-of-uses.sparql
@@ -1,4 +1,4 @@
-# title: List of uses
+#title: List of uses
 SELECT
   ?use ?useLabel ?useDescription (CONCAT("/use/", SUBSTR(STR(?use), 32)) AS ?useUrl)
   ?example_work ?example_workLabel (CONCAT("/work/", SUBSTR(STR(?example_work), 32)) AS ?example_workUrl)

--- a/scholia/app/templates/uses_list-of-works.sparql
+++ b/scholia/app/templates/uses_list-of-works.sparql
@@ -1,4 +1,4 @@
-# title: List of works on any combination of specific uses
+#title: List of works on any combination of specific uses
 SELECT
   ?count 
   (MIN(?publication_date_) AS ?publication_date)

--- a/scholia/app/templates/venue_articles-citing-retracted-articles.sparql
+++ b/scholia/app/templates/venue_articles-citing-retracted-articles.sparql
@@ -1,6 +1,6 @@
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
-# title: Articles in a specific venue citing retracted articles
+#title: Articles in a specific venue citing retracted articles
 SELECT DISTINCT
   ?retracted_work ?retracted_workLabel
   ?date

--- a/scholia/app/templates/venue_author-awards.sparql
+++ b/scholia/app/templates/venue_author-awards.sparql
@@ -1,6 +1,6 @@
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
-# title: Author awards for a specific venue
+#title: Author awards for a specific venue
 SELECT DISTINCT
   ?year 
   ?author ?authorLabel

--- a/scholia/app/templates/venue_author-gender-distribution.sparql
+++ b/scholia/app/templates/venue_author-gender-distribution.sparql
@@ -1,6 +1,6 @@
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
-# title: Author gender distribution for a specific venue
+#title: Author gender distribution for a specific venue
 SELECT ?count ?gender ?genderLabel 
 WITH {
   SELECT (COUNT(DISTINCT ?author) AS ?count) ?gender WHERE {

--- a/scholia/app/templates/venue_author-images.sparql
+++ b/scholia/app/templates/venue_author-images.sparql
@@ -1,4 +1,4 @@
-# title: Author images for a specific venue
+#title: Author images for a specific venue
 
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 

--- a/scholia/app/templates/venue_authors.sparql
+++ b/scholia/app/templates/venue_authors.sparql
@@ -1,4 +1,4 @@
-# title: Prolific authors for a specific journal
+#title: Prolific authors for a specific journal
 
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 

--- a/scholia/app/templates/venue_authorship-gender-distribution.sparql
+++ b/scholia/app/templates/venue_authorship-gender-distribution.sparql
@@ -1,4 +1,4 @@
-# title: Authorship gender distribution for a specific venue
+#title: Authorship gender distribution for a specific venue
 
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 

--- a/scholia/app/templates/venue_citation-distribution.sparql
+++ b/scholia/app/templates/venue_citation-distribution.sparql
@@ -1,4 +1,4 @@
-# title: Citation distribution for a venue
+#title: Citation distribution for a venue
 
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 

--- a/scholia/app/templates/venue_cited-venues.sparql
+++ b/scholia/app/templates/venue_cited-venues.sparql
@@ -1,6 +1,6 @@
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
-# title: Cited venues from specific journal
+#title: Cited venues from specific journal
 SELECT
   ?count
   ?short_name

--- a/scholia/app/templates/venue_citing-venues.sparql
+++ b/scholia/app/templates/venue_citing-venues.sparql
@@ -1,4 +1,4 @@
-# title: Venues citing articles from this specific journal
+#title: Venues citing articles from this specific journal
 
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 

--- a/scholia/app/templates/venue_co-author-graph.sparql
+++ b/scholia/app/templates/venue_co-author-graph.sparql
@@ -1,4 +1,4 @@
-# title: Co-author graph for a specific venue
+#title: Co-author graph for a specific venue
 
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 

--- a/scholia/app/templates/venue_most-cited-articles.sparql
+++ b/scholia/app/templates/venue_most-cited-articles.sparql
@@ -1,4 +1,4 @@
-# title: Most cited articles published in specific venue
+#title: Most cited articles published in specific venue
 
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 

--- a/scholia/app/templates/venue_most-cited-authors.sparql
+++ b/scholia/app/templates/venue_most-cited-authors.sparql
@@ -1,4 +1,4 @@
-# title: Most cited authors published in venue
+#title: Most cited authors published in venue
 
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 

--- a/scholia/app/templates/venue_topics.sparql
+++ b/scholia/app/templates/venue_topics.sparql
@@ -1,4 +1,4 @@
-# title: Count of topics in published work in specified venue
+#title: Count of topics in published work in specified venue
 
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 


### PR DESCRIPTION
Fixes #2304

### Description
Removes the space so that the `#title:` information can be used by the WDQS.
    
### Caveats
While not aware of it, I am not 100% sure there is not a downstream use of the space.

Check any of the following which apply:

* [x]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

### Testing
* See the example in https://github.com/WDscholia/scholia/issues/2304

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
