### PR TITLE
more chemical-class updates for the updated Wikidata chem hierarchy model

### DIFF
--- a/scholia/app/templates/chemical-class_class-hierarchy.sparql
+++ b/scholia/app/templates/chemical-class_class-hierarchy.sparql
@@ -1,14 +1,18 @@
 #defaultView:Graph
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
-SELECT ?class ?classLabel ?otherclass ?otherclassLabel ?rgb WITH {
+SELECT DISTINCT ?class ?classLabel ?otherclass ?otherclassLabel ?rgb WITH {
   SELECT DISTINCT ?class ?otherclass ?rgb WHERE {
+    # find the subclasses
     { VALUES ?class { target: }
-      { ?otherclass wdt:P279 ?class . BIND( "3182BD" AS ?rgb) }
+      # subclasses that have subclasses themselves
+      { ?otherclass wdt:P279 ?class . [] wdt:P279 ?otherclass  BIND( "3182BD" AS ?rgb) }
       UNION
-      { ?otherclass wdt:P31 ?class . BIND( "E6550D" AS ?rgb) }
+      # subclasses that do not have subclasses
+      { ?otherclass wdt:P279 ?class . MINUS { [] wdt:P279 ?otherclass } BIND( "E6550D" AS ?rgb) }
     }
     UNION
+    # find the superclasses
     { VALUES ?otherclass { target: }
       ?otherclass wdt:P279 ?class .
     }
@@ -18,4 +22,3 @@ WHERE {
   INCLUDE %result
   SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
 }
-

--- a/scholia/app/templates/chemical-class_publications-per-year.sparql
+++ b/scholia/app/templates/chemical-class_publications-per-year.sparql
@@ -12,7 +12,7 @@ select ?year (count(?work) as ?number_of_publications) where {
       bind(year(?date) as ?year_)
       {
         select (min(?year_) as ?earliest_year) where {
-          { ?work wdt:P921/wdt:P31*/wdt:P279* target: . }
+          { ?work wdt:P921/wdt:P279* target: . }
           union { ?work wdt:P921/wdt:P361+ target: . }
           union { ?work wdt:P921/wdt:P1269+ target: . }
           union { target: ?propp ?statement .
@@ -28,7 +28,7 @@ select ?year (count(?work) as ?number_of_publications) where {
   }
   union {
     select ?work (min(?years) as ?year) where {
-      { ?work wdt:P921/wdt:P31*/wdt:P279* target: . }
+      { ?work wdt:P921/wdt:P279* target: . }
       union { ?work wdt:P921/wdt:P361+ target: . }
       union { ?work wdt:P921/wdt:P1269+ target: . }
       union { target: ?propp ?statement .

--- a/scholia/app/templates/chemical-class_recent-literature.sparql
+++ b/scholia/app/templates/chemical-class_recent-literature.sparql
@@ -8,7 +8,7 @@ WITH {
     UNION
     { ?work wdt:P921 ?topic . ?topic ((^wdt:P361)+) target: . BIND ("part" AS ?via) }
     UNION
-    { ?work wdt:P921 ?topic . ?topic (wdt:P31* / wdt:P279* ) target: . BIND ("subclass" AS ?via). FILTER (?topic != target:) }
+    { ?work wdt:P921 ?topic . ?topic (wdt:P279* ) target: . BIND ("subclass" AS ?via). FILTER (?topic != target:) }
     UNION
     { ?work wdt:P921 ?topic . ?topic (wdt:P1269+ ) target: . BIND ("facet" AS ?via)}
     UNION

--- a/scholia/app/templates/chemical-class_related-chemicals.sparql
+++ b/scholia/app/templates/chemical-class_related-chemicals.sparql
@@ -2,7 +2,8 @@ PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
 SELECT ?mol ?molLabel ?InChIKey ?CAS ?CASUrl ?ChemSpider ?ChemSpiderUrl ?PubChem_CID ?PubChem_CIDUrl WITH {
 SELECT DISTINCT ?mol WHERE {
-  ?mol wdt:P31/wdt:P279* target: .
+  ?mol wdt:P279* target: .
+  MINUS { [] wdt:P279 ?mol }
 } LIMIT 500
 } AS %result
 WHERE {


### PR DESCRIPTION
Fixes various issues, including the visual hierarchy plot. Continues the patch in another panel: https://github.com/WDscholia/scholia/pull/2344

### Description
Previously, specific chemicals where `instance of` a chemical class, but they are now always `subclass of`. To continue the differences in the `chemical-class` aspect, we need to do this check differently. Some updates do this by checking if the subclass itself has subclasses, mimicking the `P31` behavior before. In other places, the `P31` can just be removed because it used "one or more". For those panels, we do not see differences.
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [x]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

### Testing
After the patch, some of the nodes should be orange again:

* https://scholia.toolforge.org/chemical-class/Q41581

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [ ] My changes generate no new warnings
* [ ] I have not used code from external sources without attribution
* [ ] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
