### PR TITLE
Added support for 'replies to' in the data table

### DIFF
--- a/scholia/app/templates/work_data.sparql
+++ b/scholia/app/templates/work_data.sparql
@@ -302,5 +302,16 @@ WHERE {
     BIND(COALESCE(?value_string, ?valueqid) AS ?value)
     BIND(CONCAT("../", ?valueqid) AS ?valueUrl)
   }
+  UNION
+  {
+    BIND(36 AS ?order)
+    BIND("Inspired by" AS ?description)
+    ?work wdt:P941 ?value_ .
+    BIND(SUBSTR(STR(?value_), 32) AS ?valueqid)
+    ?value_ rdfs:label ?value_string .
+    FILTER (LANG(?value_string) = 'en')
+    BIND(COALESCE(?value_string, ?valueqid) AS ?value)
+    BIND(CONCAT("../", ?valueqid) AS ?valueUrl)
+  }
 } 
 ORDER BY ?order

--- a/scholia/app/templates/work_data.sparql
+++ b/scholia/app/templates/work_data.sparql
@@ -291,5 +291,16 @@ WHERE {
     BIND(COALESCE(?value_string, ?pubqid) AS ?value)
     BIND(CONCAT("../work/", ?pubqid) AS ?valueUrl)}
   }
+  UNION
+  {
+    BIND(35 AS ?order)
+    BIND("Replies to" AS ?description)
+    ?work wdt:P2675 ?value_ .
+    BIND(SUBSTR(STR(?value_), 32) AS ?valueqid)
+    ?value_ rdfs:label ?value_string .
+    FILTER (LANG(?value_string) = 'en')
+    BIND(COALESCE(?value_string, ?valueqid) AS ?value)
+    BIND(CONCAT("../", ?valueqid) AS ?valueUrl)
+  }
 } 
 ORDER BY ?order


### PR DESCRIPTION
Fixes #249
Fixes #491 

### Description
There is a `replies to` property and the linked issue requests adding that info. I added it to the data table.
    
### Caveats
None that I can think of (right now).

Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

### Testing

* http://127.0.0.1:8100/work/Q28951838
* http://127.0.0.1:8100/work/Q56377493

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [ ] My changes generate no new warnings
* [ ] I have not used code from external sources without attribution
* [ ] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [ ] There are no remaining debug statements (print, console.log, ...)

# Screenshots

![image](https://github.com/WDscholia/scholia/assets/26721/9133501c-7a56-44bd-8c71-ec05f6a7c092)

![image](https://github.com/WDscholia/scholia/assets/26721/4923a302-5d25-4144-90df-c0e1eac28624)
