### PR TITLE
Fix/bug2352

### DIFF
--- a/scholia/app/templates/chemical-curation_missing-main-subjects.sparql
+++ b/scholia/app/templates/chemical-curation_missing-main-subjects.sparql
@@ -1,6 +1,7 @@
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
-SELECT DISTINCT ?work ?workLabel ?chemicalname
+SELECT DISTINCT ?work ?workLabel (CONCAT("/work/", SUBSTR(STR(?work),32)) AS ?workUrl)
+  ?chemicalname
   (CONCAT(SUBSTR(STR(?work),32), "\tP921\t{{ q }}\tS887\tQ69652283") AS ?quickStatements)
   (CONCAT("https://quickstatements.toolforge.org/#/v1=",
           SUBSTR(STR(?work),32), "%7CP921%7C{{ q }}%7CS887%7CQ69652283") AS ?quickStatementsUrl)

--- a/scholia/app/templates/chemical-curation_missing-main-subjects.sparql
+++ b/scholia/app/templates/chemical-curation_missing-main-subjects.sparql
@@ -1,11 +1,11 @@
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
-SELECT DISTINCT ?item ?itemLabel ?chemicalname
-  (CONCAT(SUBSTR(STR(?item),32), "\tP921\t{{ q }}\tS887\tQ69652283") AS ?quickStatements)
+SELECT DISTINCT ?work ?workLabel ?chemicalname
+  (CONCAT(SUBSTR(STR(?work),32), "\tP921\t{{ q }}\tS887\tQ69652283") AS ?quickStatements)
   (CONCAT("https://quickstatements.toolforge.org/#/v1=",
-          SUBSTR(STR(?item),32), "%7CP921%7C{{ q }}%7CS887%7CQ69652283") AS ?quickStatementsUrl)
+          SUBSTR(STR(?work),32), "%7CP921%7C{{ q }}%7CS887%7CQ69652283") AS ?quickStatementsUrl)
 WITH {
-  SELECT  ?item ?chemicalname WHERE {
+  SELECT  ?work ?chemicalname WHERE {
     VALUES ?chemicalType {
       wd:Q113145171 # type of a chemical entity
       wd:Q59199015 # group of stereoisomers
@@ -18,13 +18,13 @@ WITH {
       mwapi:generator "search";
       mwapi:gsrsearch ?chemicalname;
       mwapi:gsrlimit "max".
-      ?item wikibase:apiOutputItem mwapi:title.
+      ?work wikibase:apiOutputItem mwapi:title.
     }
-    ?item wdt:P1476 ?title .
-    MINUS {?item wdt:P921 target: }
+    ?work wdt:P1476 ?title .
+    MINUS {?work wdt:P921 target: }
     FILTER (REGEX(LCASE(?title), LCASE(CONCAT( "\\\\", "b", ?chemicalname ,"\\\\", "b"))))
   } LIMIT 200
-} AS %items WHERE {
-  INCLUDE %items
+} AS %works WHERE {
+  INCLUDE %works
   SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
 }


### PR DESCRIPTION
Fixes #2352 

### Description
This PR renames the `Item` column to `Work` and fixes the link. The SPARQL query did not actually provide
a link and I guess the JavaScript invented one based on the current link. 
    
### Caveats

Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

### Testing
* Try http://127.0.0.1:8100/chemical/Q23118/curation#missing-main-subjects

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [ ] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
