### PR TITLE
Exclude compounds that sublimate

### DIFF
--- a/scholia/app/templates/chemical-index-curation_missing-boiling-points.sparql
+++ b/scholia/app/templates/chemical-index-curation_missing-boiling-points.sparql
@@ -2,6 +2,7 @@ SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
   SELECT ?wikis ?compound WHERE {
     ?compound wdt:P31 wd:Q11173 ;
               wikibase:sitelinks ?wikis . hint:Prior hint:rangeSafe true .
+    MINUS { ?compound wdt:P2113 [] } # compounds sublimates
     FILTER(?wikis >= 40)
     FILTER(NOT EXISTS {?compound wdt:P2102 []})
   } ORDER BY DESC(?wikis)


### PR DESCRIPTION
... and likely don't have a boiling point defined.

Improves the physchem properties curation page which e.g. shows CO2 which does not have a boiling point:

![image](https://github.com/WDscholia/scholia/assets/26721/6b2a1353-fa68-46b4-b07b-6700650d43aa)


### Description
This patch adds a filter for compounds that have a sublimation point defined.
    
### Caveats

Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

### Testing
Visit https://scholia.toolforge.org/chemical/curation and confirm CO2 is no longer listed as missing a boiling point.

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [ ] My changes generate no new warnings
* [ ] I have not used code from external sources without attribution
* [ ] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [ ] There are no remaining debug statements (print, console.log, ...)
