### PR TITLE
Fix #1891 Check for P18 claim which is not deprecated

### DIFF
--- a/scholia/app/templates/base.html
+++ b/scholia/app/templates/base.html
@@ -148,34 +148,41 @@ askQuery("{{ panel }}", `# tool: scholia
     {% endif %}
 
 	if ("P18" in item.claims) {
-	    var imageName = item.claims.P18[0].mainsnak.datavalue.value;
-	    // spaces must be replaced by underscores in the file name
-	    imageName = imageName.replaceAll(" ", "_")
-	    var imageNameMd5 = md5(imageName);
-	    var imageURL = "https://upload.wikimedia.org/wikipedia/commons/thumb/" 
-	    imageURL += imageNameMd5[0] + "/" + imageNameMd5.slice(0,2) + "/"
-	    var filetype = imageName.match(/\.(\w+)$/);
-      var extension = filetype[1].toLowerCase()
-	    if (extension === "tif" || extension === "tiff") {
-	      imageURL += encodeURIComponent(imageName) + "/lossy-page1-500px-" + encodeURIComponent(imageName) + ".jpg";
-	    } else if (extension === "svg") {
-	      imageURL += encodeURIComponent(imageName) + "/500px-" + encodeURIComponent(imageName) + ".png";
-	    } else {
-	      imageURL += encodeURIComponent(imageName) + "/500px-" + encodeURIComponent(imageName);
-	    }
-	    var itemImage = document.getElementById("item-image");
-	    if (itemImage) {
-      itemImage.src = imageURL;
-      itemImage.title = imageName.slice(0, imageName.lastIndexOf('.'));
-      itemImage.setAttribute('alt', imageName);
+        // Find P18 claim which is not deprecated
+        const p18Claim = item.claims.P18.find(function (claim) {
+            return claim.rank !== "deprecated";
+        });
 
-      var link = document.createElement('a');
-      link.href = "https://commons.wikimedia.org/wiki/File:" + encodeURIComponent(imageName);
-      link.style = "max-width: 50%"
-      var parent = itemImage.parentNode;
-      parent.replaceChild(link, itemImage);
-      link.appendChild(itemImage);
-    }
+        if (undefined !== p18Claim) {
+            var imageName = p18Claim.mainsnak.datavalue.value;
+            // spaces must be replaced by underscores in the file name
+            imageName = imageName.replaceAll(" ", "_")
+            var imageNameMd5 = md5(imageName);
+            var imageURL = "https://upload.wikimedia.org/wikipedia/commons/thumb/"
+            imageURL += imageNameMd5[0] + "/" + imageNameMd5.slice(0,2) + "/"
+            var filetype = imageName.match(/\.(\w+)$/);
+            var extension = filetype[1].toLowerCase()
+            if (extension === "tif" || extension === "tiff") {
+              imageURL += encodeURIComponent(imageName) + "/lossy-page1-500px-" + encodeURIComponent(imageName) + ".jpg";
+            } else if (extension === "svg") {
+              imageURL += encodeURIComponent(imageName) + "/500px-" + encodeURIComponent(imageName) + ".png";
+            } else {
+              imageURL += encodeURIComponent(imageName) + "/500px-" + encodeURIComponent(imageName);
+            }
+            var itemImage = document.getElementById("item-image");
+            if (itemImage) {
+              itemImage.src = imageURL;
+              itemImage.title = imageName.slice(0, imageName.lastIndexOf('.'));
+              itemImage.setAttribute('alt', imageName);
+
+              var link = document.createElement('a');
+              link.href = "https://commons.wikimedia.org/wiki/File:" + encodeURIComponent(imageName);
+              link.style = "max-width: 50%"
+              var parent = itemImage.parentNode;
+              parent.replaceChild(link, itemImage);
+              link.appendChild(itemImage);
+            }
+        }
 	}
 
 	function socialMediaLink(detailsList, user, site, logo = '') {


### PR DESCRIPTION
Fixes #1891

### Description
The script checks if there is a claim which is not ranked `deprecated` and selects the first available claim using [Array.prototype.find()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find)
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both


### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [ ] My changes generate no new warnings
* [ ] I have not used code from external sources without attribution
* [ ] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
