### PR TITLE
Removed duplicates from the statements this article supports

### DIFF
--- a/scholia/app/templates/work_statements.sparql
+++ b/scholia/app/templates/work_statements.sparql
@@ -3,7 +3,7 @@
 
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
-SELECT ?item ?itemLabel ?property ?propertyLabel ?statement ?a ?value ?valueLabel ?unit ?unitLabel
+SELECT ?item ?itemLabel ?property ?propertyLabel ?value ?valueLabel ?unit ?unitLabel
 WITH {
   SELECT ?statement WHERE { 
 	  ?statement prov:wasDerivedFrom/pr:P248 target: .
@@ -11,7 +11,7 @@ WITH {
   LIMIT 2000
 } AS %statements 
 WITH {
-  SELECT distinct ?item ?property ?statement ?a ?value ?unit
+  SELECT distinct ?item ?property ?value ?unit
   WHERE {
     INCLUDE %statements
     ?item ?p ?statement .

--- a/scholia/app/templates/work_statements.sparql
+++ b/scholia/app/templates/work_statements.sparql
@@ -1,9 +1,9 @@
+#title: Statements referencing the {{ q }} article
 #defaultView:Table
 
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
-# Statements referencing this article
-SELECT ?item ?itemLabel ?property ?propertyLabel ?value ?valueLabel ?unit ?unitLabel
+SELECT ?item ?itemLabel ?property ?propertyLabel ?statement ?a ?value ?valueLabel ?unit ?unitLabel
 WITH {
   SELECT ?statement WHERE { 
 	  ?statement prov:wasDerivedFrom/pr:P248 target: .
@@ -11,14 +11,15 @@ WITH {
   LIMIT 2000
 } AS %statements 
 WITH {
-  SELECT distinct ?item ?property ?value ?unit
+  SELECT distinct ?item ?property ?statement ?a ?value ?unit
   WHERE {
     INCLUDE %statements
     ?item ?p ?statement .
-    ?property wikibase:claim ?p . 
-    ?statement ?a ?value .
-    FILTER (!STRSTARTS(LCASE(STR(?a)), "http://www.wikidata.org/prop/qualifier/"))
-    ?item ?b ?value . 
+    ?property wikibase:claim ?p . OPTIONAL { ?property wikibase:statementValueNormalized ?a1 }
+    ?statement ?a1 ?value1 ; ?a2 ?value2 . BIND (COALESCE(?value1, ?value2) AS ?value) BIND (COALESCE(?a1, ?a2) AS ?a)
+    FILTER (!STRSTARTS(LCASE(STR(?value)), "http://wikiba.se/ontology#"))
+    FILTER (!STRSTARTS(LCASE(STR(?value)), "http://www.wikidata.org/value/"))
+    FILTER (!STRSTARTS(LCASE(STR(?value)), "http://www.wikidata.org/reference/"))
     OPTIONAL {?statement ?psv_statement_predicate ?psv_statement .
     ?statement_predicate_property wikibase:statementValue ?psv_statement_predicate.
     ?psv_statement wikibase:quantityUnit ?unit}


### PR DESCRIPTION
Fixes #738

### Description
As shown in #738, there are duplicates when statement values are normalized (e.g. see the ORCID). Removing the duplicates is a bit tricky, but quite doable and implemented in this patch.
    
### Caveats
It seem to work well. I haven't done an exhaustive testing, and maybe more things need filtering out, like qualifiers.

Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

### Testing
* http://127.0.0.1:8100/work/Q30512726

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [ ] My changes generate no new warnings
* [ ] I have not used code from external sources without attribution
* [ ] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [ ] There are no remaining debug statements (print, console.log, ...)
