### PR TITLE
Fix #2367 Expand taxon-chemical-class query

### DIFF
--- a/scholia/app/templates/chemical-class_found-in-taxon.sparql
+++ b/scholia/app/templates/chemical-class_found-in-taxon.sparql
@@ -1,11 +1,30 @@
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
-SELECT DISTINCT ?taxon ?taxonLabel (CONCAT("/taxon/", SUBSTR(STR(?taxon), 32)) AS ?taxonUrl) (COUNT(DISTINCT(?chemical)) AS ?count) WHERE {
-  ?chemical wdt:P279+ target: ;
-            p:P703 ?taxonStatement .
-  ?taxonStatement ps:P703 ?taxon .
+SELECT
+  ?chemicals
+
+  ?example_chemical ?example_chemicalLabel
+  (CONCAT("/chemical/", SUBSTR(STR(?example_chemical), 32)) AS ?example_chemicalUrl)
+
+  ?taxon ?taxonLabel
+  (CONCAT("/taxon/", SUBSTR(STR(?taxon), 32)) AS ?taxonUrl)
+  ?taxonDescription
+WITH {
+  SELECT DISTINCT 
+    (COUNT(DISTINCT(?chemical)) AS ?chemicals)
+    ?taxon
+    (SAMPLE(?chemical) AS ?example_chemical)
+  WHERE {
+    ?chemical wdt:P279* target: ;
+              p:P703 ?taxonStatement .
+    ?taxonStatement ps:P703 ?taxon .
+  }
+  GROUP BY ?taxon
+  ORDER BY DESC(?chemicals)
+  LIMIT 250
+} AS %taxons
+WHERE {
+  INCLUDE %taxons
   SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
 } 
-  GROUP BY ?taxon ?taxonLabel
-  ORDER BY DESC(?count)
-  LIMIT 250
+ORDER BY DESC(?chemicals)


### PR DESCRIPTION
Taxa panel in chemical class aspect did not show a chemical class if the taxa was annotated with the chemical class - as oppose to a chemical in the chemical class.

Further change is taxon description, column renaming and example chemical.

Fixes #2367

### Description
SPARQL query change from `wdt:P279+` to `wdt:P279*` and some further edits.

    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* http://127.0.0.1:8100/chemical-class/Q105030048
* http://127.0.0.1:8100/chemical-class/Q41581

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
