### PR TITLE
Count all unique items with a P31

### DIFF
--- a/scholia/app/templates/index-statistics_statistics.sparql
+++ b/scholia/app/templates/index-statistics_statistics.sparql
@@ -26,6 +26,7 @@ WHERE {
 { {SELECT (COUNT(*) AS ?c) WHERE {[] wdt:P2427 []} } BIND("Items with a GRID ID" AS ?d)} UNION
 { {SELECT (COUNT(*) AS ?c) WHERE {[] wdt:P2860 []} } BIND("Citations" AS ?d)} UNION
 { {SELECT (COUNT(*) AS ?c) WHERE {[] wdt:P31 wd:Q13442814.} } BIND("Scholarly articles" AS ?d)} UNION
+{ {SELECT (COUNT(*) AS ?c) WHERE {[] wdt:P31 []} } BIND("Things in Wikidata" AS ?d)} UNION
 { {SELECT (COUNT(DISTINCT ?work) AS ?c) WHERE { { ?work wdt:P31 wd:Q45182324 . } UNION { ?work wdt:P793 wd:Q7316896 . } UNION { ?work wdt:P5824 [] . } } } BIND("Retracted articles" AS ?d)}
 BIND (?c AS ?count)
 BIND (?d AS ?description)


### PR DESCRIPTION
Hi Finn, this is a question if an enhancement list this makes sense. It's doesn't seem to slow down the query and answers the worry that articles are the major part of the Wikidata items.