### PR TITLE
Create Check Crossref tool

### DIFF
--- a/scholia/app/templates/base.html
+++ b/scholia/app/templates/base.html
@@ -951,6 +951,7 @@ askQuery("{{ panel }}", `# tool: scholia
     </a>
     <div class="dropdown-menu" aria-labelledby="toolsDropdown">
       <a class="dropdown-item" href="{{ url_for('app.show_id_to_quickstatements') }}">Identifier to Quickstatements</a>
+      <a class="dropdown-item" href="{{ url_for('app.show_check_crossref') }}">Check Crossref</a>
       <a class="dropdown-item" href="{{ url_for('app.show_q_to_bibliography_templates') }}">Q to Bibliography templates</a>
       <a class="dropdown-item" href="{{ url_for('app.show_text_to_topics') }}">Text to topics</a>
     </div>

--- a/scholia/app/templates/check-crossref-section.html
+++ b/scholia/app/templates/check-crossref-section.html
@@ -1,0 +1,9 @@
+<h2 id="check-crossref">Check Crossref for new papers</h2>
+
+<p>If you think that Wikidata is missing recent papers published on this topic, you can click the button below to check
+  the 20 most recent papers in Crossref. You will be redirected to the <a
+    href="/id-to-quickstatements">Identifier to Quickstatements</a> tool where you can see the presence of these in
+  Wikidata and have the opportunity to create these items in Wikidata using <a
+    href="https://www.wikidata.org/wiki/Help:QuickStatements">QuickStatements</a>.</p>
+
+<button type="button" class="btn btn-primary mx-auto d-block" id="check-crossref-button">Loading...</button>

--- a/scholia/app/templates/check-crossref.html
+++ b/scholia/app/templates/check-crossref.html
@@ -6,9 +6,9 @@
 
 <p>Enter a topic or author to search for papers in Crossref and check for their presence in Wikidata.</p>
 
-<form action="" id="form" method="GET" class="form-horizontal mb-3">
+<form id="form" class="form-horizontal mb-3">
   <div class="input-group">
-    <input type="text" class="form-control" placeholder="Search term" id="searchterm" name="query" />
+    <input type="text" class="form-control" placeholder="Search term" id="searchterm" />
     <span class="input-group-append">
       <button class="btn btn-primary" type="submit">
         Submit
@@ -19,9 +19,9 @@
   <h3 class="py-3">Options</h3>
 
   <div class="form-group row">
-    <label class="col-md-3 control-label" for="selectbasic">Type</label>
+    <label class="col-md-3 control-label" for="type">Type</label>
     <div class="col-md-9">
-      <select id="selectbasic" name="selectbasic" class="form-control">
+      <select id="type" class="form-control">
         <option value="book-chapter">Book Chapter</option>
         <option value="book-section">Book Section</option>
         <option value="book-series">Book Series</option>
@@ -58,35 +58,35 @@
 
 
   <div class="form-group row">
-    <label class="col-md-3 control-label" for="start">Published until</label>
+    <label class="col-md-3 control-label" for="until">Published until</label>
     <div class="col-md-9">
-      <input class="form-control" type="date" id="start" name="trip-start" />
+      <input class="form-control" type="date" id="until" />
     </div>
   </div>
 
   <div class="form-group row">
-    <label class="col-md-3 control-label" for="radios">Order</label>
+    <label class="col-md-3 control-label" for="order">Order</label>
     <div class="col-md-9">
       <div class="form-check form-check-inline">
-        <input class="form-check-input" type="radio" name="inlineRadioOptions" id="inlineRadio1" value="option1"
+        <input class="form-check-input" type="radio" id="latest" value="latest" name="order"
           checked>
-        <label class="form-check-label" for="inlineRadio1">Latest</label>
+        <label class="form-check-label" for="latest">Latest</label>
       </div>
       <div class="form-check form-check-inline">
-        <input class="form-check-input" type="radio" name="inlineRadioOptions" id="inlineRadio2" value="option2">
-        <label class="form-check-label" for="inlineRadio2">Earliest</label>
+        <input class="form-check-input" type="radio" id="earliest" value="earliest" name="order">
+        <label class="form-check-label" for="earliest">Earliest</label>
       </div>
       <div class="form-check form-check-inline">
-        <input class="form-check-input" type="radio" name="inlineRadioOptions" id="inlineRadio3" value="option3">
-        <label class="form-check-label" for="inlineRadio3">Random</label>
+        <input class="form-check-input" type="radio" id="relevance" value="relevance" name="order">
+        <label class="form-check-label" for="relevance">Relevance</label>
       </div>
     </div>
   </div>
 
   <div class="form-group row">
-    <label class="col-md-3 control-label" for="textinput">Number of results</label>
+    <label class="col-md-3 control-label" for="rows">Number of results</label>
     <div class="col-md-9">
-      <input id="textinput" name="textinput" type="number" placeholder="20" class="form-control input-md">
+      <input id="rows" type="number" placeholder="20" class="form-control input-md">
     </div>
   </div>
 
@@ -95,11 +95,12 @@
       <h3 class="d-inline-block">Advanced</h3>
     </summary>
 
+    <p>This is the query string which is used to check the Crossref API. For help, see the <a href="https://api.crossref.org/swagger-ui/index.html#/Works/get_works">API documentation</a>. You can also edit the query string here and use the Submit and Test query buttons as expected.</p>
     <div class="input-group">
       <div class="input-group-prepend">
         <span class="input-group-text" id="inputGroupPrepend">/works?</span>
       </div>
-      <input type="text" class="form-control" placeholder="Search term" id="searchterm1" name="query" />
+      <input type="text" class="form-control" placeholder="Search term" id="query_string" />
       <span class="input-group-append">
         <button class="btn btn-primary" type="submit">
           Submit
@@ -109,13 +110,69 @@
   </details>
 
 </form>
-<button class="btn btn-secondary">Test query</button>
+<button class="btn btn-secondary d-block ml-auto">Test query</button>
 
 {% endblock %}
 
 {% block scripts %}
 {{super()}}
 <script type="text/javascript">
+  function updateQueryString() {
+    // User validation not required as API calls are performed locally
+    const params = { 'select': 'DOI' }
+    const search_term = document.getElementById("searchterm").value
+    if (search_term) {
+      params["query"] = search_term
+    }
+
+    const type = document.getElementById("type").value
+    if (type) {
+      params["filter"] = "type:" + type
+    }
+
+    const until = document.getElementById("until").value
+    if (until) {
+      if ("filter" in params) {
+        params["filter"] += ",until-issued-date:" + until
+      }
+      else {
+        params["filter"] = "until-issued-date:" + until
+      }
+    }
+
+    const rows = document.getElementById("rows").value
+    if (rows) {
+      params["rows"] = rows
+    } else {
+      params["rows"] = 20
+    }
+
+    const order = document.querySelector("input[name=order]:checked").value
+    if (order === "relevance") {
+      params["sort"] = "relevance"
+      params["order"] = "desc"
+    } else if (order === "latest") {
+      params["sort"] = "issued"
+      params["order"] = "desc"
+    } else if (order === "earliest") {
+      params["sort"] = "issued"
+      params["order"] = "asc"
+    }
+
+    // Create a URLSearchParams object to construct the query parameters
+    const searchParams = new URLSearchParams();
+
+    // Loop through the dictionary and add each key-value pair to the searchParams
+    for (const [key, value] of Object.entries(params)) {
+      searchParams.append(key, value);
+    }
+
+    // Construct the final URL by appending the search parameters
+    // const url = `https://api.crossref.org/works/?${searchParams.toString()}`;
+    document.getElementById("query_string").value = decodeURIComponent(searchParams.toString())
+  }
+
   document.querySelector('input[type="date"]').valueAsDate = new Date();
