### PR TITLE
Removed visible links to Twitter

### DIFF
--- a/scholia/app/templates/base.html
+++ b/scholia/app/templates/base.html
@@ -224,13 +224,6 @@ askQuery("{{ panel }}", `# tool: scholia
 	     }
 	 }
 
-	 if ("P2002" in item.claims) {
-	     var user = {name: item.claims.P2002[0].mainsnak.datavalue.value, prefix: "@"};
-	     var site = { name: "Twitter", url: "https://twitter.com/" };
-	     var logo = { src: "{{ url_for('static', filename='images/twitter.svg') }}" };
-	     socialMediaLink(detailsList, user, site, logo);
-	 }
-
 	 if ("P2037" in item.claims) {
 	     var user = {name: item.claims.P2037[0].mainsnak.datavalue.value, prefix: "@"};
 	     var site = { name: "GitHub", url: "https://github.com/" };
@@ -993,8 +986,7 @@ askQuery("{{ panel }}", `# tool: scholia
     Report technical problems at Scholia's
     <a href="https://github.com/WDscholia/scholia/issues">Issues</a> GitHub page.
     |
-    Follow us on <a href="https://wikis.world/@wdscholia">Mastodon</a> or
-	<a href="https://twitter.com/wdscholia">Twitter</a>.
+    Follow us on <a href="https://wikis.world/@wdscholia">Mastodon</a>.
     <hr>
   </div>
 {% endblock %}


### PR DESCRIPTION
### Description
This patch removes user-visible links to X/Twitter.
    
### Caveats
There may be more left. These can be filed a separate bug reports.

* [x]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

Workflows that depending on looking up Twitter accounts via the web interface will break (but that's intentional).

### Testing
Without the patch, it currently looks like this:

![image](https://github.com/WDscholia/scholia/assets/26721/adccc357-378a-4129-870c-7df7bdb0116e)

After the patch, the link and logo for the X social account is gone.

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [ ] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
