### PR TITLE
Implement the new chemical entity structure

### DIFF
--- a/scholia/query.py
+++ b/scholia/query.py
@@ -1211,6 +1211,7 @@ def q_to_class(q):
             'Q79529',  # chemical substance
             'Q407595',  # metabolite
             'Q2393187',  # molecular entity
+            'Q113145171',  # type of a chemical entity
             ]):
         class_ = 'chemical'
     elif set(classes).intersection([
@@ -1218,9 +1219,9 @@ def q_to_class(q):
             ]):
         class_ = 'chemical_element'
     elif set(classes).intersection([
-            'Q15711994',  # family of isomeric compounds
+            'Q15711994',  # group of isomeric compounds
             'Q17339814',  # group or class of chemical substances
-            'Q47154513',  # structural class of chemical compounds
+            'Q47154513',  # structural class of chemical entities
             'Q55499636',  # pharmacological class of chemical compounds
             'Q55640599',  # group of ions
             'Q55662456',  # group of ortho, meta, para isomers
@@ -1312,6 +1313,8 @@ def q_to_class(q):
         elif set(parents).intersection([
                 'Q11173',  # chemical compound
                 'Q79529',  # chemical substance
+                'Q15711994',  # group of isomeric entities
+                'Q47154513',  # structural class of chemical entities
                 ]):
             class_ = 'chemical_class'
         elif set(parents).intersection([


### PR DESCRIPTION
See https://www.wikidata.org/wiki/Wikidata:WikiProject_Chemistry/Guidelines/Basic_metaclasses_and_relations#Basic_metaclasses_for_chemical_entities

This is urgent because the use of 'chemical compound' is being phased out, and most chemical compounds would map to the `/chemical-class/` aspect instead of the correct `/chemical/` aspect.

### Description
This patch updates the matching by Scholia to the correct chemical aspects. It also updates the label of two classes.
    
### Caveats
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [x]  This change requires a documentation update
    * [x]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [x]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
The following CLI call should give the following replies:

```shell
(scholia) ~/var/Projects/hub/scholia$ python -m scholia.query q-to-class Q899008
chemical
(scholia) ~/var/Projects/hub/scholia$ python -m scholia.query q-to-class Q425061
chemical_class
(scholia) ~/var/Projects/hub/scholia$ python -m scholia.query q-to-class Q411618
chemical_class
```

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
