### PR TITLE
Update event_people.sparql

### DIFF
--- a/scholia/app/templates/event_people.sparql
+++ b/scholia/app/templates/event_people.sparql
@@ -10,9 +10,15 @@ WITH {
     (GROUP_CONCAT(DISTINCT ?role; separator=", ") AS ?roles) ?person
   WHERE {
     {
-      # speaker
+      # speaker added directly in the target item
       target: wdt:P823 ?person .
       # BIND(wd:Q9379869 AS ?role)
+      BIND("speaker" AS ?role)
+    }
+    UNION
+    {
+      # speaker inferred from presentation items related to the event-target
+      ?presentation wdt:P823 ?person; wdt:P5072 target: 
       BIND("speaker" AS ?role)
     }
     UNION
@@ -56,6 +62,7 @@ WITH {
     ?person (SAMPLE(?work) AS ?example_work)
   WHERE {
     INCLUDE %people .
+    ?person wdt:P31 wd:Q5.
     OPTIONAL { ?work wdt:P50 ?person . }
   }
   GROUP BY ?roles ?person


### PR DESCRIPTION
* This query returns currently also organization. P664 is allowed both for people and organizations. so i added the P31 Q5 in the inner query.
* i added a second speaker sub-query for speaker of an event inferred from presentation-items.

Example for both changes: #vBIB23 https://scholia.toolforge.org/event/Q120378280

Fixes # (issue number, if applicable) 

### Description
> Please include a summary of the change, relevant motivation and context. If possible and applicable, include before and after screenshots and a URL where the changes can be seen.
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* Test A
* Test B

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [ ] My changes generate no new warnings
* [ ] I have not used code from external sources without attribution
* [ ] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [ ] There are no remaining debug statements (print, console.log, ...)
