### PR TITLE
Fix #2386 title issue in CEURWS scraper

### DIFF
--- a/scholia/scrape/ceurws.py
+++ b/scholia/scrape/ceurws.py
@@ -130,7 +130,7 @@ def tree_to_papers(tree, proceedings, proceedings_q, iso639='en'):
         paper['full_text_url'] = os.path.join(
             proceedings['url'],
             element.xpath(".//a")[0].attrib['href'])
-        paper['title'] = re.sub(r'\s+', ' ', title_elements[0].text)
+        paper['title'] = re.sub(r'\s+', ' ', title_elements[0].text).strip()
 
         # Authors
         authors = [
@@ -267,6 +267,9 @@ def paper_to_q(paper):
     response = requests.get(WDQS_URL,
                             params={'query': query, 'format': 'json'},
                             headers=HEADERS)
+    if not response.ok:
+        response.raise_for_status()
+
     data = response.json()['results']['bindings']
 
     if len(data) == 0 or not data[0]:
@@ -355,8 +358,9 @@ def proceedings_url_to_proceedings(url, return_tree=False):
     proceedings['urn'] = \
         tree.xpath("//span[@class='CEURURN']")[0].text
 
-    proceedings['title'] = \
-        tree.xpath("//span[@class='CEURFULLTITLE']")[0].text
+    proceedings['title'] = re.sub(
+        r'\s+', ' ',
+        tree.xpath("//span[@class='CEURFULLTITLE']")[0].text).strip()
 
     proceedings['date'] = \
         tree.xpath("//span[@class='CEURPUBDATE']")[0].text


### PR DESCRIPTION
If there was a newline in the title of the CEURWS proceeding then wrong Quickstatements would be generated.
This fix normalize consecutive whitespace to one normal space.

Fixes #2386

### Description
see above

### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [x]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* `ython -m scholia.scrape.ceurws proceedings-url-to-quickstatements https://ceur-ws.org/Vol-3559/` went through alright

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
