### PR TITLE
Fix for the redirect_omim() documentation

### DIFF
--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -1090,7 +1090,7 @@ def redirect_omim(omimID):
 
     Parameters
     ----------
-    omim : str
+    omimID : str
         OMIM identifier.
 
     """


### PR DESCRIPTION
Fixes #2353

### Description
Fixed the name of the method parameter in the documentation.
 
Minimal fix. BTW, I am not sure why `tox` did not highlight this issue. Is there a special command I should have run to make it check these kind of inconsistencies?