### PR TITLE
Also depict (CX)SMILES for chemical classes

### DIFF
--- a/scholia/app/templates/chemical-class.html
+++ b/scholia/app/templates/chemical-class.html
@@ -16,7 +16,19 @@
 {% block page_content %}
 <h1 id="h1">Chemical</h1>
 
-<div id="intro"></div>
+<div class="card-deck mb-3">
+    <div class="card mb-4 box-shadow">
+	<div class="card-body">
+	    <div id="intro"></div>
+	</div>
+    </div>
+
+    <div class="card mb-4 box-shadow">
+	<div class="card-body">
+	    <img src="https://cdkdepict.toolforge.org/depict/bow/svg?smi={{smiles|urlencode}}&abbr=on&hdisp=bridgehead&showtitle=false&zoom=2&annotate=cip" />
+	</div>
+    </div>
+</div>
 
 <h2 id="class-hierarchy">Class Hierarchy</h2>
 

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -1896,7 +1896,13 @@ def show_chemical_class(q):
         Rendered HTML.
 
     """
-    return render_template('chemical-class.html', q=q)
+    entities = wb_get_entities([q])
+    smiles = entity_to_smiles(entities[q])
+    return render_template('chemical-class.html',
+      q=q,
+      smiles=smiles,
+        third_parties_enabled=current_app.third_parties_enabled
+    )
 
 
 @main.route('/chemical-class/')

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -1898,11 +1898,11 @@ def show_chemical_class(q):
     """
     entities = wb_get_entities([q])
     smiles = entity_to_smiles(entities[q])
-    return render_template('chemical-class.html',
-      q=q,
-      smiles=smiles,
-        third_parties_enabled=current_app.third_parties_enabled
-    )
+    return render_template(
+        'chemical-class.html',
+        q=q,
+        smiles=smiles,
+        third_parties_enabled=current_app.third_parties_enabled)
 
 
 @main.route('/chemical-class/')


### PR DESCRIPTION
Fixes that the 'chemical-class' aspect did not show SMILES, even tho SMILES and CXSMILES can be given and can be depicted.

### Description
Now also shows (CX)SMILES in the `chemical-class` aspect:

![image](https://github.com/WDscholia/scholia/assets/26721/936f6b3f-528e-4596-9d70-9f8bc20450d2)
    
### Caveats
Functionality that already existed for the `chemical` aspect and is just ported here.

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [x]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
* http://127.0.0.1:8100/chemical-class/Q120868227

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [ ] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
