### PR TITLE
Fixes queries for the new chemical entity structure

### DIFF
--- a/scholia/app/templates/chemical-index-curation_missing-boiling-points.sparql
+++ b/scholia/app/templates/chemical-index-curation_missing-boiling-points.sparql
@@ -1,6 +1,6 @@
 SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
   SELECT ?wikis ?compound WHERE {
-    ?compound wdt:P31 wd:Q11173 ;
+    ?compound wdt:P31 wd:Q113145171 ;
               wikibase:sitelinks ?wikis . hint:Prior hint:rangeSafe true .
     FILTER(?wikis >= 40)
     FILTER(NOT EXISTS {?compound wdt:P2102 []})

--- a/scholia/app/templates/chemical-index-curation_missing-chemical-structure.sparql
+++ b/scholia/app/templates/chemical-index-curation_missing-chemical-structure.sparql
@@ -1,6 +1,6 @@
 SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
   SELECT ?wikis ?compound WHERE {
-    ?compound wdt:P31 wd:Q11173 ;
+    ?compound wdt:P31 wd:Q113145171 ;
               wikibase:sitelinks ?wikis . hint:Prior hint:rangeSafe true .
     FILTER(?wikis >= 40)
     FILTER(NOT EXISTS {?compound wdt:P117 []})

--- a/scholia/app/templates/chemical-index-curation_missing-combustion-enthalpy.sparql
+++ b/scholia/app/templates/chemical-index-curation_missing-combustion-enthalpy.sparql
@@ -1,6 +1,6 @@
 SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
   SELECT ?wikis ?compound WHERE {
-    ?compound wdt:P31 wd:Q11173 ;
+    ?compound wdt:P31 wd:Q113145171 ;
               wikibase:sitelinks ?wikis . hint:Prior hint:rangeSafe true .
     FILTER(?wikis >= 40)
     FILTER(NOT EXISTS {?compound wdt:P2117 []})

--- a/scholia/app/templates/chemical-index-curation_missing-density.sparql
+++ b/scholia/app/templates/chemical-index-curation_missing-density.sparql
@@ -1,6 +1,6 @@
 SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
   SELECT ?wikis ?compound WHERE {
-    ?compound wdt:P31 wd:Q11173 ;
+    ?compound wdt:P31 wd:Q113145171 ;
               wikibase:sitelinks ?wikis . hint:Prior hint:rangeSafe true .
     FILTER(?wikis >= 40)
     FILTER(NOT EXISTS {?compound wdt:P2054 []})

--- a/scholia/app/templates/chemical-index-curation_missing-enthalpy-of-formation.sparql
+++ b/scholia/app/templates/chemical-index-curation_missing-enthalpy-of-formation.sparql
@@ -1,6 +1,6 @@
 SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
   SELECT ?wikis ?compound WHERE {
-    ?compound wdt:P31 wd:Q11173 ;
+    ?compound wdt:P31 wd:Q113145171 ;
               wikibase:sitelinks ?wikis . hint:Prior hint:rangeSafe true .
     FILTER(?wikis >= 40)
     FILTER(NOT EXISTS {?compound wdt:P3078 []})

--- a/scholia/app/templates/chemical-index-curation_missing-flash-point.sparql
+++ b/scholia/app/templates/chemical-index-curation_missing-flash-point.sparql
@@ -1,6 +1,6 @@
 SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
   SELECT ?wikis ?compound WHERE {
-    ?compound wdt:P31 wd:Q11173 ;
+    ?compound wdt:P31 wd:Q113145171 ;
               wikibase:sitelinks ?wikis . hint:Prior hint:rangeSafe true .
     FILTER(?wikis >= 40)
     FILTER(NOT EXISTS {?compound wdt:P2128 []})

--- a/scholia/app/templates/chemical-index-curation_missing-idlh.sparql
+++ b/scholia/app/templates/chemical-index-curation_missing-idlh.sparql
@@ -1,6 +1,6 @@
 SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
   SELECT ?wikis ?compound WHERE {
-    ?compound wdt:P31 wd:Q11173 ;
+    ?compound wdt:P31 wd:Q113145171 ;
               wikibase:sitelinks ?wikis . hint:Prior hint:rangeSafe true .
     FILTER(?wikis >= 40)
     FILTER(NOT EXISTS {?compound wdt:P2129 []})

--- a/scholia/app/templates/chemical-index-curation_missing-mass.sparql
+++ b/scholia/app/templates/chemical-index-curation_missing-mass.sparql
@@ -1,6 +1,6 @@
 SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
   SELECT ?wikis ?compound WHERE {
-    ?compound wdt:P31 wd:Q11173 ;
+    ?compound wdt:P31 wd:Q113145171 ;
               wikibase:sitelinks ?wikis . hint:Prior hint:rangeSafe true .
     FILTER(?wikis >= 30)
     FILTER(NOT EXISTS {?compound wdt:P2067 []})

--- a/scholia/app/templates/chemical-index-curation_missing-melting-points.sparql
+++ b/scholia/app/templates/chemical-index-curation_missing-melting-points.sparql
@@ -1,6 +1,6 @@
 SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
   SELECT ?wikis ?compound WHERE {
-    ?compound wdt:P31 wd:Q11173 ;
+    ?compound wdt:P31 wd:Q113145171 ;
               wikibase:sitelinks ?wikis . hint:Prior hint:rangeSafe true .
     FILTER(?wikis >= 40)
     FILTER(NOT EXISTS {?compound wdt:P2101 []})

--- a/scholia/app/templates/chemical-index-curation_missing-molar-entropy.sparql
+++ b/scholia/app/templates/chemical-index-curation_missing-molar-entropy.sparql
@@ -1,6 +1,6 @@
 SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
   SELECT ?wikis ?compound WHERE {
-    ?compound wdt:P31 wd:Q11173 ;
+    ?compound wdt:P31 wd:Q113145171 ;
               wikibase:sitelinks ?wikis . hint:Prior hint:rangeSafe true .
     FILTER(?wikis >= 40)
     FILTER(NOT EXISTS {?compound wdt:P3071 []})

--- a/scholia/app/templates/chemical-index-curation_missing-pKa.sparql
+++ b/scholia/app/templates/chemical-index-curation_missing-pKa.sparql
@@ -1,6 +1,6 @@
 SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
   SELECT ?wikis ?compound WHERE {
-    ?compound wdt:P31 wd:Q11173 ;
+    ?compound wdt:P31 wd:Q113145171 ;
               wikibase:sitelinks ?wikis . hint:Prior hint:rangeSafe true .
     FILTER(?wikis >= 40)
     FILTER(NOT EXISTS {?compound wdt:P1117 []})

--- a/scholia/app/templates/chemical-index-curation_missing-solubility.sparql
+++ b/scholia/app/templates/chemical-index-curation_missing-solubility.sparql
@@ -1,6 +1,6 @@
 SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
   SELECT ?wikis ?compound WHERE {
-    ?compound wdt:P31 wd:Q11173 ;
+    ?compound wdt:P31 wd:Q113145171 ;
               wikibase:sitelinks ?wikis . hint:Prior hint:rangeSafe true .
     FILTER(?wikis >= 40)
     FILTER(NOT EXISTS {?compound wdt:P2177 []})

--- a/scholia/app/templates/chemical-index-curation_missing-vapor-pressure.sparql
+++ b/scholia/app/templates/chemical-index-curation_missing-vapor-pressure.sparql
@@ -1,6 +1,6 @@
 SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
   SELECT ?wikis ?compound WHERE {
-    ?compound wdt:P31 wd:Q11173 ;
+    ?compound wdt:P31 wd:Q113145171 ;
               wikibase:sitelinks ?wikis . hint:Prior hint:rangeSafe true .
     FILTER(?wikis >= 40)
     FILTER(NOT EXISTS {?compound wdt:P2119 []})


### PR DESCRIPTION
See https://www.wikidata.org/wiki/Wikidata:WikiProject_Chemistry/Guidelines/Basic_metaclasses_and_relations#Basic_metaclasses_for_chemical_entities

Fixes #2348

### Description
Fixes the empty lists in the bug report by updating the `P31` statements in the SPARQL.
    
### Caveats

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing

* Go to https://scholia.toolforge.org/chemical/curation
* Notice the lists is no longer empty

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [ ] My changes generate no new warnings
* [ ] I have not used code from external sources without attribution
* [ ] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [ ] There are no remaining debug statements (print, console.log, ...)
