### PR TITLE
Update query for chemicals in a compound class

### DIFF
--- a/scholia/app/templates/chemical-class_related-chemicals.sparql
+++ b/scholia/app/templates/chemical-class_related-chemicals.sparql
@@ -2,7 +2,9 @@ PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
 SELECT ?mol ?molLabel ?InChIKey ?CAS ?CASUrl ?ChemSpider ?ChemSpiderUrl ?PubChem_CID ?PubChem_CIDUrl WITH {
 SELECT DISTINCT ?mol WHERE {
-  ?mol wdt:P31/wdt:P279* target: .
+  { ?mol wdt:P31 target: }
+  UNION
+  { ?mol wdt:P279+ target: }
 } LIMIT 500
 } AS %result
 WHERE {


### PR DESCRIPTION
Fixes #2343

### Description
This patch updates the SPARQL query to find example compounds. 

The problem arose (apparently) from a model change where `subclass` is predominantly used, not `is a`.
    
### Testing

* Go to https://scholia.toolforge.org/chemical-class/Q648037#related-chemicals
* See a filled table

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [ ] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