+  updateQueryString()
 </script>
 {% endblock %}

--- a/scholia/app/templates/check-crossref.html
+++ b/scholia/app/templates/check-crossref.html
@@ -4,7 +4,7 @@
 
 <h1>Check Crossref</h1>
 
-<p>Enter a topic or author to search for papers in Crossref and check for their presence in Wikidata.</p>
+<p>Enter a topic to search for papers in Crossref and check for their presence in Wikidata.</p>
 
 <form id="form" class="form-horizontal mb-3">
   <div class="input-group">
@@ -97,7 +97,7 @@
 
   <p>This is the query string which is used to check the Crossref and can be edited directly. For help, see the <a
       href="https://api.crossref.org/swagger-ui/index.html#/Works/get_works">API documentation</a>. Note that using the
-    form buttons above will clear any edits you have manually made.</p>
+    form inputs above will clear any edits you have manually made.</p>
   <div class="input-group">
     <div class="input-group-prepend">
       <span class="input-group-text" id="inputGroupPrepend">/works?</span>
@@ -119,7 +119,7 @@
   const test_query_button = document.getElementById("test-query")
 
   function update_query_string() {
-    // Changing the form updates the query string in the advanced section which is 
+    // Changing the form updates the query string in the advanced section which is
     // the query string which is ultimately used to check crossref
     // User validation not required as API calls are performed locally
     const params = {}
@@ -180,8 +180,8 @@
   function get_dois_from_crossref() {
     // cribbed from q_curation.html. Maybe eventually worth refactoring
     let query_string = "select=DOI&" + document.getElementById("query_string").value
-    // on q_curation.html we need to URIencode the query string but here it breaks 
-    // the ability to select number of rows? 
+    // on q_curation.html we need to URIencode the query string but here it breaks
+    // the ability to select number of rows?
     const url = `https://api.crossref.org/works/?${query_string}`;
     const error_message = "The API failed which could be due to a problem with your connection or with the upstream server. If the issue persists <a href='https://github.com/WDscholia/scholia/issues/new?assignees=&labels=bug&projects=&template=bug_report.md&title=''>submit a bug report on GitHub</a>"
 

--- a/scholia/app/templates/check-crossref.html
+++ b/scholia/app/templates/check-crossref.html
@@ -1,9 +1,121 @@
-<h2 id="check-crossref">Check Crossref for new papers</h2>
+{% extends "base.html" %}
 
-<p>If you think that Wikidata is missing recent papers published on this topic, you can click the button below to check
-  the 20 most recent papers in Crossref. You will be redirected to the <a
-    href="/id-to-quickstatements">Identifier to Quickstatements</a> tool where you can see the presence of these in
-  Wikidata and have the opportunity to create these items in Wikidata using <a
-    href="https://www.wikidata.org/wiki/Help:QuickStatements">QuickStatements</a>.</p>
+{% block page_content %}
 
-<button type="button" class="btn btn-primary mx-auto d-block" id="check-crossref-button">Loading...</button>
+<h1>Check Crossref</h1>
+
+<p>Enter a topic or author to search for papers in Crossref and check for their presence in Wikidata.</p>
+
+<form action="" id="form" method="GET" class="form-horizontal mb-3">
+  <div class="input-group">
+    <input type="text" class="form-control" placeholder="Search term" id="searchterm" name="query" />
+    <span class="input-group-append">
+      <button class="btn btn-primary" type="submit">
+        Submit
+      </button>
+    </span>
+  </div>
+
+  <h3 class="py-3">Options</h3>
+
+  <div class="form-group row">
+    <label class="col-md-3 control-label" for="selectbasic">Type</label>
+    <div class="col-md-9">
+      <select id="selectbasic" name="selectbasic" class="form-control">
+        <option value="book-chapter">Book Chapter</option>
+        <option value="book-section">Book Section</option>
+        <option value="book-series">Book Series</option>
+        <option value="book-set">Book Set</option>
+        <option value="book-track">Book Track</option>
+        <option value="book">Book</option>
+        <option value="component">Component</option>
+        <option value="database">Database</option>
+        <option value="dataset">Dataset</option>
+        <option value="dissertation">Dissertation</option>
+        <option value="edited-book">Edited Book</option>
+        <option value="grant">Grant</option>
+        <option value="journal-article" selected>Journal Article</option>
+        <option value="journal-issue">Journal Issue</option>
+        <option value="journal-volume">Journal Volume</option>
+        <option value="journal">Journal</option>
+        <option value="monograph">Monograph</option>
+        <option value="other">Other</option>
+        <option value="book-part">Part</option>
+        <option value="peer-review">Peer Review</option>
+        <option value="posted-content">Posted Content</option>
+        <option value="proceedings-article">Proceedings Article</option>
+        <option value="proceedings-series">Proceedings Series</option>
+        <option value="proceedings">Proceedings</option>
+        <option value="reference-book">Reference Book</option>
+        <option value="reference-entry">Reference Entry</option>
+        <option value="report-component">Report Component</option>
+        <option value="report-series">Report Series</option>
+        <option value="report">Report</option>
+        <option value="standard">Standard</option>
+      </select>
+    </div>
+  </div>
+
+
+  <div class="form-group row">
+    <label class="col-md-3 control-label" for="start">Published until</label>
+    <div class="col-md-9">
+      <input class="form-control" type="date" id="start" name="trip-start" />
+    </div>
+  </div>
+
+  <div class="form-group row">
+    <label class="col-md-3 control-label" for="radios">Order</label>
+    <div class="col-md-9">
+      <div class="form-check form-check-inline">
+        <input class="form-check-input" type="radio" name="inlineRadioOptions" id="inlineRadio1" value="option1"
+          checked>
+        <label class="form-check-label" for="inlineRadio1">Latest</label>
+      </div>
+      <div class="form-check form-check-inline">
+        <input class="form-check-input" type="radio" name="inlineRadioOptions" id="inlineRadio2" value="option2">
+        <label class="form-check-label" for="inlineRadio2">Earliest</label>
+      </div>
+      <div class="form-check form-check-inline">
+        <input class="form-check-input" type="radio" name="inlineRadioOptions" id="inlineRadio3" value="option3">
+        <label class="form-check-label" for="inlineRadio3">Random</label>
+      </div>
+    </div>
+  </div>
+
+  <div class="form-group row">
+    <label class="col-md-3 control-label" for="textinput">Number of results</label>
+    <div class="col-md-9">
+      <input id="textinput" name="textinput" type="number" placeholder="20" class="form-control input-md">
+    </div>
+  </div>
+
+  <details>
+    <summary>
+      <h3 class="d-inline-block">Advanced</h3>
+    </summary>
+
+    <div class="input-group">
+      <div class="input-group-prepend">
+        <span class="input-group-text" id="inputGroupPrepend">/works?</span>
+      </div>
+      <input type="text" class="form-control" placeholder="Search term" id="searchterm1" name="query" />
+      <span class="input-group-append">
+        <button class="btn btn-primary" type="submit">
+          Submit
+        </button>
+      </span>
+    </div>
+  </details>
+
+</form>
+<button class="btn btn-secondary">Test query</button>
+
+{% endblock %}
+
+{% block scripts %}
+{{super()}}
+<script type="text/javascript">
+  document.querySelector('input[type="date"]').valueAsDate = new Date();
+</script>
+{% endblock %}

--- a/scholia/app/templates/check-crossref.html
+++ b/scholia/app/templates/check-crossref.html
@@ -10,7 +10,7 @@
   <div class="input-group">
     <input type="text" class="form-control" placeholder="Search term" id="search-term" />
     <span class="input-group-append">
-      <button class="btn btn-primary" type="submit">
+      <button class="btn btn-primary" type="button" id="submit">
         Submit
       </button>
     </span>
@@ -103,21 +103,21 @@
       <span class="input-group-text" id="inputGroupPrepend">/works?</span>
     </div>
     <input type="text" class="form-control" placeholder="Search term" id="query_string" />
-    <span class="input-group-append">
-      <button class="btn btn-primary" type="submit">
-        Submit
-      </button>
-    </span>
   </div>
 </details>
 
-<button class="btn btn-secondary d-block ml-auto">Test query</button>
+<a>
+  <button class="btn btn-secondary d-block ml-auto" type="button" id="test-query">Test query</button>
+</a>
 
 {% endblock %}
 
 {% block scripts %}
 {{super()}}
 <script type="text/javascript">
+  const submit_button = document.getElementById("submit")
+  const test_query_button = document.getElementById("test-query")
+
   function updateQueryString() {
     // User validation not required as API calls are performed locally
     const params = { 'select': 'DOI' }
@@ -169,8 +169,11 @@
     }
 
     // Construct the final URL by appending the search parameters
-    // const url = `https://api.crossref.org/works/?${searchParams.toString()}`;
     document.getElementById("query_string").value = decodeURIComponent(searchParams.toString())
+
+    searchParams.delete("select")
+    const url = `https://api.crossref.org/works/?${searchParams.toString()}`;
+    test_query_button.parentNode.href = url
   }
 
   document.querySelector('input[type="date"]').valueAsDate = new Date();

--- a/scholia/app/templates/check-crossref.html
+++ b/scholia/app/templates/check-crossref.html
@@ -8,7 +8,7 @@
 
 <form id="form" class="form-horizontal mb-3">
   <div class="input-group">
-    <input type="text" class="form-control" placeholder="Search term" id="searchterm" />
+    <input type="text" class="form-control" placeholder="Search term" id="search-term" />
     <span class="input-group-append">
       <button class="btn btn-primary" type="submit">
         Submit
@@ -68,8 +68,7 @@
     <label class="col-md-3 control-label" for="order">Order</label>
     <div class="col-md-9">
       <div class="form-check form-check-inline">
-        <input class="form-check-input" type="radio" id="latest" value="latest" name="order"
-          checked>
+        <input class="form-check-input" type="radio" id="latest" value="latest" name="order" checked>
         <label class="form-check-label" for="latest">Latest</label>
       </div>
       <div class="form-check form-check-inline">
@@ -89,27 +88,29 @@
       <input id="rows" type="number" placeholder="20" class="form-control input-md">
     </div>
   </div>
-
-  <details>
-    <summary>
-      <h3 class="d-inline-block">Advanced</h3>
-    </summary>
-
-    <p>This is the query string which is used to check the Crossref API. For help, see the <a href="https://api.crossref.org/swagger-ui/index.html#/Works/get_works">API documentation</a>. You can also edit the query string here and use the Submit and Test query buttons as expected.</p>
-    <div class="input-group">
-      <div class="input-group-prepend">
-        <span class="input-group-text" id="inputGroupPrepend">/works?</span>
-      </div>
-      <input type="text" class="form-control" placeholder="Search term" id="query_string" />
-      <span class="input-group-append">
-        <button class="btn btn-primary" type="submit">
-          Submit
-        </button>
-      </span>
-    </div>
-  </details>
-
 </form>
+
+<details class="mb-3">
+  <summary>
+    <h3 class="d-inline-block">Advanced</h3>
+  </summary>
+
+  <p>This is the query string which is used to check the Crossref API. For help, see the <a
+      href="https://api.crossref.org/swagger-ui/index.html#/Works/get_works">API documentation</a>. You can also edit
+    the query string here and use the Submit and Test query buttons as expected.</p>
+  <div class="input-group">
+    <div class="input-group-prepend">
+      <span class="input-group-text" id="inputGroupPrepend">/works?</span>
+    </div>
+    <input type="text" class="form-control" placeholder="Search term" id="query_string" />
+    <span class="input-group-append">
+      <button class="btn btn-primary" type="submit">
+        Submit
+      </button>
+    </span>
+  </div>
+</details>
+
 <button class="btn btn-secondary d-block ml-auto">Test query</button>
 
 {% endblock %}
@@ -120,7 +121,7 @@
   function updateQueryString() {
     // User validation not required as API calls are performed locally
     const params = { 'select': 'DOI' }
-    const search_term = document.getElementById("searchterm").value
+    const search_term = document.getElementById("search-term").value
     if (search_term) {
       params["query"] = search_term
     }
@@ -173,6 +174,12 @@
   }
 
   document.querySelector('input[type="date"]').valueAsDate = new Date();
+
+  const inputs = document.querySelectorAll("#form input,select");
+  for (const input of inputs) {
+    input.addEventListener("input", () => { updateQueryString() })
+  }
+
   updateQueryString()
 </script>
 {% endblock %}

--- a/scholia/app/templates/check-crossref.html
+++ b/scholia/app/templates/check-crossref.html
@@ -95,14 +95,14 @@
     <h3 class="d-inline-block">Advanced</h3>
   </summary>
 
-  <p>This is the query string which is used to check the Crossref API. For help, see the <a
-      href="https://api.crossref.org/swagger-ui/index.html#/Works/get_works">API documentation</a>. You can also edit
-    the query string here and use the Submit and Test query buttons as expected.</p>
+  <p>This is the query string which is used to check the Crossref and can be edited directly. For help, see the <a
+      href="https://api.crossref.org/swagger-ui/index.html#/Works/get_works">API documentation</a>. Note that using the
+    form buttons above will clear any edits you have manually made.</p>
   <div class="input-group">
     <div class="input-group-prepend">
       <span class="input-group-text" id="inputGroupPrepend">/works?</span>
     </div>
-    <textarea rows="1" class="form-control" id="query_string" ></textarea>
+    <textarea rows="1" class="form-control" id="query_string"></textarea>
   </div>
 </details>
 
@@ -118,7 +118,7 @@
   const submit_button = document.getElementById("submit")
   const test_query_button = document.getElementById("test-query")
 
-  function updateQueryString() {
+  function update_query_string() {
     // Changing the form updates the query string in the advanced section which is 
     // the query string which is ultimately used to check crossref
     // User validation not required as API calls are performed locally
@@ -177,12 +177,56 @@
     test_query_button.parentNode.href = url
   }
 
+  function get_dois_from_crossref() {
+    // cribbed from q_curation.html. Maybe eventually worth refactoring
+    let query_string = "select=DOI&" + document.getElementById("query_string").value
+    // on q_curation.html we need to URIencode the query string but here it breaks 
+    // the ability to select number of rows? 
+    const url = `https://api.crossref.org/works/?${query_string}`;
+    const error_message = "The API failed which could be due to a problem with your connection or with the upstream server. If the issue persists <a href='https://github.com/WDscholia/scholia/issues/new?assignees=&labels=bug&projects=&template=bug_report.md&title=''>submit a bug report on GitHub</a>"
+
+    console.log(url)
+
+    fetch(url)
+      .then(response => response.json())
+      .then(data => {
+        if (data['status'] == 'ok') {
+          if (data["message"]["total-results"] > 0) {
+            items = data.message?.items
+            if (items) {
+              dois = items.map(x => x.DOI).join(" ");
+              window.location.href = "/id-to-quickstatements?query=" + dois;
+            }
+          } else {
+            submit_button.insertAdjacentHTML('afterend', `<div class="alert alert-secondary" role="alert">No results returned for ${data.message.query['status-terms']}</div>`);
+            submit_button.innerHTML = "Submit";
+          }
+        } else {
+          console.error(`API status was ${data.status}`)
+          console.error(data)
+          submit_button.insertAdjacentHTML('afterend', `<div class="alert alert-warning" role="alert">${error_message}</div>`);
+          submit_button.innerHTML = "Submit";
+        }
+      })
+      .catch(error => {
+        console.error(error);
+        submit_button.insertAdjacentHTML('afterend', `<div class="alert alert-warning" role="alert">${error_message}</div>`);
+        submit_button.innerHTML = "Submit";
+      });
+  }
+
+
   document.querySelector('input[type="date"]').valueAsDate = new Date();
 
   const inputs = document.querySelectorAll("#form input,select");
   for (const input of inputs) {
-    input.addEventListener("input", () => { updateQueryString() })
+    input.addEventListener("input", () => { update_query_string() })
   }
+
+  submit_button.addEventListener("click", () => {
+    submit_button.innerHTML = "Loading...";
+    get_dois_from_crossref()
+  })
 
   const query_string_input = document.getElementById("query_string")
   query_string_input.addEventListener("input", () => {
@@ -191,6 +235,6 @@
     test_query_button.parentNode.href = url
   })
 
-  updateQueryString()
+  update_query_string()
 </script>
 {% endblock %}

--- a/scholia/app/templates/check-crossref.html
+++ b/scholia/app/templates/check-crossref.html
@@ -102,7 +102,7 @@
     <div class="input-group-prepend">
       <span class="input-group-text" id="inputGroupPrepend">/works?</span>
     </div>
-    <input type="text" class="form-control" placeholder="Search term" id="query_string" />
+    <textarea rows="1" class="form-control" id="query_string" ></textarea>
   </div>
 </details>
 
@@ -119,8 +119,10 @@
   const test_query_button = document.getElementById("test-query")
 
   function updateQueryString() {
+    // Changing the form updates the query string in the advanced section which is 
+    // the query string which is ultimately used to check crossref
     // User validation not required as API calls are performed locally
-    const params = { 'select': 'DOI' }
+    const params = {}
     const search_term = document.getElementById("search-term").value
     if (search_term) {
       params["query"] = search_term
@@ -171,7 +173,6 @@
     // Construct the final URL by appending the search parameters
     document.getElementById("query_string").value = decodeURIComponent(searchParams.toString())
 
-    searchParams.delete("select")
     const url = `https://api.crossref.org/works/?${searchParams.toString()}`;
     test_query_button.parentNode.href = url
   }
@@ -182,6 +183,13 @@
   for (const input of inputs) {
     input.addEventListener("input", () => { updateQueryString() })
   }
+
+  const query_string_input = document.getElementById("query_string")
+  query_string_input.addEventListener("input", () => {
+    let input = query_string_input.value
+    const url = `https://api.crossref.org/works/?${encodeURIComponent(input)}`;
+    test_query_button.parentNode.href = url
+  })
 
   updateQueryString()
 </script>

--- a/scholia/app/templates/disease-curation.html
+++ b/scholia/app/templates/disease-curation.html
@@ -2,6 +2,6 @@
 
 {% block curation_panels %}
 
-{% include 'check-crossref.html' %}
+{% include 'check-crossref-section.html' %}
 
 {% endblock %}

--- a/scholia/app/templates/gene-curation.html
+++ b/scholia/app/templates/gene-curation.html
@@ -2,6 +2,6 @@
 
 {% block curation_panels %}
 
-{% include 'check-crossref.html' %}
+{% include 'check-crossref-section.html' %}
 
 {% endblock %}

--- a/scholia/app/templates/protein-curation.html
+++ b/scholia/app/templates/protein-curation.html
@@ -2,6 +2,6 @@
 
 {% block curation_panels %}
 
-{% include 'check-crossref.html' %}
+{% include 'check-crossref-section.html' %}
 
 {% endblock %}

--- a/scholia/app/templates/taxon-curation.html
+++ b/scholia/app/templates/taxon-curation.html
@@ -12,7 +12,7 @@
 
 {% block curation_panels %}
 
-{% include 'check-crossref.html' %}
+{% include 'check-crossref-section.html' %}
 
 <h2 id="missing-topic-tags-for-taxon-name">Missing topic tags for taxon name</h2>
 

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -371,6 +371,23 @@ def show_id_to_quickstatements():
     )
 
 
+@main.route('/check-crossref')
+def show_check_crossref():
+    """Return HTML rendering for Check Crossref tool.
+
+    Returns
+    -------
+    html : str
+        Rendered HTML.
+
+    See Also
+    --------
+    show_arxiv.
+
+    """
+    return render_template('check-crossref.html')
+
+
 @main.route('/author/' + q_pattern)
 def show_author(q):
     """Return HTML rendering for specific author.


### PR DESCRIPTION
Builds on top of #2337 and #2340 Merge these first

### Description
> Please include a summary of the change, relevant motivation and context. If possible and applicable, include before and after screenshots and a URL where the changes can be seen.

This is the same functionality provided by the curation pages in #2342 but allows the user to edit the query directly rather than using the defaults set by the curation page tool

Users can either use the simple form inputs or edit the query string directly in the Advanced section. The "Submit" button sends the DOIs to the ID to QS tool, "Test query" button allows users to see the API results directly
    
![image](https://github.com/WDscholia/scholia/assets/6676843/ab0eff29-b41c-48e0-86d0-cb813bac0fc3)

Note: the date formatting in the date picker is set with the user's locale setting. For example in another of my browsers, the date shows as YYYY-MM-DD

### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* Checked that everything works as expected

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [ ] My changes generate no new warnings
* [ ] I have not used code from external sources without attribution
* [ ] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
