### PR TITLE
Implement 'Cite' for datasets

### DIFF
--- a/scholia/app/templates/dataset-export.html
+++ b/scholia/app/templates/dataset-export.html
@@ -1,0 +1,1 @@
+{% extends "work-export.html" %}

--- a/scholia/app/templates/dataset.html
+++ b/scholia/app/templates/dataset.html
@@ -12,6 +12,9 @@
 
 {% endblock %}
 
+{% block page_actions %}
+<a href="/dataset/{{ q }}/export" role="button" class="btn btn-outline-secondary">Cite</a>
+{% endblock %}
 
 {% block page_content %}
 <h1 id="h1">Taxon</h1>

--- a/scholia/app/templates/dataset.html
+++ b/scholia/app/templates/dataset.html
@@ -14,6 +14,7 @@
 
 {% block page_actions %}
 <a href="/dataset/{{ q }}/export" role="button" class="btn btn-outline-secondary">Cite</a>
+{{ super() }}
 {% endblock %}
 
 {% block page_content %}

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -593,6 +593,24 @@ def show_dataset_index():
     return render_template('dataset-index.html')
 
 
+@main.route('/dataset/' + q_pattern + '/export')
+def show_dataset_export(q):
+    """Return HTML rendering for export formats for this dataset.
+
+    Parameters
+    ----------
+    q : str
+        Wikidata item identifier.
+
+    Returns
+    -------
+    html : str
+        Rendered HTML.
+
+    """
+    return render_template('dataset-export.html', q=q)
+
+
 @main.route('/clinical-trial/')
 def show_clinical_trial_index():
     """Return clinical trial index page.


### PR DESCRIPTION
Implements #2325

### Description
Adds the `Cite` button to the `dataset` aspect.
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [x]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing

* https://scholia.toolforge.org/dataset/Q120320769
* https://scholia.toolforge.org/dataset/Q120320769/export

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [ ] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
