### PR TITLE
Fix #2317 empty pages CEUR-WS scraper

### DIFF
--- a/scholia/scrape/ceurws.py
+++ b/scholia/scrape/ceurws.py
@@ -151,7 +151,9 @@ def tree_to_papers(tree, proceedings, proceedings_q, iso639='en'):
 
         # Pages
         pages_element = element.xpath(".//span[@class='CEURPAGES']")
-        if len(pages_element) == 1:
+        if len(pages_element) == 1 and pages_element[0].text:
+            # At least one CEURPAGES element and the first one should be
+            # none-empty
             pages = pages_element[0].text
             paper['pages'] = pages
             number_of_pages = pages_to_number_of_pages(pages)


### PR DESCRIPTION
CEUR-WS scraper failed where metadata had a element for pages but this was empty.

Fixes #2317

### Description
Test on empty string for empty pages in pages element in scraped page for CEUR-WS
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* `python -m scholia.scrape.ceurws proceedings-url-to-quickstatements https://ceur-ws.org/Vol-3443/`

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
