### PR TITLE
Fix #2385 Use full title text for P1476 in OJS scraper

### DIFF
--- a/scholia/qs.py
+++ b/scholia/qs.py
@@ -68,14 +68,16 @@ def paper_to_quickstatements(paper):
     iso639 = paper.get('iso639', 'en')
 
     if 'title' in paper and paper['title']:
+        full_title = normalize_string(paper['title'])
+
         # "Label must be no more than 250 characters long"
-        short_title = normalize_string(paper['title'])[:250]
+        short_title = full_title[:250]
 
         # Label
         qs += u('LAST\tLen\t"{}"\n').format(short_title)
 
-        # Title property
-        qs += u('LAST\tP1476\t{}:"{}"\n').format(iso639, short_title)
+        # Title property, accepts longer strings
+        qs += u('LAST\tP1476\t{}:"{}"\n').format(iso639, full_title)
 
     # Instance of scientific article
     qs += 'LAST\tP31\tQ13442814\n'

--- a/scholia/scrape/ojs.py
+++ b/scholia/scrape/ojs.py
@@ -367,7 +367,7 @@ def scrape_paper_from_url(url):
             entry['full_text_url'] = pdf_urls[0]
 
     # There may be inconsistent metadata for the language.
-    # For for instance, https://tidsskrift.dk/sygdomogsamfund/article/view/579
+    # For instance, https://tidsskrift.dk/sygdomogsamfund/article/view/579
     # "DC.Language" is correct, while "citation_language" is wrong.
     language_as_iso639 = _fields_to_content(
         ['DC.Language', 'citation_language'])


### PR DESCRIPTION
Fixes #2385

### Description
Use complete text for P1476 in OJS Scraper as the field is capable to handling longer text.
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both


### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
