### PR TITLE
Added a curation page for /chemical/

### DIFF
--- a/scholia/app/templates/chemical-curation.html
+++ b/scholia/app/templates/chemical-curation.html
@@ -5,10 +5,15 @@
 {% block in_ready %}
 
 {{ sparql_to_table('missing-main-subjects') }}
+{{ sparql_to_table('missing-properties') }}
 
 {% endblock %}
 
 {% block curation_panels %}
+
+<h2 id="missing-properties">Missing chemical properties</h2>
+
+<table class="table table-hover" id="missing-properties-table"></table>
 
 <h2 id="missing-main-subjects">Articles possibly about the chemical</h2>
 

--- a/scholia/app/templates/chemical-curation.html
+++ b/scholia/app/templates/chemical-curation.html
@@ -1,0 +1,23 @@
+{% extends "q_curation.html" %}
+
+{% set aspect = "chemical-curation" %}
+
+{% block in_ready %}
+
+{{ sparql_to_table('missing-main-subjects') }}
+
+{% endblock %}
+
+{% block curation_panels %}
+
+<h2 id="missing-main-subjects">Articles possibly about the chemical</h2>
+
+The following query looks for articles with the name of the chemical in
+the name. The use is non-trivial and chemical name entity recognition is
+notoriously hard. Look up for misassignments because a search for, for example,
+<i>quassin</i> also matches the more precise <i>(+)-quassin</i>, and
+<i>L-proline</i> also matches the related-but-different <i>l-proline-based amino acid phenolates</i>.
+
+<table class="table table-hover" id="missing-main-subjects-table"></table>
+
+{% endblock %}

--- a/scholia/app/templates/chemical-curation_missing-main-subjects.sparql
+++ b/scholia/app/templates/chemical-curation_missing-main-subjects.sparql
@@ -1,0 +1,30 @@
+PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
+
+SELECT DISTINCT ?item ?itemLabel ?chemicalname
+  (CONCAT(SUBSTR(STR(?item),32), "\tP921\t{{ q }}\tS887\tQ69652283") AS ?quickStatements)
+  (CONCAT("https://quickstatements.toolforge.org/#/v1=",
+          SUBSTR(STR(?item),32), "%7CP921%7C{{ q }}%7CS887%7CQ69652283") AS ?quickStatementsUrl)
+WITH {
+  SELECT  ?item ?chemicalname WHERE {
+    VALUES ?chemicalType {
+      wd:Q113145171 # type of a chemical entity
+      wd:Q59199015 # group of stereoisomers
+    }
+    target: wdt:P31 ?chemicalType ; rdfs:label ?chemicalname .
+    FILTER(lang(?chemicalname) = "en")
+    SERVICE wikibase:mwapi {
+      bd:serviceParam wikibase:endpoint "www.wikidata.org";
+      wikibase:api "Generator";
+      mwapi:generator "search";
+      mwapi:gsrsearch ?chemicalname;
+      mwapi:gsrlimit "max".
+      ?item wikibase:apiOutputItem mwapi:title.
+    }
+    ?item wdt:P1476 ?title .
+    MINUS {?item wdt:P921 target: }
+    FILTER (REGEX(LCASE(?title), LCASE(CONCAT( "\\\\", "b", ?chemicalname ,"\\\\", "b"))))
+  } LIMIT 200
+} AS %items WHERE {
+  INCLUDE %items
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+}

--- a/scholia/app/templates/chemical-curation_missing-properties.sparql
+++ b/scholia/app/templates/chemical-curation_missing-properties.sparql
@@ -1,0 +1,11 @@
+PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
+
+SELECT ?property ?propertyLabel WHERE {
+  VALUES ?property {
+    wdt:P2177 wdt:P2102 wdt:P2101 wdt:p3078 wdt:P2119
+    wdt:P3071 wdt:P2054 wdt:P2128 wdt:P1117
+  }
+  MINUS { target: ?property [] }
+  ?property ^wikibase:directClaim / wdt:P1629 / rdfs:label ?propertyLabel .
+  FILTER (lang(?propertyLabel) = "en")
+}


### PR DESCRIPTION
* implements #1909 

### Description
Curation page for chemicals.

#### chemical name in article titles

![image](https://github.com/WDscholia/scholia/assets/26721/82991ed4-eb5e-4e57-bc04-501cc1fef69d)
  
#### missing chemical properties

![image](https://github.com/WDscholia/scholia/assets/26721/27a2e276-cbd6-4632-901c-81b4fc609d66)

### Caveats
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* test the curation page for L-proline: http://127.0.0.1:8100/chemical/Q20035886/curation

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [ ] My changes generate no new warnings
* [ ] I have not used code from external sources without attribution
* [ ] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [ ] There are no remaining debug statements (print, console.log, ...)
