### PR TITLE
expanded taxon_metabolome.sparql query to handle direct subclass of (P279) relationship

### DIFF
--- a/scholia/app/templates/taxon_metabolome.sparql
+++ b/scholia/app/templates/taxon_metabolome.sparql
@@ -11,10 +11,8 @@ WITH {
   SELECT DISTINCT ?metabolite WHERE {
     INCLUDE %taxa
             { ?metabolite wdt:P703 ?children }
-    UNION
-    { ?metabolite wdt:P1582 ?children }
-    VALUES ?chemical { wd:Q11173 wd:Q59199015 wd:Q56256086 wd:Q15711994 }.
-    ?metabolite wdt:P31|wdt:P279/wdt:P31|wdt:P279 ?chemical .
+    VALUES ?chemical { wd:Q113145171 wd:Q59199015 }
+    ?metabolite wdt:P31 ?chemical .
   }
 } AS %results {
   INCLUDE %results

--- a/scholia/app/templates/taxon_metabolome.sparql
+++ b/scholia/app/templates/taxon_metabolome.sparql
@@ -14,7 +14,7 @@ WITH {
     UNION
     { ?metabolite wdt:P1582 ?children }
     VALUES ?chemical { wd:Q11173 wd:Q59199015 wd:Q56256086 wd:Q15711994 }.
-    ?metabolite wdt:P31|wdt:P279/wdt:P31 ?chemical .
+    ?metabolite wdt:P31|wdt:P279/wdt:P31|wdt:P279 ?chemical .
   }
 } AS %results {
   INCLUDE %results


### PR DESCRIPTION
### Description
This modification allows to retrieve metabolites with a direct [subclass of (P279) ](https://www.wikidata.org/wiki/Property:P279) relationship with the values defined for chemical in the [scholia/app/templates/taxon_metabolome.sparql](https://github.com/WDscholia/scholia/blob/74701eabef0347ad0a2fd41c1ae1708ab59769a1/scholia/app/templates/taxon_metabolome.sparql) query.

This expands the range of fetched metabolites. E.g. from https://w.wiki/7SyG to ~~https://w.wiki/7SyN~~ https://w.wiki/7TAT
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* Runned the query

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [ ] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
