### PR TITLE
Like *Label, *ChemicalStructure is a new special, expects a SMILES and will use CDK Depict (Toolforge) to visualize the chemical structure in 2D

### DIFF
--- a/scholia/app/static/scholia.js
+++ b/scholia/app/static/scholia.js
@@ -85,6 +85,8 @@ function convertDataTableData(data, columns) {
         var column = columns[i];
         if (column.slice(-11) == 'Description') {
             convertedColumns.push(column.slice(0, column.length - 11) + ' description');
+        } else if (column.slice(-17) == 'ChemicalStructure') {
+            convertedColumns.push(column.slice(0, column.length - 17) + ' structure');
         } else if (column.slice(-5) == 'Label') {
             // pass
         } else if (column.slice(-3) == 'Url') {
@@ -106,6 +108,13 @@ function convertDataTableData(data, columns) {
             convertedRow[key] = '<a href="' +
 		    data[i][key + 'Url'] +
 		    '">' + data[i][key + 'Label'] + '</a>';
+
+	    } else if (key.slice(-17) == 'ChemicalStructure') {
+            convertedRow[key.slice(0, key.length - 17) + ' structure'] = '<img loading="lazy" src="' +
+            'https://cdkdepict.toolforge.org/depict/bow/svg?smi=' +
+		    encodeURIComponent(data[i][key]) +
+            '&abbr=on&hdisp=bridgehead&showtitle=false&zoom=2&annotate=cip' +
+		    '" />';
 
 	    } else if (
 			key + 'Label' in data[i] &&

--- a/scholia/app/templates/taxon_metabolome.sparql
+++ b/scholia/app/templates/taxon_metabolome.sparql
@@ -1,20 +1,23 @@
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
 SELECT DISTINCT
-  ?metabolite ?metaboliteLabel ?metaboliteDescription
+  ?metabolite ?metaboliteLabel ?metaboliteChemicalStructure ?metaboliteDescription
 WITH {
   SELECT DISTINCT ?children WHERE {
       ?children (wdt:P171*) target:.
   }
 } AS %taxa 
 WITH {
-  SELECT DISTINCT ?metabolite WHERE {
+  SELECT DISTINCT ?metabolite ?metaboliteChemicalStructure WHERE {
     INCLUDE %taxa
             { ?metabolite wdt:P703 ?children }
     UNION
     { ?metabolite wdt:P1582 ?children }
     VALUES ?chemical { wd:Q11173 wd:Q59199015 wd:Q56256086 wd:Q15711994 }.
     ?metabolite wdt:P31|wdt:P279/wdt:P31 ?chemical .
+    OPTIONAL { ?metabolite wdt:P233 ?canSmiles }
+    OPTIONAL { ?metabolite wdt:P2017 ?isoSmiles }
+    BIND(COALESCE(?isoSmiles, ?canSmiles) AS ?metaboliteChemicalStructure)
   }
 } AS %results {
   INCLUDE %results


### PR DESCRIPTION
Fixes #1427

### Description
Added some more Scholia logic to "recognize" `*ChemicalStructure` columns and then expects a SMILES (canonical or isomeric) and will use the Toolforge CDK Depict instance to display the 2D structure. The column gets renamed to `* structure` (like with `*Description`).

![image](https://github.com/WDscholia/scholia/assets/26721/3ea4d147-b311-4e9c-abbf-64d670945b16)
    
### Caveats
There is a change (like with `*Label`) that we accidentally use if for something other than SMILES (rare, I expect).

Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [x]  This change requires a documentation update
    * [x]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

### Testing
The patch uses this new functionality on the `taxon` page:

* Try pinus: http://127.0.0.1:8100/taxon/Q12024#metabolome

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
