### PR TITLE
Update award-index_statistics.sparql to make the graphic more straightforward

### DIFF
--- a/scholia/app/templates/award-index_statistics.sparql
+++ b/scholia/app/templates/award-index_statistics.sparql
@@ -1,3 +1,4 @@
+# tool: scholia
 #defaultView:ScatterChart
 # Statistics on number of recipients for award wrt. gender
 SELECT ?males ?females ?award ?awardLabel 
@@ -17,7 +18,13 @@ WITH {
   GROUP BY ?award
 } AS %result
 WHERE {
-  INCLUDE %result
+  {INCLUDE %result}
+  UNION
+  {
+    VALUES (?males ?females ?award ?awardLabel) {
+      (2000 2000 wd:Q10578722 "Fictive Award Label for axis")
+    }
+  }
   SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en,da,de,es,fr,jp,nl,no,ru,sv,zh". }
 } 
 ORDER BY DESC(?males) DESC(?female)


### PR DESCRIPTION
### Description

When looking at the current https://scholia.toolforge.org/award/#statistics, the first impression is that gender balance is "not so bad" as it seems there are quite some points above a "1/1 line", but this is heavily biased because the x and y axis do not share the same maximum.
This PR aims at fixing this.
    
### Caveats

Currently, the manual max value has been set to 2,000.

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* Test A
* Test B

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [ ] My changes generate no new warnings
* [ ] I have not used code from external sources without attribution
* [ ] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [ ] There are no remaining debug statements (print, console.log, ...)
