### PR TITLE
Fix #2322 type comparison for q id

### DIFF
--- a/scholia/utils.py
+++ b/scholia/utils.py
@@ -55,7 +55,7 @@ def sanitize_q(q):
     'Q5'
 
     """
-    if type(q) == int:
+    if type(q) is int:
         if q > 0:
             return 'Q' + str(q)
     else:


### PR DESCRIPTION
Python 3.10 flake8 style would not accept the previous form.

Fixes #2322

### Description
One-line fix for style
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

python 3.7 and 3.8 did not pass. Python 3.7 probably an remote access issue, 3.8 because lack of Interpreter.

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* Test A
* Test B

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
