### PR TITLE
Added the WikiProject index to the menu

### DIFF
--- a/scholia/app/templates/base.html
+++ b/scholia/app/templates/base.html
@@ -903,6 +903,7 @@ askQuery("{{ panel }}", `# tool: scholia
     <div class="dropdown-menu" aria-labelledby="projectDropdown">
       <a class="dropdown-item" href="{{ url_for('app.show_clinical_trial_index') }}">Clinical trial</a>
       <a class="dropdown-item" href="{{ url_for('app.show_project_index') }}">Project</a>
+      <a class="dropdown-item" href="{{ url_for('app.show_wikiproject_index') }}">WikiProject</a>
     </div>
 
 	</li>


### PR DESCRIPTION
Fixes #2368

### Description
Add an base menu item for the index page for WikiProjects.
    
### Caveats

### Testing

* Go to the Scholia front page
* Open the Project menu
* Check if WikiProject is listed:

![image](https://github.com/WDscholia/scholia/assets/26721/2726f998-dd16-4c49-8129-2c7442c6fbaa)

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
