### PR TITLE
Fix #1714 - Parse stringified date to datetime in NIPS scraper

### DIFF
--- a/scholia/scrape/nips.py
+++ b/scholia/scrape/nips.py
@@ -31,6 +31,7 @@ The generated quickstatements from `paper-url-to-quickstatements` can be
 submitted to https://quickstatements.toolforge.org/.
 
 """
+from dateutil.parser import parse
 
 from six import b, print_, u
 
@@ -66,6 +67,9 @@ USER_AGENT = "Scholia"
 
 # Year should be the nominal year, - not the year of publication
 YEAR_TO_Q = {
+    "2023": "Q122813142",
+    "2022": "Q121461824",
+    "2021": "Q109681399",
     "2020": "Q100913796",
     "2019": "Q68600639",
     "2018": "Q56580288",
@@ -296,13 +300,13 @@ def scrape_paper_from_url(url):
 
     dates = tree.xpath("//meta[@name='citation_publication_date']/@content")
     if len(dates) > 0:
-        nominal_year = dates[0]
-        year = int(nominal_year)
+        parsed_date = parse(dates[0])
+        year = parsed_date.year
         if year < 2009:
             year += 1
         entry['year'] = str(year)
 
-        entry['published_in_q'] = YEAR_TO_Q.get(nominal_year, None)
+        entry['published_in_q'] = YEAR_TO_Q.get(str(parsed_date.year), None)
 
     # All NIPS papers are in English
     entry['language_q'] = "Q1860"


### PR DESCRIPTION
Fixes #1714

### Description
This change parses the date string "2021-01-01" to a `datetime` using `dateutil` to extract the year.
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
