### PR TITLE
Exclude proceedings

### DIFF
--- a/scholia/app/templates/cito-index_articles-by-year.sparql
+++ b/scholia/app/templates/cito-index_articles-by-year.sparql
@@ -8,6 +8,7 @@ select ?year (count(?work) as ?number_of_publications) ?role where {
       OPTIONAL {
         ?work wdt:P31 wd:Q109229154 . bind("explicit" as ?type_)
         ?work wdt:P1433 / rdfs:label ?venue . FILTER (LANG(?venue) = "en")
+        MINUS { ?venue_ wdt:P31 wd:Q1143604 }
       }
     }
     group by ?work ?type_ ?venue


### PR DESCRIPTION
Fixes #2390

### Description
This patch excluded proceedings from showing up in the histogram.
    
### Caveats
Small patch that solves the problem, but nothing more than just that.

Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

### Testing
* Go to https://scholia.toolforge.org/cito/

Check that the three BioHackathon proceedings are not listed:

![image](https://github.com/WDscholia/scholia/assets/26721/f28c9c34-9e92-4a9b-9452-165cfb6f11b2)

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [ ] My changes generate no new warnings
* [ ] I have not used code from external sources without attribution
* [ ] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [ ] There are no remaining debug statements (print, console.log, ...)
