### PR TITLE
Fix #2406: DOI pattern for DOIs with square brackets

### DIFF
--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -76,7 +76,7 @@ P_PATTERN = re.compile(r'P[1-9]\d*')
 qs_pattern = r'<regex(r"Q[1-9]\d*(?:[^0-9]+Q[1-9]\d*)*"):qs>'
 
 # https://www.crossref.org/blog/dois-and-matching-regular-expressions/
-DOI_PATTERN = re.compile(r'10\.\d{4,9}/[-._;()/:A-Z0-9]+', re.IGNORECASE)
+DOI_PATTERN = re.compile(r'10\.\d{4,9}/[\[\]\-._;()/:A-Z0-9]+', re.IGNORECASE)
 
 # pattern for aspects
 ASPECT_PATTERN = '<regex("[a-zA-Z]+"):aspect>'


### PR DESCRIPTION
Fix #2406 DOI pattern for DOIs with square brackets

Fixes #2406

### Description
Extended regular expression with square brackets
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* Saw that [10.1641/0006-3568(2002)052[0044:PTLBTR]2.0.CO;2](https://doi.org/10.1641/0006-3568%282002%29052%5B0044%3APTLBTR%5D2.0.CO%3B2) worked

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
