### PR TITLE
Ensure the DOI gets linked

### DIFF
--- a/scholia/app/templates/chemical_found-in-taxon.sparql
+++ b/scholia/app/templates/chemical_found-in-taxon.sparql
@@ -2,13 +2,13 @@ PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
 SELECT DISTINCT ?taxon ?taxonLabel (CONCAT("/taxon/", SUBSTR(STR(?taxon), 32)) AS ?taxonUrl)
 ?source ?sourceLabel (CONCAT("/work/", SUBSTR(STR(?source), 32)) AS ?sourceUrl)
-?DOI WHERE {
+?doi WHERE {
   VALUES ?chemical { target: }
   ?chemical p:P703 ?taxonStatement .
   ?taxonStatement ps:P703 ?taxon .
   OPTIONAL {
       ?taxonStatement prov:wasDerivedFrom/pr:P248 ?source .
-      OPTIONAL { ?source wdt:P356 ?DOI . }
+      OPTIONAL { ?source wdt:P356 ?doi . }
     }
   SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
 } ORDER BY ASC(?taxonLabel)


### PR DESCRIPTION
Fixes #2354

### Description
The column name is case sensitive when recognized as linkable.
    
### Caveats
Doesn't look so pretty. Maybe the core that adds the link can also recognize "DOI" is column name. But that needs testing as it is used elsewhere.

### Testing
* Check if that taxon section (e.g. https://scholia.toolforge.org/chemical/Q209284#found-in-taxon) has clickable DOIs

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
