### PR TITLE
More wide use of AUTO_LANGUAGE in SPARQL queries

### DIFF
--- a/scholia/app/templates/404-chemical_related.sparql
+++ b/scholia/app/templates/404-chemical_related.sparql
@@ -15,5 +15,5 @@ SELECT ?mol ?molLabel ?InChIKey ?CAS ?ChemSpider ?PubChem_CID WITH {
   OPTIONAL { ?mol wdt:P231 ?CAS }
   OPTIONAL { ?mol wdt:P661 ?ChemSpider }
   OPTIONAL { ?mol wdt:P662 ?PubChem_CID }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }

--- a/scholia/app/templates/404-chemical_related.sparql
+++ b/scholia/app/templates/404-chemical_related.sparql
@@ -15,5 +15,5 @@ SELECT ?mol ?molLabel ?InChIKey ?CAS ?ChemSpider ?PubChem_CID WITH {
   OPTIONAL { ?mol wdt:P231 ?CAS }
   OPTIONAL { ?mol wdt:P661 ?ChemSpider }
   OPTIONAL { ?mol wdt:P662 ?PubChem_CID }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }

--- a/scholia/app/templates/author-curation_missing-citing-author-items.sparql
+++ b/scholia/app/templates/author-curation_missing-citing-author-items.sparql
@@ -29,7 +29,7 @@ WITH {
 WHERE {
   INCLUDE %result
   # Label the results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }
 ORDER BY DESC(?count)
 LIMIT 1000

--- a/scholia/app/templates/author-curation_missing-citing-author-items.sparql
+++ b/scholia/app/templates/author-curation_missing-citing-author-items.sparql
@@ -29,7 +29,7 @@ WITH {
 WHERE {
   INCLUDE %result
   # Label the results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?count)
 LIMIT 1000

--- a/scholia/app/templates/author-curation_missing-coauthor-items.sparql
+++ b/scholia/app/templates/author-curation_missing-coauthor-items.sparql
@@ -21,6 +21,6 @@ WITH {
 WHERE {
   INCLUDE %result
   # Label the results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }
 ORDER BY DESC(?count)

--- a/scholia/app/templates/author-curation_missing-coauthor-items.sparql
+++ b/scholia/app/templates/author-curation_missing-coauthor-items.sparql
@@ -21,6 +21,6 @@ WITH {
 WHERE {
   INCLUDE %result
   # Label the results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?count)

--- a/scholia/app/templates/author-curation_missing-topic.sparql
+++ b/scholia/app/templates/author-curation_missing-topic.sparql
@@ -28,6 +28,6 @@ WHERE {
   INCLUDE %result
   
   # Label the results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }
 ORDER BY DESC(?citations)

--- a/scholia/app/templates/author-curation_missing-topic.sparql
+++ b/scholia/app/templates/author-curation_missing-topic.sparql
@@ -28,6 +28,6 @@ WHERE {
   INCLUDE %result
   
   # Label the results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?citations)

--- a/scholia/app/templates/author-curation_missing-use-as-reference.sparql
+++ b/scholia/app/templates/author-curation_missing-use-as-reference.sparql
@@ -18,6 +18,6 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 } ORDER BY DESC(?citations)
   LIMIT 200

--- a/scholia/app/templates/author-index.html
+++ b/scholia/app/templates/author-index.html
@@ -226,7 +226,7 @@ Researcher with a published record.
                           ?num wikibase:apiOrdinal true.
                       }
                       ?item wdt:P50 ?author
-                      SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,ru,sv,jp". }
+                      SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
                     } ORDER BY ASC(?num)
                     `,
                     format: 'json'

--- a/scholia/app/templates/author-use_works.sparql
+++ b/scholia/app/templates/author-use_works.sparql
@@ -11,6 +11,6 @@ WHERE {
     ?work wdt:P577 ?publication_datetime .
     BIND(xsd:date(?publication_datetime) AS ?publication_date)
   }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en,da,de,es,fr,jp,nl,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en,da,de,es,fr,jp,nl,no,ru,sv,zh". }
 }
 ORDER BY DESC(?publication_date)

--- a/scholia/app/templates/author_academic-tree.sparql
+++ b/scholia/app/templates/author_academic-tree.sparql
@@ -72,6 +72,6 @@ WHERE {
   
   BIND( IF( ?student1 = target:, "3080BB", "ffffff") AS ?rgb)
 
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,sv,jp,zh,ru,fr,de" .  } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" .  } 
 }
 

--- a/scholia/app/templates/author_academic-tree.sparql
+++ b/scholia/app/templates/author_academic-tree.sparql
@@ -72,6 +72,6 @@ WHERE {
   
   BIND( IF( ?student1 = target:, "3080BB", "ffffff") AS ?rgb)
 
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" .  } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" .  } 
 }
 

--- a/scholia/app/templates/author_coauthor-map.sparql
+++ b/scholia/app/templates/author_coauthor-map.sparql
@@ -17,7 +17,7 @@ WITH {
 WHERE {
   INCLUDE %organizations
   BIND(IF( (?count < 1), "No results", IF((?count < 2), "1 result", IF((?count < 11), "1 < results ≤ 10", IF((?count < 101), "10 < results ≤ 100", IF((?count < 1001), "100 < results ≤ 1000", IF((?count < 10001), "1000 < results ≤ 10000", "over 10000 results") ) ) ) )) AS ?layer )
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }        
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }        
  }
 ORDER BY DESC (?count)
 

--- a/scholia/app/templates/author_coauthors.sparql
+++ b/scholia/app/templates/author_coauthors.sparql
@@ -36,5 +36,5 @@ WITH {
 WHERE {
   INCLUDE %result
   # Label the results 
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }

--- a/scholia/app/templates/author_coauthors.sparql
+++ b/scholia/app/templates/author_coauthors.sparql
@@ -36,5 +36,5 @@ WITH {
 WHERE {
   INCLUDE %result
   # Label the results 
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,fr,de,ru,es,zh,jp". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }

--- a/scholia/app/templates/author_events.sparql
+++ b/scholia/app/templates/author_events.sparql
@@ -30,7 +30,7 @@ WHERE {
     OPTIONAL { ?event wdt:P276 ?location . ?location rdfs:label ?location_label . FILTER (LANG(?location_label) = 'en')}
     OPTIONAL { ?event wdt:P580 | wdt:P585 ?start }
  
-    SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en,da,de,es,fr,jp,no,ru,sv,zh". }
+    SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en,da,de,es,fr,jp,no,ru,sv,zh". }
 }
 GROUP BY ?event ?eventLabel
 ORDER BY DESC(?date) 

--- a/scholia/app/templates/author_list-of-publications.sparql
+++ b/scholia/app/templates/author_list-of-publications.sparql
@@ -21,7 +21,7 @@ WHERE {
   BIND(xsd:date(?datetimes) AS ?dates)
   OPTIONAL { ?work wdt:P1104 ?pages_ }
   OPTIONAL { ?work wdt:P1433 ?venue }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,no,ru,sv,zh". }  
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }  
 }
 GROUP BY ?work ?workLabel ?venue ?venueLabel
 ORDER BY DESC(?date)  

--- a/scholia/app/templates/author_list-of-publications.sparql
+++ b/scholia/app/templates/author_list-of-publications.sparql
@@ -21,7 +21,7 @@ WHERE {
   BIND(xsd:date(?datetimes) AS ?dates)
   OPTIONAL { ?work wdt:P1104 ?pages_ }
   OPTIONAL { ?work wdt:P1433 ?venue }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }  
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }  
 }
 GROUP BY ?work ?workLabel ?venue ?venueLabel
 ORDER BY DESC(?date)  

--- a/scholia/app/templates/author_list-of-retracted-articles.sparql
+++ b/scholia/app/templates/author_list-of-retracted-articles.sparql
@@ -22,7 +22,7 @@ WHERE {
   BIND(xsd:date(?datetimes) AS ?dates)
   OPTIONAL { ?work wdt:P1104 ?pages_ }
   OPTIONAL { ?work wdt:P1433 ?venue }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 GROUP BY ?work ?workLabel ?venue ?venueLabel
 ORDER BY DESC(?date)

--- a/scholia/app/templates/author_most-cited-works.sparql
+++ b/scholia/app/templates/author_most-cited-works.sparql
@@ -12,7 +12,7 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,ru,sv,jp". }        
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }        
 }  
 ORDER BY DESC(?count)
 LIMIT 500

--- a/scholia/app/templates/author_most-cited-works.sparql
+++ b/scholia/app/templates/author_most-cited-works.sparql
@@ -12,7 +12,7 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }        
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }        
 }  
 ORDER BY DESC(?count)
 LIMIT 500

--- a/scholia/app/templates/author_most-citing-authors.sparql
+++ b/scholia/app/templates/author_most-citing-authors.sparql
@@ -33,6 +33,6 @@ WITH {
 WHERE {
   INCLUDE %result
   
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 } 
 ORDER BY DESC(?count)

--- a/scholia/app/templates/author_most-citing-authors.sparql
+++ b/scholia/app/templates/author_most-citing-authors.sparql
@@ -33,6 +33,6 @@ WITH {
 WHERE {
   INCLUDE %result
   
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 } 
 ORDER BY DESC(?count)

--- a/scholia/app/templates/author_other-locations.sparql
+++ b/scholia/app/templates/author_other-locations.sparql
@@ -7,7 +7,7 @@ WHERE {
   ?item p:P159/pq:P625 | wdt:P276*/wdt:P625 ?geo .
   ?property_item wikibase:directClaim ?property .
   OPTIONAL { ?item wdt:P18 ?image . } 
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
   
   # No automatic labeling on the property, - for some reason.
   ?property_item rdfs:label ?property_item_label . FILTER(LANG(?property_item_label) = 'en')

--- a/scholia/app/templates/author_other-locations.sparql
+++ b/scholia/app/templates/author_other-locations.sparql
@@ -7,7 +7,7 @@ WHERE {
   ?item p:P159/pq:P625 | wdt:P276*/wdt:P625 ?geo .
   ?property_item wikibase:directClaim ?property .
   OPTIONAL { ?item wdt:P18 ?image . } 
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
   
   # No automatic labeling on the property, - for some reason.
   ?property_item rdfs:label ?property_item_label . FILTER(LANG(?property_item_label) = 'en')

--- a/scholia/app/templates/author_review-statistics.sparql
+++ b/scholia/app/templates/author_review-statistics.sparql
@@ -39,7 +39,7 @@ WITH {
 WHERE {
   INCLUDE %result
   OPTIONAL { ?venue wdt:P1813 ?short_name_ . }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,ru,sv,zh". }  
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }  
 } 
 GROUP BY ?count ?venue ?venueLabel ?topics ?topicsUrl
 ORDER BY DESC(?count)

--- a/scholia/app/templates/author_review-statistics.sparql
+++ b/scholia/app/templates/author_review-statistics.sparql
@@ -39,7 +39,7 @@ WITH {
 WHERE {
   INCLUDE %result
   OPTIONAL { ?venue wdt:P1813 ?short_name_ . }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }  
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }  
 } 
 GROUP BY ?count ?venue ?venueLabel ?topics ?topicsUrl
 ORDER BY DESC(?count)

--- a/scholia/app/templates/author_topic-scores.sparql
+++ b/scholia/app/templates/author_topic-scores.sparql
@@ -31,7 +31,7 @@ WITH {
 } AS %results 
 WHERE {
   INCLUDE %results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en,da,de,es,jp,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en,da,de,es,jp,no,ru,sv,zh". }
 }
 ORDER BY DESC(?score)
 LIMIT 200

--- a/scholia/app/templates/author_topics-works-matrix.sparql
+++ b/scholia/app/templates/author_topics-works-matrix.sparql
@@ -4,6 +4,6 @@ SELECT ?work ?workLabel ?topic ?topicLabel WHERE {
 ?work wdt:P50 target: .
 ?work wdt:P921 ?topic .
 OPTIONAL { ?work wdt:P577 ?publication_date }
-SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en,cz,da,de,es,fr,hi,jp,nl,nn,ru,sv,zh". }
+SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en,cz,da,de,es,fr,hi,jp,nl,nn,ru,sv,zh". }
 }
 ORDER BY ?publication_date

--- a/scholia/app/templates/author_topics.sparql
+++ b/scholia/app/templates/author_topics.sparql
@@ -12,6 +12,6 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,ru,sv,zh" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
 }
 ORDER BY DESC(?count) 

--- a/scholia/app/templates/author_topics.sparql
+++ b/scholia/app/templates/author_topics.sparql
@@ -12,6 +12,6 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . } 
 }
 ORDER BY DESC(?count) 

--- a/scholia/app/templates/author_use.sparql
+++ b/scholia/app/templates/author_use.sparql
@@ -21,6 +21,6 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }
 ORDER BY DESC(?count)

--- a/scholia/app/templates/author_venue-statistics.sparql
+++ b/scholia/app/templates/author_venue-statistics.sparql
@@ -23,7 +23,7 @@ WITH {
 WHERE {
   INCLUDE %result
   OPTIONAL { ?venue wdt:P1813 ?short_name_ . }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,ru,sv,zh". }  
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }  
 } 
 GROUP BY ?count ?venue ?venueLabel ?topics ?topicsUrl
 ORDER BY DESC(?count)

--- a/scholia/app/templates/author_venue-statistics.sparql
+++ b/scholia/app/templates/author_venue-statistics.sparql
@@ -23,7 +23,7 @@ WITH {
 WHERE {
   INCLUDE %result
   OPTIONAL { ?venue wdt:P1813 ?short_name_ . }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }  
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }  
 } 
 GROUP BY ?count ?venue ?venueLabel ?topics ?topicsUrl
 ORDER BY DESC(?count)

--- a/scholia/app/templates/authors_co-author.sparql
+++ b/scholia/app/templates/authors_co-author.sparql
@@ -23,5 +23,5 @@ WITH {
 } AS %result 
 WHERE {
  INCLUDE %result 
- SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+ SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }

--- a/scholia/app/templates/authors_co-author.sparql
+++ b/scholia/app/templates/authors_co-author.sparql
@@ -23,5 +23,5 @@ WITH {
 } AS %result 
 WHERE {
  INCLUDE %result 
- SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,he,jp,nl,no,ru,sv,zh" . }
+ SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }

--- a/scholia/app/templates/authors_list-of-authors.sparql
+++ b/scholia/app/templates/authors_list-of-authors.sparql
@@ -8,5 +8,5 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }

--- a/scholia/app/templates/authors_list-of-authors.sparql
+++ b/scholia/app/templates/authors_list-of-authors.sparql
@@ -8,5 +8,5 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,es,fr,nl,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }

--- a/scholia/app/templates/authors_list-of-jointly-authored-works.sparql
+++ b/scholia/app/templates/authors_list-of-jointly-authored-works.sparql
@@ -18,6 +18,6 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?coauthor_count)

--- a/scholia/app/templates/authors_list-of-jointly-authored-works.sparql
+++ b/scholia/app/templates/authors_list-of-jointly-authored-works.sparql
@@ -18,6 +18,6 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,es,fr,nl,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }
 ORDER BY DESC(?coauthor_count)

--- a/scholia/app/templates/award-curation_missing-coauthor-items.sparql
+++ b/scholia/app/templates/award-curation_missing-coauthor-items.sparql
@@ -23,6 +23,6 @@ WITH {
 WHERE {
   INCLUDE %result
   # Label the results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?count)

--- a/scholia/app/templates/award-curation_missing-coauthor-items.sparql
+++ b/scholia/app/templates/award-curation_missing-coauthor-items.sparql
@@ -23,6 +23,6 @@ WITH {
 WHERE {
   INCLUDE %result
   # Label the results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }
 ORDER BY DESC(?count)

--- a/scholia/app/templates/award-curation_missing-topics.sparql
+++ b/scholia/app/templates/award-curation_missing-topics.sparql
@@ -29,6 +29,6 @@ WHERE {
   INCLUDE %result
   
   # Label the results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?citations)

--- a/scholia/app/templates/award-curation_missing-topics.sparql
+++ b/scholia/app/templates/award-curation_missing-topics.sparql
@@ -29,6 +29,6 @@ WHERE {
   INCLUDE %result
   
   # Label the results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }
 ORDER BY DESC(?citations)

--- a/scholia/app/templates/award-index_statistics.sparql
+++ b/scholia/app/templates/award-index_statistics.sparql
@@ -25,6 +25,6 @@ WHERE {
       (2000 2000 wd:Q10578722 "Fictive Award Label for axis")
     }
   }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en,da,de,es,fr,jp,nl,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en,da,de,es,fr,jp,nl,no,ru,sv,zh". }
 } 
 ORDER BY DESC(?males) DESC(?female)

--- a/scholia/app/templates/award_coawards.sparql
+++ b/scholia/app/templates/award_coawards.sparql
@@ -13,6 +13,6 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result 
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en,da,de,es,fr,jp,no,ru,sv,zh" . }  
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en,da,de,es,fr,jp,no,ru,sv,zh" . }  
 }
 ORDER BY DESC(?number_of_corecipients)

--- a/scholia/app/templates/award_gender-distribution.sparql
+++ b/scholia/app/templates/award_gender-distribution.sparql
@@ -11,6 +11,6 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en,da,de,ep,fr,jp,nl,no,ru,sv,zh" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en,da,de,ep,fr,jp,nl,no,ru,sv,zh" . } 
 } 
 ORDER BY DESC(?count)

--- a/scholia/app/templates/award_images-of-recipients.sparql
+++ b/scholia/app/templates/award_images-of-recipients.sparql
@@ -19,7 +19,7 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result 
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,no,ru,sv,zh" . }  
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }  
 }
 ORDER BY DESC(?year)
   

--- a/scholia/app/templates/award_images-of-recipients.sparql
+++ b/scholia/app/templates/award_images-of-recipients.sparql
@@ -19,7 +19,7 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result 
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }  
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }  
 }
 ORDER BY DESC(?year)
   

--- a/scholia/app/templates/award_list-of-recipients.sparql
+++ b/scholia/app/templates/award_list-of-recipients.sparql
@@ -20,6 +20,6 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result 
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en,da,de,es,fr,jp,no,ru,sv,zh" . }  
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en,da,de,es,fr,jp,no,ru,sv,zh" . }  
 }
 ORDER BY DESC(?year)

--- a/scholia/app/templates/award_locations-of-recipients.sparql
+++ b/scholia/app/templates/award_locations-of-recipients.sparql
@@ -14,5 +14,5 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,ru,sv,zh" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
 }

--- a/scholia/app/templates/award_locations-of-recipients.sparql
+++ b/scholia/app/templates/award_locations-of-recipients.sparql
@@ -14,5 +14,5 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . } 
 }

--- a/scholia/app/templates/award_recent-publications-by-recipients.sparql
+++ b/scholia/app/templates/award_recent-publications-by-recipients.sparql
@@ -15,7 +15,7 @@ WITH {
 WHERE {
   INCLUDE %result 
   BIND(xsd:date(?publication_datetime) AS ?publication_date)
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en,da,de,es,fr,jp,no,ru,sv,zh" . }  
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en,da,de,es,fr,jp,no,ru,sv,zh" . }  
 }
 ORDER BY DESC(?publication_date)
 LIMIT 500

--- a/scholia/app/templates/award_topics-of-works-by-recipients.sparql
+++ b/scholia/app/templates/award_topics-of-works-by-recipients.sparql
@@ -13,7 +13,7 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result 
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }  
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }  
 }
 ORDER BY DESC(?count)
 LIMIT 50

--- a/scholia/app/templates/award_topics-of-works-by-recipients.sparql
+++ b/scholia/app/templates/award_topics-of-works-by-recipients.sparql
@@ -13,7 +13,7 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result 
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,no,ru,sv,zh" . }  
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }  
 }
 ORDER BY DESC(?count)
 LIMIT 50

--- a/scholia/app/templates/catalogue_images.sparql
+++ b/scholia/app/templates/catalogue_images.sparql
@@ -7,5 +7,5 @@ SELECT
 WHERE {
   ?item wdt:P972 target: ;
         wdt:P18 ?image .
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en,da,es,fr,jp,nl,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en,da,es,fr,jp,nl,no,ru,sv,zh". }
 }

--- a/scholia/app/templates/catalogue_items.sparql
+++ b/scholia/app/templates/catalogue_items.sparql
@@ -16,7 +16,7 @@ WHERE {
   BIND(xsd:integer(?code) AS ?number)
 
   # Label the result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en,da,es,fr,jp,nl,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en,da,es,fr,jp,nl,no,ru,sv,zh". }
 }
 ORDER BY ?number ?code
 LIMIT 1000

--- a/scholia/app/templates/chemical-class_found-in-taxon.sparql
+++ b/scholia/app/templates/chemical-class_found-in-taxon.sparql
@@ -25,6 +25,6 @@ WITH {
 } AS %taxons
 WHERE {
   INCLUDE %taxons
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 } 
 ORDER BY DESC(?chemicals)

--- a/scholia/app/templates/chemical-class_identifiers.sparql
+++ b/scholia/app/templates/chemical-class_identifiers.sparql
@@ -12,7 +12,7 @@ SELECT
     ?IDpred wdt:P1630 ?formatterurl .
   }
   BIND(IRI(REPLACE(?formatterurl, '\\\\$1', str(?id))) AS ?idUrl).
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,ru,sv,zh" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }
 ORDER BY ASC(?IDpredLabel)
 LIMIT 500

--- a/scholia/app/templates/chemical-class_identifiers.sparql
+++ b/scholia/app/templates/chemical-class_identifiers.sparql
@@ -12,7 +12,7 @@ SELECT
     ?IDpred wdt:P1630 ?formatterurl .
   }
   BIND(IRI(REPLACE(?formatterurl, '\\\\$1', str(?id))) AS ?idUrl).
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY ASC(?IDpredLabel)
 LIMIT 500

--- a/scholia/app/templates/chemical-class_recent-literature.sparql
+++ b/scholia/app/templates/chemical-class_recent-literature.sparql
@@ -37,7 +37,7 @@ WITH {
 WHERE {
   INCLUDE %result
   BIND(xsd:date(?datetime) AS ?date)
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?date)
 LIMIT 500

--- a/scholia/app/templates/chemical-class_recent-literature.sparql
+++ b/scholia/app/templates/chemical-class_recent-literature.sparql
@@ -37,7 +37,7 @@ WITH {
 WHERE {
   INCLUDE %result
   BIND(xsd:date(?datetime) AS ?date)
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }
 ORDER BY DESC(?date)
 LIMIT 500

--- a/scholia/app/templates/chemical-class_related-chemicals.sparql
+++ b/scholia/app/templates/chemical-class_related-chemicals.sparql
@@ -37,5 +37,5 @@ OPTIONAL {
   }
   BIND(IRI(REPLACE(?PCformatterurl, '\\\\$1', str(?PubChem_CID))) AS ?PubChem_CIDUrl).
 }
-SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }

--- a/scholia/app/templates/chemical-class_related-chemicals.sparql
+++ b/scholia/app/templates/chemical-class_related-chemicals.sparql
@@ -37,5 +37,5 @@ OPTIONAL {
   }
   BIND(IRI(REPLACE(?PCformatterurl, '\\\\$1', str(?PubChem_CID))) AS ?PubChem_CIDUrl).
 }
-SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
+SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }

--- a/scholia/app/templates/chemical-curation_missing-main-subjects.sparql
+++ b/scholia/app/templates/chemical-curation_missing-main-subjects.sparql
@@ -27,5 +27,5 @@ WITH {
   } LIMIT 200
 } AS %works WHERE {
   INCLUDE %works
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }

--- a/scholia/app/templates/chemical-element_allotropes.sparql
+++ b/scholia/app/templates/chemical-element_allotropes.sparql
@@ -18,5 +18,5 @@ SELECT DISTINCT ?allotrope ?allotropeLabel ?density ?densityUnit ?densityUnitLab
     ?densityValNode wikibase:quantityAmount ?density ;
                     wikibase:quantityUnit ?densityUnit .
   }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 } ORDER BY ASC(?allotropeLabel)

--- a/scholia/app/templates/chemical-element_isotopes.sparql
+++ b/scholia/app/templates/chemical-element_isotopes.sparql
@@ -14,5 +14,5 @@ WHERE {
   ?halflifeStat psv:P2114 ?halflifeValNode .
   ?halflifeValNode wikibase:quantityAmount ?halflife ;
                    wikibase:quantityUnit ?halflifeUnit .
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 } ORDER BY ?neutrons

--- a/scholia/app/templates/chemical-element_recent-literature.sparql
+++ b/scholia/app/templates/chemical-element_recent-literature.sparql
@@ -25,7 +25,7 @@ WITH {
 WHERE {
   INCLUDE %result
   BIND(xsd:date(?datetime) AS ?date)
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?date)
 LIMIT 500

--- a/scholia/app/templates/chemical-element_recent-literature.sparql
+++ b/scholia/app/templates/chemical-element_recent-literature.sparql
@@ -25,7 +25,7 @@ WITH {
 WHERE {
   INCLUDE %result
   BIND(xsd:date(?datetime) AS ?date)
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }
 ORDER BY DESC(?date)
 LIMIT 500

--- a/scholia/app/templates/chemical-index-curation_missing-boiling-points.sparql
+++ b/scholia/app/templates/chemical-index-curation_missing-boiling-points.sparql
@@ -10,5 +10,5 @@ SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
 } AS %CHEMICALS WHERE {
   INCLUDE %CHEMICALS
   OPTIONAL { ?compound wdt:P274 ?formula }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 } ORDER BY DESC(?wikis)

--- a/scholia/app/templates/chemical-index-curation_missing-chemical-structure.sparql
+++ b/scholia/app/templates/chemical-index-curation_missing-chemical-structure.sparql
@@ -9,5 +9,5 @@ SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
 } AS %CHEMICALS WHERE {
   INCLUDE %CHEMICALS
   OPTIONAL { ?compound wdt:P274 ?formula }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 } ORDER BY DESC(?wikis)

--- a/scholia/app/templates/chemical-index-curation_missing-combustion-enthalpy.sparql
+++ b/scholia/app/templates/chemical-index-curation_missing-combustion-enthalpy.sparql
@@ -9,5 +9,5 @@ SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
 } AS %CHEMICALS WHERE {
   INCLUDE %CHEMICALS
   OPTIONAL { ?compound wdt:P274 ?formula }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 } ORDER BY DESC(?wikis)

--- a/scholia/app/templates/chemical-index-curation_missing-density.sparql
+++ b/scholia/app/templates/chemical-index-curation_missing-density.sparql
@@ -9,5 +9,5 @@ SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
 } AS %CHEMICALS WHERE {
   INCLUDE %CHEMICALS
   OPTIONAL { ?compound wdt:P274 ?formula }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 } ORDER BY DESC(?wikis)

--- a/scholia/app/templates/chemical-index-curation_missing-enthalpy-of-formation.sparql
+++ b/scholia/app/templates/chemical-index-curation_missing-enthalpy-of-formation.sparql
@@ -9,5 +9,5 @@ SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
 } AS %CHEMICALS WHERE {
   INCLUDE %CHEMICALS
   OPTIONAL { ?compound wdt:P274 ?formula }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 } ORDER BY DESC(?wikis)

--- a/scholia/app/templates/chemical-index-curation_missing-flash-point.sparql
+++ b/scholia/app/templates/chemical-index-curation_missing-flash-point.sparql
@@ -9,5 +9,5 @@ SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
 } AS %CHEMICALS WHERE {
   INCLUDE %CHEMICALS
   OPTIONAL { ?compound wdt:P274 ?formula }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 } ORDER BY DESC(?wikis)

--- a/scholia/app/templates/chemical-index-curation_missing-idlh.sparql
+++ b/scholia/app/templates/chemical-index-curation_missing-idlh.sparql
@@ -9,5 +9,5 @@ SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
 } AS %CHEMICALS WHERE {
   INCLUDE %CHEMICALS
   OPTIONAL { ?compound wdt:P274 ?formula }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 } ORDER BY DESC(?wikis)

--- a/scholia/app/templates/chemical-index-curation_missing-mass.sparql
+++ b/scholia/app/templates/chemical-index-curation_missing-mass.sparql
@@ -9,5 +9,5 @@ SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
 } AS %CHEMICALS WHERE {
   INCLUDE %CHEMICALS
   OPTIONAL { ?compound wdt:P274 ?formula }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 } ORDER BY DESC(?wikis)

--- a/scholia/app/templates/chemical-index-curation_missing-melting-points.sparql
+++ b/scholia/app/templates/chemical-index-curation_missing-melting-points.sparql
@@ -9,5 +9,5 @@ SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
 } AS %CHEMICALS WHERE {
   INCLUDE %CHEMICALS
   OPTIONAL { ?compound wdt:P274 ?formula }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 } ORDER BY DESC(?wikis)

--- a/scholia/app/templates/chemical-index-curation_missing-molar-entropy.sparql
+++ b/scholia/app/templates/chemical-index-curation_missing-molar-entropy.sparql
@@ -9,5 +9,5 @@ SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
 } AS %CHEMICALS WHERE {
   INCLUDE %CHEMICALS
   OPTIONAL { ?compound wdt:P274 ?formula }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 } ORDER BY DESC(?wikis)

--- a/scholia/app/templates/chemical-index-curation_missing-pKa.sparql
+++ b/scholia/app/templates/chemical-index-curation_missing-pKa.sparql
@@ -9,5 +9,5 @@ SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
 } AS %CHEMICALS WHERE {
   INCLUDE %CHEMICALS
   OPTIONAL { ?compound wdt:P274 ?formula }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 } ORDER BY DESC(?wikis)

--- a/scholia/app/templates/chemical-index-curation_missing-solubility.sparql
+++ b/scholia/app/templates/chemical-index-curation_missing-solubility.sparql
@@ -9,5 +9,5 @@ SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
 } AS %CHEMICALS WHERE {
   INCLUDE %CHEMICALS
   OPTIONAL { ?compound wdt:P274 ?formula }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 } ORDER BY DESC(?wikis)

--- a/scholia/app/templates/chemical-index-curation_missing-vapor-pressure.sparql
+++ b/scholia/app/templates/chemical-index-curation_missing-vapor-pressure.sparql
@@ -9,5 +9,5 @@ SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
 } AS %CHEMICALS WHERE {
   INCLUDE %CHEMICALS
   OPTIONAL { ?compound wdt:P274 ?formula }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 } ORDER BY DESC(?wikis)

--- a/scholia/app/templates/chemical_biological-processes.sparql
+++ b/scholia/app/templates/chemical_biological-processes.sparql
@@ -8,7 +8,7 @@ WHERE {
   ?pathway wdt:P527 target: ;
            wdt:P31 wd:Q2996394 .
   target: wdt:P361 ?pathway .
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }
 ORDER BY ASC(?pathwayLabel)
 LIMIT 250

--- a/scholia/app/templates/chemical_found-in-matrix-np.sparql
+++ b/scholia/app/templates/chemical_found-in-matrix-np.sparql
@@ -5,6 +5,6 @@ SELECT DISTINCT ?matrix ?matrixLabel ?taxon ?taxonLabel (CONCAT("/taxon/", SUBST
   ?chemical wdt:P361 ?matrix.
   ?matrix (wdt:P279*/wdt:P1582) ?taxon .
   ?matrix wdt:P527 ?chemical.
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 } ORDER BY ASC(?taxonLabel)
   LIMIT 250

--- a/scholia/app/templates/chemical_found-in-taxon.sparql
+++ b/scholia/app/templates/chemical_found-in-taxon.sparql
@@ -10,6 +10,6 @@ SELECT DISTINCT ?taxon ?taxonLabel (CONCAT("/taxon/", SUBSTR(STR(?taxon), 32)) A
       ?taxonStatement prov:wasDerivedFrom/pr:P248 ?source .
       OPTIONAL { ?source wdt:P356 ?doi . }
     }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 } ORDER BY ASC(?taxonLabel)
   LIMIT 250

--- a/scholia/app/templates/chemical_identifiers.sparql
+++ b/scholia/app/templates/chemical_identifiers.sparql
@@ -30,7 +30,7 @@ WITH {
       BIND(IRI(REPLACE(?formatterurl, '\\\\$1', str(?Value))) AS ?idUrls).
     }
   }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }
 GROUP BY ?Identifier ?IdentifierLabel ?IdentifierDescription ?Value
 ORDER BY ASC(?IdentifierLabel)

--- a/scholia/app/templates/chemical_physchem-properties.sparql
+++ b/scholia/app/templates/chemical_physchem-properties.sparql
@@ -38,7 +38,7 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 } 
 ORDER BY ASC(?propEntityLabel)
 

--- a/scholia/app/templates/chemical_recent-literature.sparql
+++ b/scholia/app/templates/chemical_recent-literature.sparql
@@ -34,7 +34,7 @@ WITH {
 WHERE {
   INCLUDE %result
   BIND(xsd:date(?datetime) AS ?date)
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?date)
 LIMIT 500

--- a/scholia/app/templates/chemical_recent-literature.sparql
+++ b/scholia/app/templates/chemical_recent-literature.sparql
@@ -34,7 +34,7 @@ WITH {
 WHERE {
   INCLUDE %result
   BIND(xsd:date(?datetime) AS ?date)
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }
 ORDER BY DESC(?date)
 LIMIT 500

--- a/scholia/app/templates/chemical_related.sparql
+++ b/scholia/app/templates/chemical_related.sparql
@@ -26,5 +26,5 @@ SELECT ?mol ?molLabel ?InChIKey ?CAS ?ChemSpider ?PubChem_CID WITH {
   OPTIONAL { ?mol wdt:P231 ?CAS }
   OPTIONAL { ?mol wdt:P661 ?ChemSpider }
   OPTIONAL { ?mol wdt:P662 ?PubChem_CID }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }

--- a/scholia/app/templates/chemical_related.sparql
+++ b/scholia/app/templates/chemical_related.sparql
@@ -26,5 +26,5 @@ SELECT ?mol ?molLabel ?InChIKey ?CAS ?ChemSpider ?PubChem_CID WITH {
   OPTIONAL { ?mol wdt:P231 ?CAS }
   OPTIONAL { ?mol wdt:P661 ?ChemSpider }
   OPTIONAL { ?mol wdt:P662 ?PubChem_CID }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }

--- a/scholia/app/templates/chemical_relates.sparql
+++ b/scholia/app/templates/chemical_relates.sparql
@@ -8,5 +8,5 @@ SELECT ?mol ?molLabel ?InChIKey ?CAS ?ChemSpider ?PubChem_CID WHERE {
   OPTIONAL { ?mol wdt:P661 ?ChemSpider }
   OPTIONAL { ?mol wdt:P662 ?PubChem_CID }
   FILTER (regex(str(?InChIKey), concat("^", substr($queryKey,1,14), "-")))
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }

--- a/scholia/app/templates/chemical_relates.sparql
+++ b/scholia/app/templates/chemical_relates.sparql
@@ -8,5 +8,5 @@ SELECT ?mol ?molLabel ?InChIKey ?CAS ?ChemSpider ?PubChem_CID WHERE {
   OPTIONAL { ?mol wdt:P661 ?ChemSpider }
   OPTIONAL { ?mol wdt:P662 ?PubChem_CID }
   FILTER (regex(str(?InChIKey), concat("^", substr($queryKey,1,14), "-")))
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }

--- a/scholia/app/templates/chemical_structural-identifiers.sparql
+++ b/scholia/app/templates/chemical_structural-identifiers.sparql
@@ -17,7 +17,7 @@ WITH {
 } AS %RESULTS {
   INCLUDE %RESULTS
   BIND(IRI(REPLACE(?formatterurl, '\\\\$1', str(?idLit))) AS ?idUrls).
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }
 GROUP BY ?Structural_identifier ?Structural_identifierLabel ?idLit
 ORDER BY ASC(?ID_TypeLabel)

--- a/scholia/app/templates/cito-index_article-counts.sparql
+++ b/scholia/app/templates/cito-index_article-counts.sparql
@@ -6,6 +6,6 @@ SELECT ?intention ?intentionLabel (CONCAT("/cito/", SUBSTR(STR(?intention), 32))
                      ps:P2860 ?citedArticle .
   ?intention wdt:P31 wd:Q96471816 ;
              wdt:P2888 ?cito .
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 } GROUP BY ?cito ?intention ?intentionLabel
   ORDER BY DESC(?citations)

--- a/scholia/app/templates/cito-index_cited-journal-counts.sparql
+++ b/scholia/app/templates/cito-index_cited-journal-counts.sparql
@@ -6,6 +6,6 @@ SELECT ?citedJournal ?citedJournalLabel (CONCAT("/venue/", SUBSTR(STR(?citedJour
                      ps:P2860 ?citedArticle .
   ?citedArticle wdt:P1433 ?citedJournal .
   ?intention wdt:P31 wd:Q96471816 .
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 } GROUP BY ?citedJournal ?citedJournalLabel
   ORDER BY DESC(?citations)

--- a/scholia/app/templates/cito-index_journal-counts.sparql
+++ b/scholia/app/templates/cito-index_journal-counts.sparql
@@ -6,6 +6,6 @@ SELECT ?journal ?journalLabel (CONCAT("/venue/", SUBSTR(STR(?journal), 32), "#ci
   ?citationStatement pq:P3712 ?intention ;
                      ps:P2860 ?citedArticle .
   ?intention wdt:P31 wd:Q96471816 .
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 } GROUP BY ?journal ?journalLabel
   ORDER BY DESC(?citations)

--- a/scholia/app/templates/cito-index_recent-articles.sparql
+++ b/scholia/app/templates/cito-index_recent-articles.sparql
@@ -4,6 +4,6 @@ select distinct ?date ?work ?workLabel ?venue ?venueLabel where {
   BIND(xsd:date(?dates) AS ?date)
   ?work wdt:P31 wd:Q109229154 . bind("explicit" as ?type_)
   ?work wdt:P1433 ?venue .
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 } ORDER BY DESC(?date)
   LIMIT 50

--- a/scholia/app/templates/cito_articles.sparql
+++ b/scholia/app/templates/cito_articles.sparql
@@ -6,6 +6,6 @@ SELECT (COUNT(?citingArticle) AS ?count)
   ?citingArticle p:P2860 ?citationStatement .
   ?citationStatement ps:P2860 ?citedArticle ;
                      pq:P3712 ?INTENTION .
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 } GROUP BY ?citedArticle ?citedArticleLabel
   ORDER BY DESC(?count)

--- a/scholia/app/templates/cito_journals.sparql
+++ b/scholia/app/templates/cito_journals.sparql
@@ -6,6 +6,6 @@ SELECT (COUNT(DISTINCT ?citingArticle) AS ?count)
   ?citingArticle p:P2860 ?citationStatement ;
                  wdt:P1433 ?journal .
   ?citationStatement pq:P3712 ?INTENTION .
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 } GROUP BY ?journal ?journalLabel
   ORDER BY DESC(?count)

--- a/scholia/app/templates/clinical-trial-index_interventions.sparql
+++ b/scholia/app/templates/clinical-trial-index_interventions.sparql
@@ -18,6 +18,6 @@ SELECT
     LIMIT 500
   }
   BIND(IF(EXISTS { ?intervention wdt:P31 wd:Q11173 }, ?intervention, "") AS ?as_chemical) 
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,pl,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }
 ORDER BY DESC(?count)

--- a/scholia/app/templates/clinical-trial-index_interventions.sparql
+++ b/scholia/app/templates/clinical-trial-index_interventions.sparql
@@ -18,6 +18,6 @@ SELECT
     LIMIT 500
   }
   BIND(IF(EXISTS { ?intervention wdt:P31 wd:Q11173 }, ?intervention, "") AS ?as_chemical) 
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?count)

--- a/scholia/app/templates/clinical-trial-index_medical-conditions.sparql
+++ b/scholia/app/templates/clinical-trial-index_medical-conditions.sparql
@@ -16,6 +16,6 @@ WHERE {
     ORDER BY DESC(?count)
     LIMIT 500
   }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?count)

--- a/scholia/app/templates/clinical-trial-index_medical-conditions.sparql
+++ b/scholia/app/templates/clinical-trial-index_medical-conditions.sparql
@@ -16,6 +16,6 @@ WHERE {
     ORDER BY DESC(?count)
     LIMIT 500
   }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,pl,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }
 ORDER BY DESC(?count)

--- a/scholia/app/templates/clinical-trial-index_phases.sparql
+++ b/scholia/app/templates/clinical-trial-index_phases.sparql
@@ -16,5 +16,5 @@ WHERE {
     }
     GROUP BY ?year_ ?phase
   }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }

--- a/scholia/app/templates/clinical-trial-index_phases.sparql
+++ b/scholia/app/templates/clinical-trial-index_phases.sparql
@@ -16,5 +16,5 @@ WHERE {
     }
     GROUP BY ?year_ ?phase
   }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }

--- a/scholia/app/templates/clinical-trial-index_recent-clinical-trials.sparql
+++ b/scholia/app/templates/clinical-trial-index_recent-clinical-trials.sparql
@@ -12,6 +12,6 @@ WITH {
 WHERE {
   INCLUDE %trials
   BIND(xsd:date(?start_datetime) AS ?start_date)
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en,da,de,es,fr,jp,nl,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en,da,de,es,fr,jp,nl,no,ru,sv,zh". }
 }
 ORDER BY DESC(?start_datetime)

--- a/scholia/app/templates/clinical-trial_related-trials.sparql
+++ b/scholia/app/templates/clinical-trial_related-trials.sparql
@@ -31,6 +31,6 @@ WHERE {
     LIMIT 500
   }
   FILTER (target: != ?trial)
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?score)

--- a/scholia/app/templates/clinical-trial_related-trials.sparql
+++ b/scholia/app/templates/clinical-trial_related-trials.sparql
@@ -31,6 +31,6 @@ WHERE {
     LIMIT 500
   }
   FILTER (target: != ?trial)
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,pl,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }
 ORDER BY DESC(?score)

--- a/scholia/app/templates/complex_articles-recent.sparql
+++ b/scholia/app/templates/complex_articles-recent.sparql
@@ -26,7 +26,7 @@ WHERE {
   # BIND(xsd:date(?datetime) AS ?date)
   BIND(REPLACE(STR(?datetime), 'T.*', '') AS ?date)
     
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 GROUP BY ?date ?work ?workLabel ?topicsUrl ?topics
 ORDER BY DESC(?date)

--- a/scholia/app/templates/complex_articles-recent.sparql
+++ b/scholia/app/templates/complex_articles-recent.sparql
@@ -26,7 +26,7 @@ WHERE {
   # BIND(xsd:date(?datetime) AS ?date)
   BIND(REPLACE(STR(?datetime), 'T.*', '') AS ?date)
     
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }
 GROUP BY ?date ?work ?workLabel ?topicsUrl ?topics
 ORDER BY DESC(?date)

--- a/scholia/app/templates/complex_identifiers.sparql
+++ b/scholia/app/templates/complex_identifiers.sparql
@@ -31,7 +31,7 @@ WITH {
       BIND(IRI(REPLACE(?formatterurl, '\\\\$1', str(?id))) AS ?idUrls).
     }
   }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }
 GROUP BY ?Identifier ?IdentifierLabel ?IdentifierDescription ?id
 ORDER BY ASC(?IdentifierLabel)

--- a/scholia/app/templates/complex_participants.sparql
+++ b/scholia/app/templates/complex_participants.sparql
@@ -17,5 +17,5 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 } ORDER BY ASC(?partLabel)

--- a/scholia/app/templates/countries_list-of-countries.sparql
+++ b/scholia/app/templates/countries_list-of-countries.sparql
@@ -26,6 +26,6 @@ WITH {
 } AS %results
 WHERE {
   INCLUDE %results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en,da,es,fr,jp,nl,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en,da,es,fr,jp,nl,no,ru,sv,zh". }
 }
 ORDER BY DESC(?number_of_publications)

--- a/scholia/app/templates/countries_tmp.sparql
+++ b/scholia/app/templates/countries_tmp.sparql
@@ -9,5 +9,5 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,es,fr,nl,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }

--- a/scholia/app/templates/countries_tmp.sparql
+++ b/scholia/app/templates/countries_tmp.sparql
@@ -9,5 +9,5 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }

--- a/scholia/app/templates/country-topic_authors.sparql
+++ b/scholia/app/templates/country-topic_authors.sparql
@@ -24,6 +24,6 @@ WITH {
 } AS %results
 WHERE {
   INCLUDE %results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }
 ORDER BY DESC(?number_of_works)

--- a/scholia/app/templates/country-topic_authors.sparql
+++ b/scholia/app/templates/country-topic_authors.sparql
@@ -24,6 +24,6 @@ WITH {
 } AS %results
 WHERE {
   INCLUDE %results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?number_of_works)

--- a/scholia/app/templates/country-topic_coauthors-graph.sparql
+++ b/scholia/app/templates/country-topic_coauthors-graph.sparql
@@ -22,5 +22,5 @@ WITH {
 } AS %results
 WHERE {
   INCLUDE %results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }

--- a/scholia/app/templates/country-topic_coauthors-graph.sparql
+++ b/scholia/app/templates/country-topic_coauthors-graph.sparql
@@ -22,5 +22,5 @@ WITH {
 } AS %results
 WHERE {
   INCLUDE %results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }

--- a/scholia/app/templates/country-topic_cocitations-graph.sparql
+++ b/scholia/app/templates/country-topic_cocitations-graph.sparql
@@ -22,5 +22,5 @@ WITH {
 } AS %results
 WHERE {
   INCLUDE %results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }

--- a/scholia/app/templates/country-topic_cocitations-graph.sparql
+++ b/scholia/app/templates/country-topic_cocitations-graph.sparql
@@ -22,5 +22,5 @@ WITH {
 } AS %results
 WHERE {
   INCLUDE %results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }

--- a/scholia/app/templates/country-topic_organizations.sparql
+++ b/scholia/app/templates/country-topic_organizations.sparql
@@ -32,6 +32,6 @@ WITH {
 } AS %results
 WHERE {
   INCLUDE %results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }
 ORDER BY DESC(?number_of_works)

--- a/scholia/app/templates/country-topic_organizations.sparql
+++ b/scholia/app/templates/country-topic_organizations.sparql
@@ -32,6 +32,6 @@ WITH {
 } AS %results
 WHERE {
   INCLUDE %results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?number_of_works)

--- a/scholia/app/templates/country_authors.sparql
+++ b/scholia/app/templates/country_authors.sparql
@@ -29,6 +29,6 @@ WITH {
 } AS %results
 WHERE {
   INCLUDE %results
-  service wikibase:label { bd:serviceParam wikibase:language "en" . } 
+  service wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
 }
 ORDER BY DESC(?number_of_citing_works) 

--- a/scholia/app/templates/country_authors.sparql
+++ b/scholia/app/templates/country_authors.sparql
@@ -29,6 +29,6 @@ WITH {
 } AS %results
 WHERE {
   INCLUDE %results
-  service wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
+  service wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . } 
 }
 ORDER BY DESC(?number_of_citing_works) 

--- a/scholia/app/templates/country_co-organizations.sparql
+++ b/scholia/app/templates/country_co-organizations.sparql
@@ -21,5 +21,5 @@ WITH {
 } AS %results
 WHERE {
   INCLUDE %results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }

--- a/scholia/app/templates/country_locations-as-topics.sparql
+++ b/scholia/app/templates/country_locations-as-topics.sparql
@@ -28,5 +28,5 @@ WHERE {
     FILTER (LANG(?layer) = 'en')
   }
   
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en,da,de,es,fr,jp,nl,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en,da,de,es,fr,jp,nl,no,ru,sv,zh". }
 } 

--- a/scholia/app/templates/country_narrative-locations.sparql
+++ b/scholia/app/templates/country_narrative-locations.sparql
@@ -24,5 +24,5 @@ WITH {
 WHERE {
   INCLUDE %results 
 
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en,da,de,es,fr,jp,nl,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en,da,de,es,fr,jp,nl,no,ru,sv,zh". }
 }

--- a/scholia/app/templates/country_organizations.sparql
+++ b/scholia/app/templates/country_organizations.sparql
@@ -19,6 +19,6 @@ WITH {
 } AS %results
 WHERE {
   INCLUDE %results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en,da,es,fr,jp,nl,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en,da,es,fr,jp,nl,no,ru,sv,zh". }
 }
 ORDER BY DESC(?number_of_authors) DESC(?number_of_works)

--- a/scholia/app/templates/dataset_citations.sparql
+++ b/scholia/app/templates/dataset_citations.sparql
@@ -26,6 +26,6 @@ WITH {
 WHERE {
   # Label the result
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . } 
 } 
 ORDER BY DESC(?citations) DESC(?publication_date) 

--- a/scholia/app/templates/dataset_citations.sparql
+++ b/scholia/app/templates/dataset_citations.sparql
@@ -26,6 +26,6 @@ WITH {
 WHERE {
   # Label the result
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,it,jp,nl,no,ru,sv,zh" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
 } 
 ORDER BY DESC(?citations) DESC(?publication_date) 

--- a/scholia/app/templates/dataset_identifiers.sparql
+++ b/scholia/app/templates/dataset_identifiers.sparql
@@ -26,7 +26,7 @@ WITH {
       BIND(IRI(REPLACE(?formatterurl, '\\\\$1', str(?id))) AS ?idUrls).
     }
   }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }
 GROUP BY ?Identifier ?IdentifierLabel ?IdentifierDescription ?id
 ORDER BY ASC(?IdentifierLabel)

--- a/scholia/app/templates/dataset_topic-scores.sparql
+++ b/scholia/app/templates/dataset_topic-scores.sparql
@@ -35,7 +35,7 @@ WITH {
 } AS %results 
 WHERE {
   INCLUDE %results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en,da,de,es,jp,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en,da,de,es,jp,no,ru,sv,zh". }
 }
 ORDER BY DESC(?score)
 LIMIT 200

--- a/scholia/app/templates/disease_clinical-trials.sparql
+++ b/scholia/app/templates/disease_clinical-trials.sparql
@@ -15,6 +15,6 @@ WHERE {
   }
   OPTIONAL { ?trial wdt:P4844 ?intervention }
   OPTIONAL { ?trial wdt:P859 ?sponsor }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?starttime)

--- a/scholia/app/templates/disease_clinical-trials.sparql
+++ b/scholia/app/templates/disease_clinical-trials.sparql
@@ -15,6 +15,6 @@ WHERE {
   }
   OPTIONAL { ?trial wdt:P4844 ?intervention }
   OPTIONAL { ?trial wdt:P859 ?sponsor }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,pl,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }
 ORDER BY DESC(?starttime)

--- a/scholia/app/templates/disease_related-diseases.sparql
+++ b/scholia/app/templates/disease_related-diseases.sparql
@@ -34,6 +34,6 @@ SELECT
   # Aggregate count
   BIND((COALESCE(?symptom_count, 0) + COALESCE(?gene_count, 0)) AS ?count)
 
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }
 ORDER BY DESC(?count)

--- a/scholia/app/templates/disease_related-diseases.sparql
+++ b/scholia/app/templates/disease_related-diseases.sparql
@@ -34,6 +34,6 @@ SELECT
   # Aggregate count
   BIND((COALESCE(?symptom_count, 0) + COALESCE(?gene_count, 0)) AS ?count)
 
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?count)

--- a/scholia/app/templates/event-series-index_acceptance-rate.sparql
+++ b/scholia/app/templates/event-series-index_acceptance-rate.sparql
@@ -21,6 +21,6 @@ WITH {
 } AS %event_series
 WHERE {
   INCLUDE %event_series
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }
 ORDER BY ?mean_acceptance_rate

--- a/scholia/app/templates/event-series-index_list.sparql
+++ b/scholia/app/templates/event-series-index_list.sparql
@@ -14,6 +14,6 @@ WITH {
 WHERE {
   INCLUDE %events
   OPTIONAL { ?event_series wdt:P1813 ?short_name }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en,da,de,fr". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en,da,de,fr". }
 }
 ORDER BY DESC(?events)

--- a/scholia/app/templates/event-series_acceptance-rate.sparql
+++ b/scholia/app/templates/event-series_acceptance-rate.sparql
@@ -15,6 +15,6 @@ WHERE {
   BIND(COALESCE(?track_, "total") AS ?track)
   
   BIND(STR(YEAR(?datetime)) AS ?year)
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }
 ORDER BY ?year

--- a/scholia/app/templates/event-series_events.sparql
+++ b/scholia/app/templates/event-series_events.sparql
@@ -33,7 +33,7 @@ WHERE {
       BIND(YEAR(?datetime) AS ?years)    
     }
   }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
   }
 GROUP BY ?event ?year ?eventLabel ?proceedings ?proceedingsLabel
 ORDER BY DESC(?year)

--- a/scholia/app/templates/event-series_events.sparql
+++ b/scholia/app/templates/event-series_events.sparql
@@ -33,7 +33,7 @@ WHERE {
       BIND(YEAR(?datetime) AS ?years)    
     }
   }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
   }
 GROUP BY ?event ?year ?eventLabel ?proceedings ?proceedingsLabel
 ORDER BY DESC(?year)

--- a/scholia/app/templates/event-series_map.sparql
+++ b/scholia/app/templates/event-series_map.sparql
@@ -6,5 +6,5 @@ SELECT ?event ?eventLabel ?geo ?image WHERE {
   ?event (wdt:P179 | wdt:P31) target: .
   ?event wdt:P276? / wdt:P625 ?geo .
   OPTIONAL { ?event wdt:P18 ?image . }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }

--- a/scholia/app/templates/event-series_map.sparql
+++ b/scholia/app/templates/event-series_map.sparql
@@ -6,5 +6,5 @@ SELECT ?event ?eventLabel ?geo ?image WHERE {
   ?event (wdt:P179 | wdt:P31) target: .
   ?event wdt:P276? / wdt:P625 ?geo .
   OPTIONAL { ?event wdt:P18 ?image . }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }

--- a/scholia/app/templates/event-series_number-of-participants.sparql
+++ b/scholia/app/templates/event-series_number-of-participants.sparql
@@ -11,6 +11,6 @@ WHERE {
          wdt:P1132 ?number_of_participants .
   
   BIND(STR(YEAR(?datetime)) AS ?year)
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }
 ORDER BY ?year

--- a/scholia/app/templates/event-series_people.sparql
+++ b/scholia/app/templates/event-series_people.sparql
@@ -64,7 +64,7 @@ WITH {
 } AS %results
 WHERE {
   INCLUDE %results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en,da,de,es,fr,jp,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en,da,de,es,fr,jp,no,ru,sv,zh". }
 }
 ORDER BY DESC(?number_of_roles)
 LIMIT 500

--- a/scholia/app/templates/event-series_proceedings-publications.sparql
+++ b/scholia/app/templates/event-series_proceedings-publications.sparql
@@ -34,6 +34,6 @@ WITH {
 } AS %results
 WHERE {
   INCLUDE %results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }
 ORDER BY DESC(?date)

--- a/scholia/app/templates/event-series_recent-publications.sparql
+++ b/scholia/app/templates/event-series_recent-publications.sparql
@@ -46,7 +46,7 @@ WITH {
 } AS %results
 WHERE {
   INCLUDE %results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en,da,de,es,fr,jp,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en,da,de,es,fr,jp,no,ru,sv,zh". }
 }
 ORDER BY DESC(?publication_date)
 LIMIT 500

--- a/scholia/app/templates/event-series_timeline.sparql
+++ b/scholia/app/templates/event-series_timeline.sparql
@@ -43,6 +43,6 @@ WHERE {
           
   OPTIONAL { ?event wdt:P18 ?image . }
   SERVICE wikibase:label {
-    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" .
+    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" .
   }
 }

--- a/scholia/app/templates/event-series_timeline.sparql
+++ b/scholia/app/templates/event-series_timeline.sparql
@@ -43,6 +43,6 @@ WHERE {
           
   OPTIONAL { ?event wdt:P18 ?image . }
   SERVICE wikibase:label {
-    bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,ru,sv,zh".
+    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" .
   }
 }

--- a/scholia/app/templates/event-series_top-topics-through-time.sparql
+++ b/scholia/app/templates/event-series_top-topics-through-time.sparql
@@ -41,6 +41,6 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }
 ORDER BY ?year

--- a/scholia/app/templates/event-series_topics.sparql
+++ b/scholia/app/templates/event-series_topics.sparql
@@ -58,7 +58,7 @@ WITH {
 } AS %results
 WHERE {
   INCLUDE %results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en,da,de,es,fr,jp,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en,da,de,es,fr,jp,no,ru,sv,zh". }
 }
 ORDER BY DESC(?score)
 LIMIT 200

--- a/scholia/app/templates/event_co-authors.sparql
+++ b/scholia/app/templates/event_co-authors.sparql
@@ -52,7 +52,7 @@ WHERE {
     
   OPTIONAL { ?author1 wdt:P18 ?image1_ . }
   OPTIONAL { ?author2 wdt:P18 ?image2_ . }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" .
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" .
   }
 }
 GROUP BY ?author1 ?author1Label ?rgb ?author2 ?author2Label  

--- a/scholia/app/templates/event_co-authors.sparql
+++ b/scholia/app/templates/event_co-authors.sparql
@@ -52,7 +52,7 @@ WHERE {
     
   OPTIONAL { ?author1 wdt:P18 ?image1_ . }
   OPTIONAL { ?author2 wdt:P18 ?image2_ . }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,sv,ru,zh".
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" .
   }
 }
 GROUP BY ?author1 ?author1Label ?rgb ?author2 ?author2Label  

--- a/scholia/app/templates/event_data.sparql
+++ b/scholia/app/templates/event_data.sparql
@@ -94,6 +94,6 @@ WHERE {
     BIND(IF(BOUND(?track), CONCAT(STR(?acceptance_rate * 100), " % (", ?track, ")"), CONCAT(STR(?acceptance_rate * 100), " %")) AS ?value)
   }
 
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 } 
 ORDER BY ?order

--- a/scholia/app/templates/event_future-events.sparql
+++ b/scholia/app/templates/event_future-events.sparql
@@ -28,6 +28,6 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en,da,de,fr,jp,nl,no,pl,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en,da,de,fr,jp,nl,no,pl,ru,sv,zh". }
 }
 ORDER BY ?time

--- a/scholia/app/templates/event_past-events.sparql
+++ b/scholia/app/templates/event_past-events.sparql
@@ -28,7 +28,7 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en,da,de,fr,jp,nl,no,pl,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en,da,de,fr,jp,nl,no,pl,ru,sv,zh". }
 }
 ORDER BY DESC(?time)
 LIMIT 200

--- a/scholia/app/templates/event_people.sparql
+++ b/scholia/app/templates/event_people.sparql
@@ -69,6 +69,6 @@ WITH {
 } AS %results
 WHERE {
   INCLUDE %results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en,da,de,es,fr,jp,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en,da,de,es,fr,jp,no,ru,sv,zh". }
 }
 ORDER BY DESC(?number_of_publications)

--- a/scholia/app/templates/event_presentations.sparql
+++ b/scholia/app/templates/event_presentations.sparql
@@ -26,5 +26,5 @@ WITH {
 } AS %results
 WHERE {
   INCLUDE %results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }

--- a/scholia/app/templates/event_proceedings.sparql
+++ b/scholia/app/templates/event_proceedings.sparql
@@ -28,5 +28,5 @@ WITH {
 } AS %results
 WHERE {
   INCLUDE %results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }

--- a/scholia/app/templates/event_recent-publications.sparql
+++ b/scholia/app/templates/event_recent-publications.sparql
@@ -46,7 +46,7 @@ WITH {
 } AS %results
 WHERE {
   INCLUDE %results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en,da,de,es,fr,jp,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en,da,de,es,fr,jp,no,ru,sv,zh". }
 }
 ORDER BY DESC(?publication_date)
 LIMIT 500

--- a/scholia/app/templates/event_related-events-people.sparql
+++ b/scholia/app/templates/event_related-events-people.sparql
@@ -16,6 +16,6 @@ WHERE {
     ORDER BY DESC(?score)
     LIMIT 200
   } 
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }
 ORDER BY DESC(?score)

--- a/scholia/app/templates/event_related-events-people.sparql
+++ b/scholia/app/templates/event_related-events-people.sparql
@@ -16,6 +16,6 @@ WHERE {
     ORDER BY DESC(?score)
     LIMIT 200
   } 
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?score)

--- a/scholia/app/templates/event_related-events-timelocation.sparql
+++ b/scholia/app/templates/event_related-events-timelocation.sparql
@@ -68,6 +68,6 @@ WITH {
 WHERE {
   INCLUDE %results
   FILTER (?event != target:)
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?score)

--- a/scholia/app/templates/event_related-events-timelocation.sparql
+++ b/scholia/app/templates/event_related-events-timelocation.sparql
@@ -68,6 +68,6 @@ WITH {
 WHERE {
   INCLUDE %results
   FILTER (?event != target:)
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,es,fr,jp,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }
 ORDER BY DESC(?score)

--- a/scholia/app/templates/event_sponsors.sparql
+++ b/scholia/app/templates/event_sponsors.sparql
@@ -4,5 +4,5 @@ SELECT ?sponsor ?sponsorLabel ?sponsorUrl ?sponsorDescription
 WHERE {
   target: wdt:P859 ?sponsor .
   BIND(CONCAT("/sponsor/", SUBSTR(STR(?sponsor), 32)) AS ?sponsorUrl)
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }

--- a/scholia/app/templates/event_timeline.sparql
+++ b/scholia/app/templates/event_timeline.sparql
@@ -17,6 +17,6 @@ WHERE {
   }
   UNION 
   { target: p:P793 [ ps:P793 ?item ; pq:P585 ?time ] . }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }
 

--- a/scholia/app/templates/event_topic-scores.sparql
+++ b/scholia/app/templates/event_topic-scores.sparql
@@ -47,7 +47,7 @@ WITH {
 } AS %results
 WHERE {
   INCLUDE %results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en,da,de,es,fr,jp,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en,da,de,es,fr,jp,no,ru,sv,zh". }
 }
 ORDER BY DESC(?score)
 LIMIT 200

--- a/scholia/app/templates/event_upcoming-deadlines.sparql
+++ b/scholia/app/templates/event_upcoming-deadlines.sparql
@@ -28,6 +28,6 @@ WHERE {
   INCLUDE %events
   
   BIND(xsd:date(?datetime) AS ?date)
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en,da,de,es,fr,jp,nl,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en,da,de,es,fr,jp,nl,no,ru,sv,zh". }
 }
 ORDER BY(?date)

--- a/scholia/app/templates/event_uses.sparql
+++ b/scholia/app/templates/event_uses.sparql
@@ -39,7 +39,7 @@ WITH {
 } AS %results
 WHERE {
   INCLUDE %results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en,da,de,es,fr,jp,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en,da,de,es,fr,jp,no,ru,sv,zh". }
 }
 ORDER BY DESC(?number_of_persons)
 LIMIT 200

--- a/scholia/app/templates/gene_identifiers.sparql
+++ b/scholia/app/templates/gene_identifiers.sparql
@@ -21,7 +21,7 @@ WITH {
       BIND(IRI(REPLACE(?formatterurl, '\\\\$1', str(?Value))) AS ?idUrls).
     }
   }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }
 GROUP BY ?Identifier ?IdentifierLabel ?IdentifierDescription ?Value
 ORDER BY ASC(?IdentifierLabel)

--- a/scholia/app/templates/gene_orthologs.sparql
+++ b/scholia/app/templates/gene_orthologs.sparql
@@ -13,5 +13,5 @@ WITH {
 } AS %result 
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }

--- a/scholia/app/templates/gene_proteins.sparql
+++ b/scholia/app/templates/gene_proteins.sparql
@@ -11,5 +11,5 @@ WITH {
 } AS %result 
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }

--- a/scholia/app/templates/gene_transcripts.sparql
+++ b/scholia/app/templates/gene_transcripts.sparql
@@ -14,5 +14,5 @@ WITH {
 } AS %result 
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }

--- a/scholia/app/templates/gene_variants.sparql
+++ b/scholia/app/templates/gene_variants.sparql
@@ -21,5 +21,5 @@ WITH {
 } AS %result 
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }

--- a/scholia/app/templates/language-index_works-written-in-the-language.sparql
+++ b/scholia/app/templates/language-index_works-written-in-the-language.sparql
@@ -19,7 +19,7 @@ WHERE {
   # This is to get rid of a language number of unknown values
   FILTER EXISTS { ?language ?p [] }
 
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }
 ORDER BY DESC(?count)
 

--- a/scholia/app/templates/language_recently-published-works.sparql
+++ b/scholia/app/templates/language_recently-published-works.sparql
@@ -29,7 +29,7 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }
 ORDER BY DESC(?publication_date)
 

--- a/scholia/app/templates/lexeme_works.sparql
+++ b/scholia/app/templates/lexeme_works.sparql
@@ -1,4 +1,4 @@
 SELECT DISTINCT ?work ?workLabel ?workDescription {
   wd:{{ lexeme }} wdt:P1343 | ^wdt:P6254 ?work
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en,cz,da,de,es,fi,fr,it,nl,nn,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en,cz,da,de,es,fi,fr,it,nl,nn,ru,sv,zh". }
 }

--- a/scholia/app/templates/license-index_work-counts.sparql
+++ b/scholia/app/templates/license-index_work-counts.sparql
@@ -12,6 +12,6 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }
 ORDER BY DESC(?count)

--- a/scholia/app/templates/license_recently-published-works.sparql
+++ b/scholia/app/templates/license_recently-published-works.sparql
@@ -27,7 +27,7 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }
 ORDER BY DESC(?publication_date)
 

--- a/scholia/app/templates/license_types-of-work.sparql
+++ b/scholia/app/templates/license_types-of-work.sparql
@@ -16,6 +16,6 @@ WITH {
 } AS %types
 WHERE {
   INCLUDE %types
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }
 ORDER BY DESC(?count)

--- a/scholia/app/templates/location-topic_nearby-researchers.sparql
+++ b/scholia/app/templates/location-topic_nearby-researchers.sparql
@@ -63,6 +63,6 @@ WITH {
 } AS %results
 WHERE {
   INCLUDE %results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?score) 

--- a/scholia/app/templates/location-topic_nearby-researchers.sparql
+++ b/scholia/app/templates/location-topic_nearby-researchers.sparql
@@ -63,6 +63,6 @@ WITH {
 } AS %results
 WHERE {
   INCLUDE %results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }
 ORDER BY DESC(?score) 

--- a/scholia/app/templates/location_nearby-locations-as-topics-in-works.sparql
+++ b/scholia/app/templates/location_nearby-locations-as-topics-in-works.sparql
@@ -34,6 +34,6 @@ WHERE {
   INCLUDE %results
           
   # Label the result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,cs,da,de,es,jp,nl,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }
 ORDER BY ?distance

--- a/scholia/app/templates/location_nearby-locations-as-topics-in-works.sparql
+++ b/scholia/app/templates/location_nearby-locations-as-topics-in-works.sparql
@@ -34,6 +34,6 @@ WHERE {
   INCLUDE %results
           
   # Label the result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY ?distance

--- a/scholia/app/templates/location_nearby-organizations.sparql
+++ b/scholia/app/templates/location_nearby-organizations.sparql
@@ -30,6 +30,6 @@ WITH {
 } AS %results
 WHERE {
   INCLUDE %results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY ?distance

--- a/scholia/app/templates/location_nearby-organizations.sparql
+++ b/scholia/app/templates/location_nearby-organizations.sparql
@@ -30,6 +30,6 @@ WITH {
 } AS %results
 WHERE {
   INCLUDE %results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }
 ORDER BY ?distance

--- a/scholia/app/templates/ontology-index_most-used-ontology.sparql
+++ b/scholia/app/templates/ontology-index_most-used-ontology.sparql
@@ -19,7 +19,7 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?count)
 LIMIT 500    

--- a/scholia/app/templates/ontology_recent-works.sparql
+++ b/scholia/app/templates/ontology_recent-works.sparql
@@ -17,6 +17,6 @@ WITH{
 WHERE {
   INCLUDE %result
   BIND(xsd:date(?publication_datetime) AS ?publication_date)
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?publication_date)

--- a/scholia/app/templates/organization-curation_authors-no-initials.sparql
+++ b/scholia/app/templates/organization-curation_authors-no-initials.sparql
@@ -37,6 +37,6 @@ WITH {
 WHERE {
   INCLUDE %researchers_and_number_of_works
           
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en,da,de,es,fr,nl,no,ru,sv,zh" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en,da,de,es,fr,nl,no,ru,sv,zh" . } 
 }
 ORDER BY DESC(?works)

--- a/scholia/app/templates/organization-curation_authors-with-initials.sparql
+++ b/scholia/app/templates/organization-curation_authors-with-initials.sparql
@@ -36,6 +36,6 @@ WITH {
 WHERE {
   INCLUDE %researchers_and_number_of_works
           
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en,da,de,es,fr,nl,no,ru,sv,zh" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en,da,de,es,fr,nl,no,ru,sv,zh" . } 
 }
 ORDER BY DESC(?works)

--- a/scholia/app/templates/organization-topic_authors.sparql
+++ b/scholia/app/templates/organization-topic_authors.sparql
@@ -26,6 +26,6 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }
 ORDER BY DESC (?works)

--- a/scholia/app/templates/organization-topic_recent-literature.sparql
+++ b/scholia/app/templates/organization-topic_recent-literature.sparql
@@ -31,6 +31,6 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }
 ORDER BY DESC (?publication_date)

--- a/scholia/app/templates/organization-use_authors.sparql
+++ b/scholia/app/templates/organization-use_authors.sparql
@@ -25,6 +25,6 @@ WITH {
 WHERE {
   INCLUDE %researchers_and_works
 
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en,da,de,es,fr,jp,nl,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en,da,de,es,fr,jp,nl,no,ru,sv,zh". }
 }
 ORDER BY DESC (?works)

--- a/scholia/app/templates/organization-use_recent-literature.sparql
+++ b/scholia/app/templates/organization-use_recent-literature.sparql
@@ -18,6 +18,6 @@ WHERE {
     ?work wdt:P577 ?publication_datetime .
     BIND(xsd:date(?publication_datetime) AS ?publication_date)
   }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en,da,de,es,fr,jp,nl,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en,da,de,es,fr,jp,nl,no,ru,sv,zh". }
 }
 ORDER BY DESC(?publication_date)

--- a/scholia/app/templates/organization_advisor-graph.sparql
+++ b/scholia/app/templates/organization_advisor-graph.sparql
@@ -17,6 +17,6 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" .
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" .
   }
 }

--- a/scholia/app/templates/organization_advisor-graph.sparql
+++ b/scholia/app/templates/organization_advisor-graph.sparql
@@ -17,6 +17,6 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,sv,ru,zh".
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" .
   }
 }

--- a/scholia/app/templates/organization_awards.sparql
+++ b/scholia/app/templates/organization_awards.sparql
@@ -26,6 +26,6 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . } 
 }
 ORDER BY DESC(?count)

--- a/scholia/app/templates/organization_awards.sparql
+++ b/scholia/app/templates/organization_awards.sparql
@@ -26,6 +26,6 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,ru,sv,zh" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
 }
 ORDER BY DESC(?count)

--- a/scholia/app/templates/organization_co-author-graph.sparql
+++ b/scholia/app/templates/organization_co-author-graph.sparql
@@ -33,7 +33,7 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" .
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" .
   }
 }
 

--- a/scholia/app/templates/organization_co-author-graph.sparql
+++ b/scholia/app/templates/organization_co-author-graph.sparql
@@ -33,7 +33,7 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,sv,ru,zh".
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" .
   }
 }
 

--- a/scholia/app/templates/organization_co-author-normalized-citations.sparql
+++ b/scholia/app/templates/organization_co-author-normalized-citations.sparql
@@ -26,7 +26,7 @@ WITH {
 WHERE {
   # Label the results
   INCLUDE %counts    
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 GROUP BY ?year ?researcher ?researcherLabel
 ORDER BY ?year

--- a/scholia/app/templates/organization_co-author-normalized-citations.sparql
+++ b/scholia/app/templates/organization_co-author-normalized-citations.sparql
@@ -26,7 +26,7 @@ WITH {
 WHERE {
   # Label the results
   INCLUDE %counts    
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }
 GROUP BY ?year ?researcher ?researcherLabel
 ORDER BY ?year

--- a/scholia/app/templates/organization_employees-and-affiliated.sparql
+++ b/scholia/app/templates/organization_employees-and-affiliated.sparql
@@ -31,7 +31,7 @@ WHERE {
   INCLUDE %researchers_and_number_of_works
   OPTIONAL { ?researcher wdt:P496 ?orcid_ . }
   OPTIONAL { ?researcher wikibase:sitelinks ?wikis_ }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,nl,no,ru,sv,zh" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
 }
 GROUP BY ?researcher ?researcherLabel ?researcherDescription 
 ORDER BY DESC(?works)

--- a/scholia/app/templates/organization_employees-and-affiliated.sparql
+++ b/scholia/app/templates/organization_employees-and-affiliated.sparql
@@ -31,7 +31,7 @@ WHERE {
   INCLUDE %researchers_and_number_of_works
   OPTIONAL { ?researcher wdt:P496 ?orcid_ . }
   OPTIONAL { ?researcher wikibase:sitelinks ?wikis_ }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . } 
 }
 GROUP BY ?researcher ?researcherLabel ?researcherDescription 
 ORDER BY DESC(?works)

--- a/scholia/app/templates/organization_gender-distribution.sparql
+++ b/scholia/app/templates/organization_gender-distribution.sparql
@@ -10,6 +10,6 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,ep,fr,jp,nl,no,ru,sv,zh" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
 } 
 ORDER BY DESC(?count)

--- a/scholia/app/templates/organization_gender-distribution.sparql
+++ b/scholia/app/templates/organization_gender-distribution.sparql
@@ -10,6 +10,6 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . } 
 } 
 ORDER BY DESC(?count)

--- a/scholia/app/templates/organization_most-cited-papers.sparql
+++ b/scholia/app/templates/organization_most-cited-papers.sparql
@@ -27,7 +27,7 @@ WHERE {
   # Label the works
   INCLUDE %works
   SERVICE wikibase:label {
-    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" .
+    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" .
   }
 }
 ORDER BY DESC(?count)

--- a/scholia/app/templates/organization_most-cited-papers.sparql
+++ b/scholia/app/templates/organization_most-cited-papers.sparql
@@ -27,7 +27,7 @@ WHERE {
   # Label the works
   INCLUDE %works
   SERVICE wikibase:label {
-    bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,ru,sv,zh" .
+    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" .
   }
 }
 ORDER BY DESC(?count)

--- a/scholia/app/templates/organization_recent-citations.sparql
+++ b/scholia/app/templates/organization_recent-citations.sparql
@@ -8,7 +8,7 @@ WHERE {
   ?citing_work wdt:P2860 ?work .
   ?citing_work wdt:P577 ?publication_datetime .
   BIND(xsd:date(?publication_datetime) AS ?publication_date)
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,nl,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
  }
 ORDER BY DESC(?publication_date)
 LIMIT 200

--- a/scholia/app/templates/organization_recent-citations.sparql
+++ b/scholia/app/templates/organization_recent-citations.sparql
@@ -8,7 +8,7 @@ WHERE {
   ?citing_work wdt:P2860 ?work .
   ?citing_work wdt:P577 ?publication_datetime .
   BIND(xsd:date(?publication_datetime) AS ?publication_date)
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
  }
 ORDER BY DESC(?publication_date)
 LIMIT 200

--- a/scholia/app/templates/organization_recent-literature.sparql
+++ b/scholia/app/templates/organization_recent-literature.sparql
@@ -26,6 +26,6 @@ WITH {
 WHERE {
   INCLUDE %results
   BIND(xsd:date(?publication_datetime) AS ?publication_date)
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,nl,ru,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }
 ORDER BY DESC(?publication_date)

--- a/scholia/app/templates/organization_recent-literature.sparql
+++ b/scholia/app/templates/organization_recent-literature.sparql
@@ -26,6 +26,6 @@ WITH {
 WHERE {
   INCLUDE %results
   BIND(xsd:date(?publication_datetime) AS ?publication_date)
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?publication_date)

--- a/scholia/app/templates/organization_topics.sparql
+++ b/scholia/app/templates/organization_topics.sparql
@@ -27,7 +27,7 @@ WITH {
 } AS %works_and_number_of_researchers
 WHERE {
   INCLUDE %works_and_number_of_researchers
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . } 
 }
 GROUP BY ?researchers ?topic ?topicLabel ?topicDescription ?samplework ?sampleworkLabel
 ORDER BY DESC(?researchers)

--- a/scholia/app/templates/organization_topics.sparql
+++ b/scholia/app/templates/organization_topics.sparql
@@ -27,7 +27,7 @@ WITH {
 } AS %works_and_number_of_researchers
 WHERE {
   INCLUDE %works_and_number_of_researchers
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,nl,no,ru,sv,zh" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
 }
 GROUP BY ?researchers ?topic ?topicLabel ?topicDescription ?samplework ?sampleworkLabel
 ORDER BY DESC(?researchers)

--- a/scholia/app/templates/organization_uses.sparql
+++ b/scholia/app/templates/organization_uses.sparql
@@ -27,7 +27,7 @@ WITH {
 } AS %works_and_number_of_researchers
 WHERE {
   INCLUDE %works_and_number_of_researchers
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,nl,no,ru,sv,zh" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
 }
 GROUP BY ?researchers ?use ?useLabel ?useDescription ?samplework ?sampleworkLabel
 ORDER BY DESC(?researchers)

--- a/scholia/app/templates/organization_uses.sparql
+++ b/scholia/app/templates/organization_uses.sparql
@@ -27,7 +27,7 @@ WITH {
 } AS %works_and_number_of_researchers
 WHERE {
   INCLUDE %works_and_number_of_researchers
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . } 
 }
 GROUP BY ?researchers ?use ?useLabel ?useDescription ?samplework ?sampleworkLabel
 ORDER BY DESC(?researchers)

--- a/scholia/app/templates/organizations_citations-per-year.sparql
+++ b/scholia/app/templates/organizations_citations-per-year.sparql
@@ -38,7 +38,7 @@ WHERE {
   
   # Label the results
   INCLUDE %results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,es,fr,jp,nl,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }
 ORDER BY ?year_of_citation
 

--- a/scholia/app/templates/organizations_citations-per-year.sparql
+++ b/scholia/app/templates/organizations_citations-per-year.sparql
@@ -38,7 +38,7 @@ WHERE {
   
   # Label the results
   INCLUDE %results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY ?year_of_citation
 

--- a/scholia/app/templates/organizations_citations-to-works.sparql
+++ b/scholia/app/templates/organizations_citations-to-works.sparql
@@ -50,7 +50,7 @@ WHERE {
   INCLUDE %citation_numbers
   INCLUDE %work_numbers
   FILTER (?year_of_citation = ?year_of_cited)
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,es,fr,jp,nl,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }
 ORDER BY ?year_of_citation
  

--- a/scholia/app/templates/organizations_citations-to-works.sparql
+++ b/scholia/app/templates/organizations_citations-to-works.sparql
@@ -50,7 +50,7 @@ WHERE {
   INCLUDE %citation_numbers
   INCLUDE %work_numbers
   FILTER (?year_of_citation = ?year_of_cited)
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY ?year_of_citation
  

--- a/scholia/app/templates/organizations_coauthorships.sparql
+++ b/scholia/app/templates/organizations_coauthorships.sparql
@@ -9,7 +9,7 @@ SELECT DISTINCT ?author1 ?author1Label ?author2 ?author2Label ?work ?workLabel W
   ?author2 ?v2 ?organization2 . 
   ?work wdt:P50 ?author1, ?author2 .  
   FILTER (STR(?author1) < STR(?author2) && ?organization1 != ?organization2)
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY ?author1Label
 LIMIT 500

--- a/scholia/app/templates/organizations_coauthorships.sparql
+++ b/scholia/app/templates/organizations_coauthorships.sparql
@@ -9,7 +9,7 @@ SELECT DISTINCT ?author1 ?author1Label ?author2 ?author2Label ?work ?workLabel W
   ?author2 ?v2 ?organization2 . 
   ?work wdt:P50 ?author1, ?author2 .  
   FILTER (STR(?author1) < STR(?author2) && ?organization1 != ?organization2)
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }
 ORDER BY ?author1Label
 LIMIT 500

--- a/scholia/app/templates/organizations_list.sparql
+++ b/scholia/app/templates/organizations_list.sparql
@@ -16,5 +16,5 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }

--- a/scholia/app/templates/organizations_list.sparql
+++ b/scholia/app/templates/organizations_list.sparql
@@ -16,5 +16,5 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,es,fr,nl,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }

--- a/scholia/app/templates/organizations_topic-tree-map.sparql
+++ b/scholia/app/templates/organizations_topic-tree-map.sparql
@@ -32,7 +32,7 @@ WITH {
 WHERE {
   # Join the work and citation counts
   INCLUDE %work_numbers
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,es,fr,jp,nl,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }
 ORDER BY DESC(?number_of_works)
 LIMIT 100

--- a/scholia/app/templates/organizations_topic-tree-map.sparql
+++ b/scholia/app/templates/organizations_topic-tree-map.sparql
@@ -32,7 +32,7 @@ WITH {
 WHERE {
   # Join the work and citation counts
   INCLUDE %work_numbers
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?number_of_works)
 LIMIT 100

--- a/scholia/app/templates/organizations_topic-tree.sparql
+++ b/scholia/app/templates/organizations_topic-tree.sparql
@@ -31,7 +31,7 @@ WITH {
 WHERE {
   # Label the items returned
   INCLUDE %work_numbers
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?number_of_works)
 LIMIT 100

--- a/scholia/app/templates/organizations_topic-tree.sparql
+++ b/scholia/app/templates/organizations_topic-tree.sparql
@@ -31,7 +31,7 @@ WITH {
 WHERE {
   # Label the items returned
   INCLUDE %work_numbers
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,es,fr,jp,nl,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }
 ORDER BY DESC(?number_of_works)
 LIMIT 100

--- a/scholia/app/templates/organizations_works-per-year.sparql
+++ b/scholia/app/templates/organizations_works-per-year.sparql
@@ -12,7 +12,7 @@ WHERE {
     }
     GROUP BY ?work ?year ?organization
   } 
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 GROUP BY ?year ?organization ?organizationLabel
 ORDER BY ?year

--- a/scholia/app/templates/organizations_works-per-year.sparql
+++ b/scholia/app/templates/organizations_works-per-year.sparql
@@ -12,7 +12,7 @@ WHERE {
     }
     GROUP BY ?work ?year ?organization
   } 
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }
 GROUP BY ?year ?organization ?organizationLabel
 ORDER BY ?year

--- a/scholia/app/templates/pathway_citing-articles.sparql
+++ b/scholia/app/templates/pathway_citing-articles.sparql
@@ -20,6 +20,6 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?citations) DESC(?date)

--- a/scholia/app/templates/pathway_optional-data-values.sparql
+++ b/scholia/app/templates/pathway_optional-data-values.sparql
@@ -7,5 +7,5 @@ WHERE {
     target: wdt:P2410 ?wpid ;
     wdt:P703 ?organism .
   }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }

--- a/scholia/app/templates/pathway_participants.sparql
+++ b/scholia/app/templates/pathway_participants.sparql
@@ -16,5 +16,5 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 } ORDER BY ASC(?partLabel)

--- a/scholia/app/templates/pathway_recent-articles.sparql
+++ b/scholia/app/templates/pathway_recent-articles.sparql
@@ -33,7 +33,7 @@ WITH {
 WHERE {
   INCLUDE %result
   BIND(xsd:date(?datetime) AS ?date)
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?date)
 LIMIT 500

--- a/scholia/app/templates/podcast-episode_guests.sparql
+++ b/scholia/app/templates/podcast-episode_guests.sparql
@@ -5,5 +5,5 @@ SELECT DISTINCT ?guest ?guestLabel
 WHERE {
   BIND(target: AS ?episode)
   ?episode wdt:P5030 ?guest .
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }

--- a/scholia/app/templates/podcast-episode_listings.sparql
+++ b/scholia/app/templates/podcast-episode_listings.sparql
@@ -26,7 +26,7 @@ WITH {
     }
   }
   BIND(CONCAT(?Value, " ↗") AS ?value)
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }
 GROUP BY ?Identifier ?IdentifierLabel ?IdentifierDescription ?value
 ORDER BY ASC(?IdentifierLabel)

--- a/scholia/app/templates/podcast-language_podcast-list.sparql
+++ b/scholia/app/templates/podcast-language_podcast-list.sparql
@@ -11,6 +11,6 @@ WHERE {
     FILTER (LANG(?value_string) = 'en')
     BIND(COALESCE(?value_string, ?q) AS ?genreWDLabel)
   }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 } GROUP BY ?podcast ?podcastLabel
   ORDER BY DESC(?podcastLabel)

--- a/scholia/app/templates/podcast-language_recent-episodes.sparql
+++ b/scholia/app/templates/podcast-language_recent-episodes.sparql
@@ -16,6 +16,6 @@ WITH {
     LIMIT 50
 } AS %EPISODES WHERE {
   INCLUDE %EPISODES
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 } GROUP BY ?publication_date ?episode ?episodeLabel ?podcast ?podcastLabel
   ORDER BY DESC(?publication_date)

--- a/scholia/app/templates/podcast-season_episodes.sparql
+++ b/scholia/app/templates/podcast-season_episodes.sparql
@@ -4,5 +4,5 @@ SELECT DISTINCT ?episode ?episodeLabel
   (CONCAT("/podcast-episode/", SUBSTR(STR(?episode), 32)) AS ?episodeUrl)
 WHERE {
   ?episode wdt:P31 wd:Q61855877 ; wdt:P4908 target: .
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }

--- a/scholia/app/templates/podcast_listings.sparql
+++ b/scholia/app/templates/podcast_listings.sparql
@@ -26,7 +26,7 @@ WITH {
     }
   }
   BIND(CONCAT(?Value, " ↗") AS ?value)
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }
 GROUP BY ?Identifier ?IdentifierLabel ?IdentifierDescription ?value
 ORDER BY ASC(?IdentifierLabel)

--- a/scholia/app/templates/podcast_recent-episodes.sparql
+++ b/scholia/app/templates/podcast_recent-episodes.sparql
@@ -14,6 +14,6 @@ WITH {
     LIMIT 50
 } AS %EPISODES WHERE {
   INCLUDE %EPISODES
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 } GROUP BY ?publication_date ?episode ?episodeLabel
 ORDER BY DESC(?publication_date)

--- a/scholia/app/templates/podcast_seasons.sparql
+++ b/scholia/app/templates/podcast_seasons.sparql
@@ -8,5 +8,5 @@ WHERE {
   OPTIONAL {
     ?season wdt:P1113 ?count .
   }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 } GROUP BY ?season ?seasonLabel ?seasonUrl

--- a/scholia/app/templates/podcast_topics.sparql
+++ b/scholia/app/templates/podcast_topics.sparql
@@ -23,7 +23,7 @@ WITH {
 } AS %results 
 WHERE {
   INCLUDE %results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }
 ORDER BY DESC(?score)
 LIMIT 200

--- a/scholia/app/templates/printer-index_map.sparql
+++ b/scholia/app/templates/printer-index_map.sparql
@@ -18,7 +18,7 @@ WHERE {
   }
   BIND(IF(?count = 1, "1", IF(?count <= 5, "2-5", IF(?count <= 10, "6-10", "10+"))) AS ?counts)
   ?printer wdt:P159? / wdt:P625 ?geo
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en,da,de,es,fr,it,jp,nl,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en,da,de,es,fr,it,jp,nl,no,ru,sv,zh". }
 }
 ORDER BY DESC(?count)
 LIMIT 1000

--- a/scholia/app/templates/printer-index_printed-works-per-publisher.sparql
+++ b/scholia/app/templates/printer-index_printed-works-per-publisher.sparql
@@ -13,7 +13,7 @@ WHERE {
     }
     GROUP BY ?printer
   }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?count)
 LIMIT 1000

--- a/scholia/app/templates/printer_works.sparql
+++ b/scholia/app/templates/printer_works.sparql
@@ -19,7 +19,7 @@ WHERE {
     }
     GROUP BY ?work
   }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?date)
 LIMIT 1000

--- a/scholia/app/templates/project_citations-per-budget.sparql
+++ b/scholia/app/templates/project_citations-per-budget.sparql
@@ -23,6 +23,6 @@ WHERE {
   INCLUDE %results
   OPTIONAL { ?project wdt:P1813 ?short_name }
   SERVICE wikibase:label {
-    bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,ru,sv,zh". }
+    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }
 ORDER BY DESC(?cites_per_million)

--- a/scholia/app/templates/project_citations-per-budget.sparql
+++ b/scholia/app/templates/project_citations-per-budget.sparql
@@ -23,6 +23,6 @@ WHERE {
   INCLUDE %results
   OPTIONAL { ?project wdt:P1813 ?short_name }
   SERVICE wikibase:label {
-    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?cites_per_million)

--- a/scholia/app/templates/project_partners.sparql
+++ b/scholia/app/templates/project_partners.sparql
@@ -11,5 +11,5 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }

--- a/scholia/app/templates/project_prolific-authors.sparql
+++ b/scholia/app/templates/project_prolific-authors.sparql
@@ -32,7 +32,7 @@ WHERE {
   OPTIONAL { ?author wdt:P496 ?orcid . }
   
   # Label the results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?count)
 LIMIT 50

--- a/scholia/app/templates/project_recent-articles.sparql
+++ b/scholia/app/templates/project_recent-articles.sparql
@@ -47,7 +47,7 @@ WHERE {
   INCLUDE %result
   BIND(xsd:date(?datetime) AS ?date)
   SERVICE wikibase:label {
-    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" .
+    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" .
   }
 }
 ORDER BY DESC(?date)

--- a/scholia/app/templates/project_topic-scores.sparql
+++ b/scholia/app/templates/project_topic-scores.sparql
@@ -32,7 +32,7 @@ WITH {
 } AS %results 
 WHERE {
   INCLUDE %results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en,da,de,es,jp,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en,da,de,es,jp,no,ru,sv,zh". }
 }
 ORDER BY DESC(?score)
 LIMIT 200

--- a/scholia/app/templates/property_item-counts.sparql
+++ b/scholia/app/templates/property_item-counts.sparql
@@ -13,6 +13,6 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language  "en,da,de,es,fr,jp,nl,no,ru,sv,zh" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language  "[AUTO_LANGUAGE],en" . }
 }
 ORDER BY DESC(?count)

--- a/scholia/app/templates/property_item-counts.sparql
+++ b/scholia/app/templates/property_item-counts.sparql
@@ -13,6 +13,6 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language  "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language  "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?count)

--- a/scholia/app/templates/property_property-value-counts.sparql
+++ b/scholia/app/templates/property_property-value-counts.sparql
@@ -13,6 +13,6 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language  "en,da,de,es,fr,jp,nl,no,ru,sv,zh" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language  "[AUTO_LANGUAGE],en" . }
 }
 ORDER BY DESC(?count)

--- a/scholia/app/templates/property_property-value-counts.sparql
+++ b/scholia/app/templates/property_property-value-counts.sparql
@@ -13,6 +13,6 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language  "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language  "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?count)

--- a/scholia/app/templates/property_use.sparql
+++ b/scholia/app/templates/property_use.sparql
@@ -2,6 +2,6 @@ PREFIX target: <http://www.wikidata.org/prop/direct/{{ p }}>
 
 SELECT ?item ?itemLabel ?property_value ?property_valueLabel WHERE {
   ?item target: ?property_value .
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 LIMIT 500

--- a/scholia/app/templates/protein_cofunctional-proteins.sparql
+++ b/scholia/app/templates/protein_cofunctional-proteins.sparql
@@ -16,7 +16,7 @@ WITH {
 WHERE {
   INCLUDE %result
   OPTIONAL { ?protein wdt:P703 ?species . }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?count)
 LIMIT 500

--- a/scholia/app/templates/protein_cointeracting-proteins.sparql
+++ b/scholia/app/templates/protein_cointeracting-proteins.sparql
@@ -21,7 +21,7 @@ WITH {
 WHERE {
   INCLUDE %result
   OPTIONAL { ?protein wdt:P703 ?species . }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?count)
 LIMIT 500

--- a/scholia/app/templates/protein_participates-in.sparql
+++ b/scholia/app/templates/protein_participates-in.sparql
@@ -12,5 +12,5 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 } ORDER BY ASC(?partLabel)

--- a/scholia/app/templates/protein_similar-proteins.sparql
+++ b/scholia/app/templates/protein_similar-proteins.sparql
@@ -16,7 +16,7 @@ WITH {
 WHERE {
   INCLUDE %result
   OPTIONAL { ?protein wdt:P703 ?species . }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?count)
 LIMIT 500

--- a/scholia/app/templates/publisher_citations-works.sparql
+++ b/scholia/app/templates/publisher_citations-works.sparql
@@ -24,5 +24,5 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . } 
 }

--- a/scholia/app/templates/publisher_citations-works.sparql
+++ b/scholia/app/templates/publisher_citations-works.sparql
@@ -24,5 +24,5 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,ru,sv,zh" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
 }

--- a/scholia/app/templates/publisher_editor-photos.sparql
+++ b/scholia/app/templates/publisher_editor-photos.sparql
@@ -24,5 +24,5 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result 
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . } 
 }

--- a/scholia/app/templates/publisher_editor-photos.sparql
+++ b/scholia/app/templates/publisher_editor-photos.sparql
@@ -24,5 +24,5 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result 
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,fr,jp,nl,sv,ru,zh" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
 }

--- a/scholia/app/templates/publisher_editors.sparql
+++ b/scholia/app/templates/publisher_editors.sparql
@@ -21,5 +21,5 @@ WITH {
 WHERE {
   # Label the result
   INCLUDE %result 
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . } 
 }

--- a/scholia/app/templates/publisher_journals.sparql
+++ b/scholia/app/templates/publisher_journals.sparql
@@ -23,7 +23,7 @@ WHERE {
     FILTER (LANG(?themes_labels) = 'en')
   }
   OPTIONAL { ?journal wdt:P1240 ?bfi . }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . } 
 } 
 GROUP BY ?journal ?journalLabel
 ORDER BY DESC(?number_of_works)

--- a/scholia/app/templates/publisher_most-cited.sparql
+++ b/scholia/app/templates/publisher_most-cited.sparql
@@ -17,6 +17,6 @@ WITH {
 WHERE {
   INCLUDE %result
   # Label the result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . } 
 }
 ORDER BY DESC(?number_of_citations)

--- a/scholia/app/templates/publisher_timeline.sparql
+++ b/scholia/app/templates/publisher_timeline.sparql
@@ -13,7 +13,7 @@ SELECT DISTINCT ?datetime ?venue ?venueLabel WHERE {
   ?venue wdt:P571 ?datetime.
   
   # Label the journal
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }
 ORDER BY DESC(?datetime)
 LIMIT 50

--- a/scholia/app/templates/series_authors.sparql
+++ b/scholia/app/templates/series_authors.sparql
@@ -22,6 +22,6 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" }
 }
 ORDER BY DESC(?number_of_works) DESC(?number_of_citations)

--- a/scholia/app/templates/series_in-series.sparql
+++ b/scholia/app/templates/series_in-series.sparql
@@ -22,6 +22,6 @@ WITH {
 WHERE {
   INCLUDE %result
   BIND(xsd:date(?publication_datetime) AS ?publication_date)
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" }
 }
 ORDER BY DESC(?publication_date) DESC(?number_of_papers)

--- a/scholia/app/templates/series_organizations.sparql
+++ b/scholia/app/templates/series_organizations.sparql
@@ -30,6 +30,6 @@ WITH {
 } AS %result
 WHERE {
  INCLUDE %result
- SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,ru,sv,zh" }
+ SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }
 ORDER BY ?year

--- a/scholia/app/templates/series_organizations.sparql
+++ b/scholia/app/templates/series_organizations.sparql
@@ -30,6 +30,6 @@ WITH {
 } AS %result
 WHERE {
  INCLUDE %result
- SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+ SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY ?year

--- a/scholia/app/templates/series_topics.sparql
+++ b/scholia/app/templates/series_topics.sparql
@@ -19,7 +19,7 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?count)
 DESC(?count)

--- a/scholia/app/templates/series_topics.sparql
+++ b/scholia/app/templates/series_topics.sparql
@@ -19,7 +19,7 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,ru,sv,zh" }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }
 ORDER BY DESC(?count)
 DESC(?count)

--- a/scholia/app/templates/series_works.sparql
+++ b/scholia/app/templates/series_works.sparql
@@ -20,6 +20,6 @@ WITH {
 WHERE {
   INCLUDE %result
   BIND(xsd:date(?publication_datetime) AS ?publication_date)
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" }
 }
 ORDER BY DESC(?number_of_citations) DESC(?publication_date)

--- a/scholia/app/templates/software-curation_missing-describes-use.sparql
+++ b/scholia/app/templates/software-curation_missing-describes-use.sparql
@@ -23,5 +23,5 @@ WITH {
   } LIMIT 200
 } AS %works WHERE {
   INCLUDE %works
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }

--- a/scholia/app/templates/software-index_most-used-software.sparql
+++ b/scholia/app/templates/software-index_most-used-software.sparql
@@ -21,7 +21,7 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?count)
 LIMIT 500    

--- a/scholia/app/templates/software_authors.sparql
+++ b/scholia/app/templates/software_authors.sparql
@@ -19,6 +19,6 @@ WITH{
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?count)

--- a/scholia/app/templates/software_authors.sparql
+++ b/scholia/app/templates/software_authors.sparql
@@ -19,6 +19,6 @@ WITH{
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,nl,no,ru,sv,zh" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }
 ORDER BY DESC(?count)

--- a/scholia/app/templates/software_coused.sparql
+++ b/scholia/app/templates/software_coused.sparql
@@ -16,6 +16,6 @@ WITH{
 WHERE {
   # Label the result
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?count)  

--- a/scholia/app/templates/software_dependent-software.sparql
+++ b/scholia/app/templates/software_dependent-software.sparql
@@ -19,6 +19,6 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }
 ORDER BY DESC(?count)

--- a/scholia/app/templates/software_recent-works.sparql
+++ b/scholia/app/templates/software_recent-works.sparql
@@ -17,6 +17,6 @@ WITH{
 WHERE {
   INCLUDE %result
   BIND(xsd:date(?publication_datetime) AS ?publication_date)
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?publication_date)

--- a/scholia/app/templates/software_software-dependencies.sparql
+++ b/scholia/app/templates/software_software-dependencies.sparql
@@ -28,5 +28,5 @@ WITH {
 } AS %result
 {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }

--- a/scholia/app/templates/software_topics.sparql
+++ b/scholia/app/templates/software_topics.sparql
@@ -17,6 +17,6 @@ WITH{
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,nl,no,ru,sv,zh" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }
 ORDER BY DESC(?count)

--- a/scholia/app/templates/software_topics.sparql
+++ b/scholia/app/templates/software_topics.sparql
@@ -17,6 +17,6 @@ WITH{
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?count)

--- a/scholia/app/templates/sponsor_authors-on-sponsored-works.sparql
+++ b/scholia/app/templates/sponsor_authors-on-sponsored-works.sparql
@@ -16,6 +16,6 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" }
 } 
 ORDER BY DESC(?publication_count)

--- a/scholia/app/templates/sponsor_co-sponsors.sparql
+++ b/scholia/app/templates/sponsor_co-sponsors.sparql
@@ -16,6 +16,6 @@ WITH {
 WHERE {
   # Label the result
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" }
 }
 ORDER BY DESC(?count)

--- a/scholia/app/templates/sponsor_project-budgets.sparql
+++ b/scholia/app/templates/sponsor_project-budgets.sparql
@@ -8,5 +8,5 @@ SELECT ?start_time ?budget ?project ?projectLabel WHERE {
   ?project wdt:P2769 ?budget .
   ?project (wdt:P580 | wdt:P571) ?start_time .
   SERVICE wikibase:label {
-    bd:serviceParam wikibase:language "en,da,es,fr,jp,nl,no,ru,sv,zh". }
+    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }

--- a/scholia/app/templates/sponsor_project-budgets.sparql
+++ b/scholia/app/templates/sponsor_project-budgets.sparql
@@ -8,5 +8,5 @@ SELECT ?start_time ?budget ?project ?projectLabel WHERE {
   ?project wdt:P2769 ?budget .
   ?project (wdt:P580 | wdt:P571) ?start_time .
   SERVICE wikibase:label {
-    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }

--- a/scholia/app/templates/sponsor_recently-published-sponsored-works.sparql
+++ b/scholia/app/templates/sponsor_recently-published-sponsored-works.sparql
@@ -19,7 +19,7 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" }
 } 
 ORDER BY DESC(?publication_date) DESC(?number_of_citations)
 LIMIT 1000

--- a/scholia/app/templates/sponsor_topics-of-sponsored-works.sparql
+++ b/scholia/app/templates/sponsor_topics-of-sponsored-works.sparql
@@ -16,6 +16,6 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 } 
 ORDER BY DESC(?count)

--- a/scholia/app/templates/sponsor_topics-of-sponsored-works.sparql
+++ b/scholia/app/templates/sponsor_topics-of-sponsored-works.sparql
@@ -16,6 +16,6 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,ru,sv,zh" }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 } 
 ORDER BY DESC(?count)

--- a/scholia/app/templates/taxon-curation_missing-topic-tags-for-taxon-name.sparql
+++ b/scholia/app/templates/taxon-curation_missing-topic-tags-for-taxon-name.sparql
@@ -34,6 +34,6 @@ WITH
 AS %items
 WHERE {
   INCLUDE %items
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }
 LIMIT 200

--- a/scholia/app/templates/taxon_co-occurring-taxa.sparql
+++ b/scholia/app/templates/taxon_co-occurring-taxa.sparql
@@ -23,7 +23,7 @@ WITH {
 WHERE {
   # Label the results
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . } 
 }
 ORDER BY DESC(?count)
 LIMIT 200

--- a/scholia/app/templates/taxon_genome.sparql
+++ b/scholia/app/templates/taxon_genome.sparql
@@ -11,5 +11,5 @@ WITH {
   }
 } AS %results {
   INCLUDE %results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }

--- a/scholia/app/templates/taxon_identifiers.sparql
+++ b/scholia/app/templates/taxon_identifiers.sparql
@@ -29,7 +29,7 @@ WITH {
       BIND(IRI(REPLACE(?formatterurl, '\\\\$1', str(?id))) AS ?idUrls).
     }
   }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }
 GROUP BY ?Identifier ?IdentifierLabel ?IdentifierDescription ?id
 ORDER BY ASC(?IdentifierLabel)

--- a/scholia/app/templates/taxon_metabolome.sparql
+++ b/scholia/app/templates/taxon_metabolome.sparql
@@ -19,5 +19,5 @@ WITH {
   }
 } AS %results {
   INCLUDE %results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }

--- a/scholia/app/templates/taxon_parent-taxa.sparql
+++ b/scholia/app/templates/taxon_parent-taxa.sparql
@@ -11,7 +11,7 @@ SELECT
   OPTIONAL {
     ?rank rdfs:label ?rank_label_ . FILTER (LANG(?rank_label_) = 'en')
   }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }
 GROUP BY ?parent ?parentLabel ?parentDescription
 ORDER BY ?distance

--- a/scholia/app/templates/taxon_proteome.sparql
+++ b/scholia/app/templates/taxon_proteome.sparql
@@ -11,5 +11,5 @@ WITH {
 } AS %results {
   INCLUDE %results
   ?protein wdt:P702 ?gene .
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }

--- a/scholia/app/templates/topic-curation_missing-author-items.sparql
+++ b/scholia/app/templates/topic-curation_missing-author-items.sparql
@@ -60,7 +60,7 @@ WHERE {
   INCLUDE %scores
 
   # Label the result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?count) DESC(?score)
 LIMIT 200

--- a/scholia/app/templates/topic-curation_missing-co-topic.sparql
+++ b/scholia/app/templates/topic-curation_missing-co-topic.sparql
@@ -24,6 +24,6 @@ WHERE {
   # Label results
   INCLUDE %result
   SERVICE wikibase:label {
-    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
+    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . } 
 }
 ORDER BY DESC(?count) ?topics

--- a/scholia/app/templates/topic-curation_missing-pub-date.sparql
+++ b/scholia/app/templates/topic-curation_missing-pub-date.sparql
@@ -31,6 +31,6 @@ WHERE {
   INCLUDE %result
   
   # Label the results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?citations)

--- a/scholia/app/templates/topic-curation_missing-pub-venue.sparql
+++ b/scholia/app/templates/topic-curation_missing-pub-venue.sparql
@@ -31,6 +31,6 @@ WHERE {
   INCLUDE %result
   
   # Label the results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?citations)

--- a/scholia/app/templates/topic-use_works.sparql
+++ b/scholia/app/templates/topic-use_works.sparql
@@ -11,6 +11,6 @@ WHERE {
     ?work wdt:P577 ?publication_datetime .
     BIND(xsd:date(?publication_datetime) AS ?publication_date)
   }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en,da,de,es,fr,jp,nl,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en,da,de,es,fr,jp,nl,no,ru,sv,zh". }
 }
 ORDER BY DESC(?publication_date)

--- a/scholia/app/templates/topic_author-scores-graph.sparql
+++ b/scholia/app/templates/topic_author-scores-graph.sparql
@@ -34,7 +34,7 @@ WITH {
 } AS %results 
 WHERE {
   INCLUDE %results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en,da,de,es,jp,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en,da,de,es,jp,no,ru,sv,zh". }
 }
 ORDER BY DESC(?score)
 LIMIT 200

--- a/scholia/app/templates/topic_author-scores.sparql
+++ b/scholia/app/templates/topic_author-scores.sparql
@@ -35,6 +35,6 @@ WITH {
 } AS %results 
 WHERE {
   INCLUDE %results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en,da,de,es,jp,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en,da,de,es,jp,no,ru,sv,zh". }
 }
 ORDER BY DESC(?score)

--- a/scholia/app/templates/topic_authors.sparql
+++ b/scholia/app/templates/topic_authors.sparql
@@ -27,6 +27,6 @@ WHERE {
           
   # Include optional ORCID iD
   OPTIONAL { ?author wdt:P496 ?orcid_ . }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,ru,sv,zh" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
 }
 ORDER BY DESC(?count)

--- a/scholia/app/templates/topic_authors.sparql
+++ b/scholia/app/templates/topic_authors.sparql
@@ -27,6 +27,6 @@ WHERE {
           
   # Include optional ORCID iD
   OPTIONAL { ?author wdt:P496 ?orcid_ . }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . } 
 }
 ORDER BY DESC(?count)

--- a/scholia/app/templates/topic_co-occurring-map.sparql
+++ b/scholia/app/templates/topic_co-occurring-map.sparql
@@ -25,6 +25,6 @@ WHERE {
   
   # Label the results
   SERVICE wikibase:label {
-    bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,ru,sv,zh".
+    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" .
   }
 }

--- a/scholia/app/templates/topic_co-occurring-map.sparql
+++ b/scholia/app/templates/topic_co-occurring-map.sparql
@@ -25,6 +25,6 @@ WHERE {
   
   # Label the results
   SERVICE wikibase:label {
-    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" .
+    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" .
   }
 }

--- a/scholia/app/templates/topic_co-occurring.sparql
+++ b/scholia/app/templates/topic_co-occurring.sparql
@@ -30,7 +30,7 @@ WHERE {
   
   # Label the results
   SERVICE wikibase:label {
-    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" .
+    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" .
   }
 }
 

--- a/scholia/app/templates/topic_co-occurring.sparql
+++ b/scholia/app/templates/topic_co-occurring.sparql
@@ -30,7 +30,7 @@ WHERE {
   
   # Label the results
   SERVICE wikibase:label {
-    bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,ru,sv,zh".
+    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" .
   }
 }
 

--- a/scholia/app/templates/topic_coauthor-graph.sparql
+++ b/scholia/app/templates/topic_coauthor-graph.sparql
@@ -37,6 +37,6 @@ WHERE {
   OPTIONAL { ?author1 wdt:P21 ?gender1 . }
   BIND( IF(?gender1 = wd:Q6581097, "3182BD", "E6550D") AS ?rgb)
   SERVICE wikibase:label {
-    bd:serviceParam wikibase:language "en,fr,de,ru,es,zh,jp".
+    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" .
   }
 }

--- a/scholia/app/templates/topic_coauthor-graph.sparql
+++ b/scholia/app/templates/topic_coauthor-graph.sparql
@@ -37,6 +37,6 @@ WHERE {
   OPTIONAL { ?author1 wdt:P21 ?gender1 . }
   BIND( IF(?gender1 = wd:Q6581097, "3182BD", "E6550D") AS ?rgb)
   SERVICE wikibase:label {
-    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" .
+    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" .
   }
 }

--- a/scholia/app/templates/topic_context.sparql
+++ b/scholia/app/templates/topic_context.sparql
@@ -51,5 +51,5 @@ WHERE {
     ?childNode ?childNodeclaim ?childNodeImage. 
   }
   
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }        
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }        
 }

--- a/scholia/app/templates/topic_country-citation-graph.sparql
+++ b/scholia/app/templates/topic_country-citation-graph.sparql
@@ -30,5 +30,5 @@ WHERE {
   INCLUDE %results
   ?cited_country wdt:P41 ?cited_flag . 
   ?citing_country wdt:P41 ?citing_flag . 
- SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }        
+ SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }        
  }

--- a/scholia/app/templates/topic_earliest-published-works.sparql
+++ b/scholia/app/templates/topic_earliest-published-works.sparql
@@ -26,7 +26,7 @@ WHERE {
   # BIND(xsd:date(?datetime) AS ?date)
   BIND(REPLACE(STR(?datetime), 'T.*', '') AS ?date)
     
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 GROUP BY ?date ?work ?workLabel ?topicsUrl ?topics
 ORDER BY ASC(?date)

--- a/scholia/app/templates/topic_earliest-published-works.sparql
+++ b/scholia/app/templates/topic_earliest-published-works.sparql
@@ -26,7 +26,7 @@ WHERE {
   # BIND(xsd:date(?datetime) AS ?date)
   BIND(REPLACE(STR(?datetime), 'T.*', '') AS ?date)
     
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }
 GROUP BY ?date ?work ?workLabel ?topicsUrl ?topics
 ORDER BY ASC(?date)

--- a/scholia/app/templates/topic_most-cited-authors.sparql
+++ b/scholia/app/templates/topic_most-cited-authors.sparql
@@ -22,7 +22,7 @@ WITH {
 WHERE {
   # Label the results
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 } 
 ORDER BY DESC(?number_of_citations)
 LIMIT 200

--- a/scholia/app/templates/topic_organization-map.sparql
+++ b/scholia/app/templates/topic_organization-map.sparql
@@ -29,6 +29,6 @@ WITH {
 WHERE {
   INCLUDE %organizations
   BIND(IF( (?count < 1), "No results", IF((?count < 2), "1 result", IF((?count < 11), "1 < results ≤ 10", IF((?count < 101), "10 < results ≤ 100", IF((?count < 1001), "100 < results ≤ 1000", IF((?count < 10001), "1000 < results ≤ 10000", "10000 or more results") ) ) ) )) AS ?layer )
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }        
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }        
  }
 ORDER BY DESC (?count)

--- a/scholia/app/templates/topic_recently-published-works.sparql
+++ b/scholia/app/templates/topic_recently-published-works.sparql
@@ -25,7 +25,7 @@ WHERE {
   # BIND(xsd:date(?datetime) AS ?date)
   BIND(REPLACE(STR(?datetime), 'T.*', '') AS ?date)
     
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 GROUP BY ?date ?work ?workLabel ?topicsUrl ?topics
 ORDER BY DESC(?date)

--- a/scholia/app/templates/topic_recently-published-works.sparql
+++ b/scholia/app/templates/topic_recently-published-works.sparql
@@ -25,7 +25,7 @@ WHERE {
   # BIND(xsd:date(?datetime) AS ?date)
   BIND(REPLACE(STR(?datetime), 'T.*', '') AS ?date)
     
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }
 GROUP BY ?date ?work ?workLabel ?topicsUrl ?topics
 ORDER BY DESC(?date)

--- a/scholia/app/templates/topic_top-cited.sparql
+++ b/scholia/app/templates/topic_top-cited.sparql
@@ -15,7 +15,7 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . } 
 }
 ORDER BY DESC(?count)
 LIMIT 200

--- a/scholia/app/templates/topic_top-cited.sparql
+++ b/scholia/app/templates/topic_top-cited.sparql
@@ -15,7 +15,7 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,ru,sv,zh" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
 }
 ORDER BY DESC(?count)
 LIMIT 200

--- a/scholia/app/templates/topic_topics.sparql
+++ b/scholia/app/templates/topic_topics.sparql
@@ -21,6 +21,6 @@ WITH {
 WHERE {
   # Label the results
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . } 
 }
 ORDER BY DESC(?count)

--- a/scholia/app/templates/topic_topics.sparql
+++ b/scholia/app/templates/topic_topics.sparql
@@ -21,6 +21,6 @@ WITH {
 WHERE {
   # Label the results
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,ru,sv,zh" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
 }
 ORDER BY DESC(?count)

--- a/scholia/app/templates/topic_uses.sparql
+++ b/scholia/app/templates/topic_uses.sparql
@@ -21,6 +21,6 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }
 ORDER BY DESC(?count)

--- a/scholia/app/templates/topic_venues.sparql
+++ b/scholia/app/templates/topic_venues.sparql
@@ -16,7 +16,7 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . } 
 }
 ORDER BY DESC(?count)
 LIMIT 200

--- a/scholia/app/templates/topic_venues.sparql
+++ b/scholia/app/templates/topic_venues.sparql
@@ -16,7 +16,7 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,ru,sv,zh" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
 }
 ORDER BY DESC(?count)
 LIMIT 200

--- a/scholia/app/templates/topics_authors.sparql
+++ b/scholia/app/templates/topics_authors.sparql
@@ -22,6 +22,6 @@ WITH {
 } AS %results
 WHERE {
   INCLUDE %results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?score)

--- a/scholia/app/templates/topics_list-of-topics.sparql
+++ b/scholia/app/templates/topics_list-of-topics.sparql
@@ -13,5 +13,5 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }

--- a/scholia/app/templates/topics_list-of-works.sparql
+++ b/scholia/app/templates/topics_list-of-works.sparql
@@ -28,7 +28,7 @@ WHERE {
     ?work wdt:P577 ?publication_datetime .
     BIND(xsd:date(?publication_datetime) AS ?publication_date_)
   }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 GROUP BY ?count ?work ?workLabel ?topics ?topicsUrl
 ORDER BY DESC(?count) DESC(?publication_date)

--- a/scholia/app/templates/use-curation_missing-author-items.sparql
+++ b/scholia/app/templates/use-curation_missing-author-items.sparql
@@ -60,7 +60,7 @@ WHERE {
   INCLUDE %scores
 
   # Label the result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?score) DESC(?count) 
 LIMIT 500

--- a/scholia/app/templates/use-curation_missing-co-uses.sparql
+++ b/scholia/app/templates/use-curation_missing-co-uses.sparql
@@ -29,6 +29,6 @@ WHERE {
   # Label results
   INCLUDE %result
   SERVICE wikibase:label {
-    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
+    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . } 
 }
 ORDER BY ?couses DESC(?citing_works)

--- a/scholia/app/templates/use-curation_works-with-few-topics.sparql
+++ b/scholia/app/templates/use-curation_works-with-few-topics.sparql
@@ -28,6 +28,6 @@ WHERE {
   # Label results
   INCLUDE %result
   SERVICE wikibase:label {
-    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
+    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . } 
 }
 ORDER BY ?number_of_topics DESC(?citing_works)

--- a/scholia/app/templates/use-index_most-used.sparql
+++ b/scholia/app/templates/use-index_most-used.sparql
@@ -17,7 +17,7 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?count)
 LIMIT 500

--- a/scholia/app/templates/use_authors-of-works-using-the-resource.sparql
+++ b/scholia/app/templates/use_authors-of-works-using-the-resource.sparql
@@ -19,6 +19,6 @@ WITH{
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?count)

--- a/scholia/app/templates/use_authors-of-works-using-the-resource.sparql
+++ b/scholia/app/templates/use_authors-of-works-using-the-resource.sparql
@@ -19,6 +19,6 @@ WITH{
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,nl,no,ru,sv,zh" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }
 ORDER BY DESC(?count)

--- a/scholia/app/templates/use_co-used.sparql
+++ b/scholia/app/templates/use_co-used.sparql
@@ -26,6 +26,6 @@ WITH {
 WHERE {
   # Label the result
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?count) 

--- a/scholia/app/templates/use_recent-work-using-the-used.sparql
+++ b/scholia/app/templates/use_recent-work-using-the-used.sparql
@@ -17,6 +17,6 @@ WITH{
 WHERE {
   INCLUDE %result
   BIND(xsd:date(?publication_datetime) AS ?publication_date)
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" }
 }
 ORDER BY DESC(?publication_date)

--- a/scholia/app/templates/use_topics-of-works-using-the-resource.sparql
+++ b/scholia/app/templates/use_topics-of-works-using-the-resource.sparql
@@ -19,7 +19,7 @@ WITH{
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,nl,no,ru,sv,zh" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }
 ORDER BY DESC(?count)
 

--- a/scholia/app/templates/use_topics-of-works-using-the-resource.sparql
+++ b/scholia/app/templates/use_topics-of-works-using-the-resource.sparql
@@ -19,7 +19,7 @@ WITH{
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?count)
 

--- a/scholia/app/templates/use_usage-over-time.sparql
+++ b/scholia/app/templates/use_usage-over-time.sparql
@@ -19,7 +19,7 @@ WITH{
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 GROUP BY ?year ?useLabel
 ORDER BY ?year

--- a/scholia/app/templates/use_usage-over-time.sparql
+++ b/scholia/app/templates/use_usage-over-time.sparql
@@ -19,7 +19,7 @@ WITH{
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,nl,no,ru,sv,zh" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }
 GROUP BY ?year ?useLabel
 ORDER BY ?year

--- a/scholia/app/templates/uses_authors.sparql
+++ b/scholia/app/templates/uses_authors.sparql
@@ -20,6 +20,6 @@ WITH {
 } AS %results
 WHERE {
   INCLUDE %results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?uses) DESC(?works)

--- a/scholia/app/templates/uses_list-of-uses.sparql
+++ b/scholia/app/templates/uses_list-of-uses.sparql
@@ -13,5 +13,5 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }

--- a/scholia/app/templates/uses_list-of-works.sparql
+++ b/scholia/app/templates/uses_list-of-works.sparql
@@ -28,7 +28,7 @@ WHERE {
     ?work wdt:P577 ?publication_datetime .
     BIND(xsd:date(?publication_datetime) AS ?publication_date_)
   }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 GROUP BY ?count ?work ?workLabel ?uses ?usesUrl
 ORDER BY DESC(?count) DESC(?publication_date)

--- a/scholia/app/templates/venue-curation_missing-topics.sparql
+++ b/scholia/app/templates/venue-curation_missing-topics.sparql
@@ -25,6 +25,6 @@ WHERE {
   INCLUDE %result
   FILTER (?topics < 2)
   SERVICE wikibase:label {
-    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
+    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . } 
 }
 ORDER BY DESC(?count) ?topics

--- a/scholia/app/templates/venue-use_authors.sparql
+++ b/scholia/app/templates/venue-use_authors.sparql
@@ -25,6 +25,6 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en,da,de,es,fr,it,sv,uk,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en,da,de,es,fr,it,sv,uk,zh". }
 }
 ORDER BY DESC(?number_of_works)

--- a/scholia/app/templates/venue-use_works.sparql
+++ b/scholia/app/templates/venue-use_works.sparql
@@ -11,6 +11,6 @@ WHERE {
     ?work wdt:P577 ?publication_datetime .
     BIND(xsd:date(?publication_datetime) AS ?publication_date)
   }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en,da,de,es,fr,jp,nl,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en,da,de,es,fr,jp,nl,no,ru,sv,zh". }
 }
 ORDER BY DESC(?publication_date)

--- a/scholia/app/templates/venue_articles-citing-retracted-articles.sparql
+++ b/scholia/app/templates/venue_articles-citing-retracted-articles.sparql
@@ -32,6 +32,6 @@ WHERE {
     ?retracted_work p:P793 [ ps:P793 wd:Q45203135 ; pq:P585 ?keyevent_datetime ]
   }
   BIND(COALESCE(xsd:date(COALESCE(?retraction_datetime, ?keyevent_datetime)), "Unknown date") AS ?date)
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }
 ORDER BY DESC(?date)

--- a/scholia/app/templates/venue_author-awards.sparql
+++ b/scholia/app/templates/venue_author-awards.sparql
@@ -16,7 +16,7 @@ WHERE {
     { ?award_statement pq:P580 ?time }
     BIND(YEAR(?time) AS ?year)
   }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }  
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }  
 }
 ORDER BY DESC(?year)
 LIMIT 500

--- a/scholia/app/templates/venue_author-gender-distribution.sparql
+++ b/scholia/app/templates/venue_author-gender-distribution.sparql
@@ -12,6 +12,6 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . } 
 } 
  ORDER BY DESC(?count)

--- a/scholia/app/templates/venue_author-images.sparql
+++ b/scholia/app/templates/venue_author-images.sparql
@@ -14,7 +14,7 @@ WITH {
 WHERE {
   INCLUDE %authors
   ?author wdt:P18 ?image_ .
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl.no,ru,sv,zh" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
 }
 GROUP BY ?author ?authorLabel ?count
 ORDER BY DESC(?count)

--- a/scholia/app/templates/venue_author-images.sparql
+++ b/scholia/app/templates/venue_author-images.sparql
@@ -14,7 +14,7 @@ WITH {
 WHERE {
   INCLUDE %authors
   ?author wdt:P18 ?image_ .
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . } 
 }
 GROUP BY ?author ?authorLabel ?count
 ORDER BY DESC(?count)

--- a/scholia/app/templates/venue_authors.sparql
+++ b/scholia/app/templates/venue_authors.sparql
@@ -22,7 +22,7 @@ WHERE {
   OPTIONAL { ?author wdt:P496 ?orcid . }
   
   # Label the results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . } 
 }
 ORDER BY DESC(?count)
 LIMIT 50

--- a/scholia/app/templates/venue_authorship-gender-distribution.sparql
+++ b/scholia/app/templates/venue_authorship-gender-distribution.sparql
@@ -13,6 +13,6 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . } 
 } 
  ORDER BY DESC(?count)

--- a/scholia/app/templates/venue_cited-venues.sparql
+++ b/scholia/app/templates/venue_cited-venues.sparql
@@ -25,7 +25,7 @@ WITH {
 WHERE {
   INCLUDE %result
   SERVICE wikibase:label {
-    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
+    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . } 
 }
 ORDER BY DESC(?count)
 LIMIT 200

--- a/scholia/app/templates/venue_citing-venues.sparql
+++ b/scholia/app/templates/venue_citing-venues.sparql
@@ -25,6 +25,6 @@ WITH {
 WHERE {
   INCLUDE %result
   SERVICE wikibase:label {
-    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
+    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . } 
 }
 ORDER BY DESC(?count)

--- a/scholia/app/templates/venue_co-author-graph.sparql
+++ b/scholia/app/templates/venue_co-author-graph.sparql
@@ -38,6 +38,6 @@ WHERE {
   OPTIONAL { ?author1 wdt:P21 ?gender1 . }
   BIND( IF(?gender1 = wd:Q6581097, "3182BD", "E6550D") AS ?rgb)
   SERVICE wikibase:label {
-    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" .
+    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" .
   }
 }

--- a/scholia/app/templates/venue_co-author-graph.sparql
+++ b/scholia/app/templates/venue_co-author-graph.sparql
@@ -38,6 +38,6 @@ WHERE {
   OPTIONAL { ?author1 wdt:P21 ?gender1 . }
   BIND( IF(?gender1 = wd:Q6581097, "3182BD", "E6550D") AS ?rgb)
   SERVICE wikibase:label {
-    bd:serviceParam wikibase:language "en,fr,de,ru,es,zh,jp".
+    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" .
   }
 }

--- a/scholia/app/templates/venue_incoming-bubble.sparql
+++ b/scholia/app/templates/venue_incoming-bubble.sparql
@@ -9,6 +9,6 @@ SELECT ?intention ?intentionLabel (COUNT(DISTINCT ?citingArticle) AS ?count) WHE
   ?citedArticle wdt:P1433 target: .
   ?intention wdt:P31 wd:Q96471816 ;
              wdt:P2888 ?cito .
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 } GROUP BY ?cito ?intention ?intentionLabel
   ORDER BY DESC(?count)

--- a/scholia/app/templates/venue_incoming.sparql
+++ b/scholia/app/templates/venue_incoming.sparql
@@ -9,6 +9,6 @@ SELECT ?intention ?intentionLabel (CONCAT("/cito/", SUBSTR(STR(?intention), 32))
   ?citedArticle wdt:P1433 ?JOURNAL .
   ?intention wdt:P31 wd:Q96471816 ;
              wdt:P2888 ?cito .
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 } GROUP BY ?cito ?intention ?intentionLabel
   ORDER BY DESC(?count)

--- a/scholia/app/templates/venue_most-cited-articles.sparql
+++ b/scholia/app/templates/venue_most-cited-articles.sparql
@@ -25,6 +25,6 @@ WHERE {
   # Label results
   INCLUDE %result
   SERVICE wikibase:label {
-    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
+    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . } 
 }
 ORDER BY DESC(?count)

--- a/scholia/app/templates/venue_most-cited-authors.sparql
+++ b/scholia/app/templates/venue_most-cited-authors.sparql
@@ -29,7 +29,7 @@ WHERE {
   OPTIONAL { ?author wdt:P496 ?orcid . }
   
   # Label the results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . } 
 }
 ORDER BY DESC(?count)
 LIMIT 100

--- a/scholia/app/templates/venue_most-reused-articles.sparql
+++ b/scholia/app/templates/venue_most-reused-articles.sparql
@@ -8,6 +8,6 @@ SELECT ?citedArticle ?citedArticleLabel (CONCAT("/work/", SUBSTR(STR(?citedArtic
   ?citationStatement pq:P3712 ?INTENTION ;
                      ps:P2860 ?citedArticle .
   ?citedArticle wdt:P1433 ?JOURNAL .
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 } GROUP BY ?citedArticle ?citedArticleLabel
   ORDER BY DESC(?count)

--- a/scholia/app/templates/venue_outgoing-bubble.sparql
+++ b/scholia/app/templates/venue_outgoing-bubble.sparql
@@ -9,6 +9,6 @@ SELECT ?cito ?intentionLabel (COUNT(DISTINCT ?citingArticle) AS ?count) WHERE {
                      ps:P2860 ?citedArticle .
   ?intention wdt:P31 wd:Q96471816 ;
              wdt:P2888 ?cito .
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 } GROUP BY ?cito ?intention ?intentionLabel
   ORDER BY DESC(?count)

--- a/scholia/app/templates/venue_outgoing.sparql
+++ b/scholia/app/templates/venue_outgoing.sparql
@@ -9,6 +9,6 @@ SELECT ?intention ?intentionLabel (CONCAT("/cito/", SUBSTR(STR(?intention), 32))
                      ps:P2860 ?citedArticle .
   ?intention wdt:P31 wd:Q96471816 ;
              wdt:P2888 ?cito .
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 } GROUP BY ?cito ?intention ?intentionLabel
   ORDER BY DESC(?count)

--- a/scholia/app/templates/venue_recently-published-works.sparql
+++ b/scholia/app/templates/venue_recently-published-works.sparql
@@ -24,6 +24,6 @@ WITH {
     ?author rdfs:label ?author_label .
     FILTER (LANG(?author_label) = 'en')
   }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 } GROUP BY ?publication_date ?work ?workLabel
 ORDER BY DESC(?publication_date)

--- a/scholia/app/templates/venue_retractions.sparql
+++ b/scholia/app/templates/venue_retractions.sparql
@@ -8,7 +8,7 @@ SELECT DISTINCT ?work ?workLabel ?doi (COUNT(DISTINCT ?citing) AS ?citations) WH
   { ?work wdt:P5824 [] . }
   OPTIONAL { ?citing wdt:P2860 ?work . }
   ?work wdt:P1433 target: ; wdt:P356 ?doi .
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 } GROUP BY ?work ?workLabel ?doi
   ORDER BY DESC(?citations)
   LIMIT 100

--- a/scholia/app/templates/venue_top-topics-through-time.sparql
+++ b/scholia/app/templates/venue_top-topics-through-time.sparql
@@ -41,6 +41,6 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }
 ORDER BY ?year

--- a/scholia/app/templates/venue_topics.sparql
+++ b/scholia/app/templates/venue_topics.sparql
@@ -16,6 +16,6 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . } 
 }
 ORDER BY DESC(?count)

--- a/scholia/app/templates/venue_uses.sparql
+++ b/scholia/app/templates/venue_uses.sparql
@@ -21,6 +21,6 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }
 ORDER BY DESC(?count)

--- a/scholia/app/templates/venues_citations-per-year.sparql
+++ b/scholia/app/templates/venues_citations-per-year.sparql
@@ -13,6 +13,6 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }
 ORDER BY ?year

--- a/scholia/app/templates/venues_citations-per-year.sparql
+++ b/scholia/app/templates/venues_citations-per-year.sparql
@@ -13,6 +13,6 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY ?year

--- a/scholia/app/templates/venues_citations-to-work-ratio.sparql
+++ b/scholia/app/templates/venues_citations-to-work-ratio.sparql
@@ -29,6 +29,6 @@ WITH {
 WHERE {
   INCLUDE %work_counts
   INCLUDE %citation_counts
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,es,fr,nl,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }
 ORDER BY ?year

--- a/scholia/app/templates/venues_citations-to-work-ratio.sparql
+++ b/scholia/app/templates/venues_citations-to-work-ratio.sparql
@@ -29,6 +29,6 @@ WITH {
 WHERE {
   INCLUDE %work_counts
   INCLUDE %citation_counts
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY ?year

--- a/scholia/app/templates/venues_list-of-venues.sparql
+++ b/scholia/app/templates/venues_list-of-venues.sparql
@@ -13,6 +13,6 @@ WITH {
 WHERE {
   INCLUDE %result
   OPTIONAL { ?venue wdt:P123 ?publisher }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY ?venueLabel

--- a/scholia/app/templates/venues_published-works-per-year.sparql
+++ b/scholia/app/templates/venues_published-works-per-year.sparql
@@ -4,7 +4,7 @@ SELECT ?year (COUNT(?work) AS ?count) ?venue ?venueLabel WHERE {
   ?work wdt:P1433 ?venue .
   ?work wdt:P577 ?publication_datetime . 
   BIND(STR(YEAR(?publication_datetime)) AS ?year)
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 GROUP BY ?year ?venue ?venueLabel
 ORDER BY ?year

--- a/scholia/app/templates/venues_published-works-per-year.sparql
+++ b/scholia/app/templates/venues_published-works-per-year.sparql
@@ -4,7 +4,7 @@ SELECT ?year (COUNT(?work) AS ?count) ?venue ?venueLabel WHERE {
   ?work wdt:P1433 ?venue .
   ?work wdt:P577 ?publication_datetime . 
   BIND(STR(YEAR(?publication_datetime)) AS ?year)
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 }
 GROUP BY ?year ?venue ?venueLabel
 ORDER BY ?year

--- a/scholia/app/templates/wikiproject-index_most-used.sparql
+++ b/scholia/app/templates/wikiproject-index_most-used.sparql
@@ -17,7 +17,7 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }
 ORDER BY DESC(?count)
 LIMIT 1000

--- a/scholia/app/templates/wikiproject_authors.sparql
+++ b/scholia/app/templates/wikiproject_authors.sparql
@@ -25,6 +25,6 @@ WHERE {
           
   # Include optional ORCID iD
   OPTIONAL { ?author wdt:P496 ?orcid_ . }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . } 
 }
 ORDER BY DESC(?count)

--- a/scholia/app/templates/wikiproject_co-occurring-wikiprojects.sparql
+++ b/scholia/app/templates/wikiproject_co-occurring-wikiprojects.sparql
@@ -22,6 +22,6 @@ WITH {
 WHERE {
   # Label the results
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?count)

--- a/scholia/app/templates/wikiproject_context.sparql
+++ b/scholia/app/templates/wikiproject_context.sparql
@@ -50,5 +50,5 @@ WHERE {
     ?childNode ?childNodeclaim ?childNodeImage. 
   }
   
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }        
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }        
 }

--- a/scholia/app/templates/wikiproject_earliest-published-works.sparql
+++ b/scholia/app/templates/wikiproject_earliest-published-works.sparql
@@ -28,7 +28,7 @@ WHERE {
   # BIND(xsd:date(?datetime) AS ?date)
   BIND(REPLACE(STR(?datetime), 'T.*', '') AS ?date)
     
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 GROUP BY ?date ?work ?workLabel ?topicsUrl ?topics
 ORDER BY ASC(?date)

--- a/scholia/app/templates/wikiproject_focus.sparql
+++ b/scholia/app/templates/wikiproject_focus.sparql
@@ -8,6 +8,6 @@ SELECT ?type ?typeLabel ?count WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en,da,de,es,fr,it,sv,uk,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en,da,de,es,fr,it,sv,uk,zh". }
 }
 ORDER BY DESC (?count)

--- a/scholia/app/templates/wikiproject_maintained.sparql
+++ b/scholia/app/templates/wikiproject_maintained.sparql
@@ -8,6 +8,6 @@ SELECT ?type ?typeLabel ?count WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en,da,de,es,fr,it,sv,uk,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en,da,de,es,fr,it,sv,uk,zh". }
 }
 ORDER BY DESC (?count)

--- a/scholia/app/templates/wikiproject_organization-map.sparql
+++ b/scholia/app/templates/wikiproject_organization-map.sparql
@@ -32,6 +32,6 @@ WITH {
 WHERE {
   INCLUDE %organizations
   BIND(IF( (?count < 1), "No results", IF((?count < 2), "1 result", IF((?count < 11), "1 < results ≤ 10", IF((?count < 101), "10 < results ≤ 100", IF((?count < 1001), "100 < results ≤ 1000", IF((?count < 10001), "1000 < results ≤ 10000", "10000 or more results") ) ) ) )) AS ?layer )
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }        
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }        
  }
 ORDER BY DESC (?count)

--- a/scholia/app/templates/wikiproject_recently-published-works.sparql
+++ b/scholia/app/templates/wikiproject_recently-published-works.sparql
@@ -27,7 +27,7 @@ WHERE {
   # BIND(xsd:date(?datetime) AS ?date)
   BIND(REPLACE(STR(?datetime), 'T.*', '') AS ?date)
     
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }
 GROUP BY ?date ?work ?workLabel ?topicsUrl ?topics
 ORDER BY DESC(?date)

--- a/scholia/app/templates/wikiproject_topics.sparql
+++ b/scholia/app/templates/wikiproject_topics.sparql
@@ -22,6 +22,6 @@ WITH {
 WHERE {
   # Label the results
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . } 
 }
 ORDER BY DESC(?count)

--- a/scholia/app/templates/wikiproject_venues.sparql
+++ b/scholia/app/templates/wikiproject_venues.sparql
@@ -15,7 +15,7 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . } 
 }
 ORDER BY DESC(?count)
 LIMIT 200

--- a/scholia/app/templates/work-cito-intention_incoming.sparql
+++ b/scholia/app/templates/work-cito-intention_incoming.sparql
@@ -5,5 +5,5 @@ SELECT ?citingArticle ?citingArticleLabel
   ?citingArticle p:P2860 ?citationStatement .
   ?citationStatement pq:P3712 ?intention ;
                      ps:P2860 ?CITEDARTICLE .
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }

--- a/scholia/app/templates/work-curation_missing-orcid.sparql
+++ b/scholia/app/templates/work-curation_missing-orcid.sparql
@@ -10,5 +10,5 @@ SELECT DISTINCT
 WHERE {
   target: wdt:P50 ?author .
   FILTER NOT EXISTS { ?author wdt:P496 ?orcid . }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }

--- a/scholia/app/templates/work-index_recently-retracted-works.sparql
+++ b/scholia/app/templates/work-index_recently-retracted-works.sparql
@@ -23,6 +23,6 @@ WHERE {
     ?retracted_work p:P793 [ ps:P793 wd:Q45203135 ; pq:P585 ?keyevent_datetime ]
   }
   BIND(COALESCE(xsd:date(COALESCE(?retraction_datetime, ?keyevent_datetime)), "Unknown date") AS ?date)
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }
 ORDER BY DESC(?date)

--- a/scholia/app/templates/work_citations.sparql
+++ b/scholia/app/templates/work_citations.sparql
@@ -27,6 +27,6 @@ WITH {
 WHERE {
   # Label the result
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,it,jp,nl,no,ru,sv,zh" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
 } 
 ORDER BY DESC(?citations) DESC(?publication_date) 

--- a/scholia/app/templates/work_citations.sparql
+++ b/scholia/app/templates/work_citations.sparql
@@ -27,6 +27,6 @@ WITH {
 WHERE {
   # Label the result
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . } 
 } 
 ORDER BY DESC(?citations) DESC(?publication_date) 

--- a/scholia/app/templates/work_cited-work-authors.sparql
+++ b/scholia/app/templates/work_cited-work-authors.sparql
@@ -29,6 +29,6 @@ WITH {
 WHERE {
   # Label the result
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
 ORDER BY DESC(?cited_works)

--- a/scholia/app/templates/work_cited-works.sparql
+++ b/scholia/app/templates/work_cited-works.sparql
@@ -18,6 +18,6 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,it,jp,nl,no,ru,sv,zh" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
 } 
 ORDER BY DESC(?citations) DESC(?date)

--- a/scholia/app/templates/work_cited-works.sparql
+++ b/scholia/app/templates/work_cited-works.sparql
@@ -18,6 +18,6 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . } 
 } 
 ORDER BY DESC(?citations) DESC(?date)

--- a/scholia/app/templates/work_cito-incoming-chart.sparql
+++ b/scholia/app/templates/work_cito-incoming-chart.sparql
@@ -8,6 +8,6 @@ SELECT ?intention ?intentionLabel (COUNT(DISTINCT ?citingArticle) AS ?count) WHE
   ?citationStatement pq:P3712 ?intention ;
                      ps:P2860 ?CITEDARTICLE .
   ?intention wdt:P31 wd:Q96471816 .
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 } GROUP BY ?intention ?intentionLabel
   ORDER BY DESC(?count)

--- a/scholia/app/templates/work_cito-incoming.sparql
+++ b/scholia/app/templates/work_cito-incoming.sparql
@@ -16,7 +16,7 @@ WITH {
 } AS %intentions
 WHERE {
   INCLUDE %intentions
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }
 GROUP BY ?intention ?intentionLabel ?count ?example_work_for_intention ?example_work_for_intentionLabel
 ORDER BY DESC(?count)

--- a/scholia/app/templates/work_related-works.sparql
+++ b/scholia/app/templates/work_related-works.sparql
@@ -15,6 +15,6 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,it,jp,nl,no,ru,sv,zh" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
 } 
 ORDER BY DESC(?count) 

--- a/scholia/app/templates/work_related-works.sparql
+++ b/scholia/app/templates/work_related-works.sparql
@@ -15,6 +15,6 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . } 
 } 
 ORDER BY DESC(?count) 

--- a/scholia/app/templates/work_statements.sparql
+++ b/scholia/app/templates/work_statements.sparql
@@ -27,6 +27,6 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,it,jp,nl,no,ru,sv,zh" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
 } 
 ORDER BY DESC(?itemLabel)

--- a/scholia/app/templates/work_statements.sparql
+++ b/scholia/app/templates/work_statements.sparql
@@ -27,6 +27,6 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . } 
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . } 
 } 
 ORDER BY DESC(?itemLabel)

--- a/scholia/app/templates/work_topic-scores.sparql
+++ b/scholia/app/templates/work_topic-scores.sparql
@@ -35,7 +35,7 @@ WITH {
 } AS %results 
 WHERE {
   INCLUDE %results
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en,da,de,es,jp,no,ru,sv,zh". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en,da,de,es,jp,no,ru,sv,zh". }
 }
 ORDER BY DESC(?score)
 LIMIT 200

--- a/scholia/app/templates/work_wikipedia-mentions.sparql
+++ b/scholia/app/templates/work_wikipedia-mentions.sparql
@@ -84,5 +84,5 @@ WHERE {
   }
   hint:Prior hint:runFirst "true" .
   BIND(CONCAT(?title_, "&nbsp;↗") AS ?title)
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 } 

--- a/scholia/app/templates/works_authors.sparql
+++ b/scholia/app/templates/works_authors.sparql
@@ -18,6 +18,6 @@ WITH {
 WHERE {
   INCLUDE %results
   SERVICE wikibase:label {
-    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
   }
 ORDER BY DESC(?count)

--- a/scholia/app/templates/works_citing-works.sparql
+++ b/scholia/app/templates/works_citing-works.sparql
@@ -21,7 +21,7 @@ WHERE {
     BIND(xsd:date(?datetimes) AS ?dates)
   }
   SERVICE wikibase:label {
-    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
   }
 GROUP BY ?count ?citing_work ?citing_workLabel
 ORDER BY DESC(?count) DESC(?date)

--- a/scholia/app/templates/works_list-of-works.sparql
+++ b/scholia/app/templates/works_list-of-works.sparql
@@ -9,5 +9,5 @@ WITH {
 WHERE {
   INCLUDE %result
   SERVICE wikibase:label {
-    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }

--- a/scholia/app/templates/works_topics.sparql
+++ b/scholia/app/templates/works_topics.sparql
@@ -17,6 +17,6 @@ WITH {
 WHERE {
   INCLUDE %results
   SERVICE wikibase:label {
-    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
   }
 ORDER BY DESC(?count)

--- a/scholia/app/templates/works_topics.sparql
+++ b/scholia/app/templates/works_topics.sparql
@@ -17,6 +17,6 @@ WITH {
 WHERE {
   INCLUDE %results
   SERVICE wikibase:label {
-    bd:serviceParam wikibase:language "en,da,de,es,fr,nl,no,ru,sv,zh". }
+    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
   }
 ORDER BY DESC(?count)


### PR DESCRIPTION
Fixes #1 

### Description
Uses `AUTO_LANGUAGE` more often in SPARQL queries allowing the WDQS to pick up the language used in the web browser.
    
### Caveats
It does not solve picking the language when `rdfs:label` is used in combination with `FILTER lang()`.

Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

### Testing
This patch touches on a lot of SPARQL queries, in the following aspects:

```
404-chemical
author
author-curation
author-index.html
authors
award
award-curation
chemical
chemical-class
chemical-element
clinical-trial
clinical-trial-index
complex
countries
country
country-topic
dataset
disease
event
event-series
location
location-topic
organization
organizations
project
property
publisher
series
software
sponsor
topic
use
venue
venues
work
works
```

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
