### PR TITLE
Fix finding taxons in which this class is found

### DIFF
--- a/scholia/app/templates/chemical-class_found-in-taxon.sparql
+++ b/scholia/app/templates/chemical-class_found-in-taxon.sparql
@@ -1,13 +1,9 @@
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
 SELECT DISTINCT ?taxon ?taxonLabel (CONCAT("/taxon/", SUBSTR(STR(?taxon), 32)) AS ?taxonUrl) (COUNT(DISTINCT(?chemical)) AS ?count) WHERE {
-  ?chemical wdt:P31/wdt:P279* target: ;
+  ?chemical wdt:P279+ target: ;
             p:P703 ?taxonStatement .
   ?taxonStatement ps:P703 ?taxon .
-  OPTIONAL {
-      ?taxonStatement prov:wasDerivedFrom/pr:P248 ?source .
-      OPTIONAL { ?source wdt:P356 ?DOI . }
-    }
   SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
 } 
   GROUP BY ?taxon ?taxonLabel


### PR DESCRIPTION
Fixes listing the taxons in which chemicals in this chemical class are found.

Also removes an unused OPTIONAL part.

### Description
The list was empty because it still used the P31 structure. Similar to other recent fixes.
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

### Testing
* Got to https://scholia.toolforge.org/chemical-class/Q2832210
* Before the patch the list is empty
* After the patch it should look like this:

![image](https://github.com/WDscholia/scholia/assets/26721/d3c9c428-c387-46bc-a8f4-ed13640dfc2c)

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [ ] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [ ] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
