### PR TITLE
three new aspects: podcast. - episode, and - season)

### DIFF
--- a/scholia/app/templates/base.html
+++ b/scholia/app/templates/base.html
@@ -178,6 +178,14 @@ askQuery("{{ panel }}", `# tool: scholia
     }
 	}
 
+	if ("P10286" in item.claims) {
+	    var imageURL = item.claims.P10286[0].mainsnak.datavalue.value;
+	    var itemImage = document.getElementById("item-image");
+	    if (itemImage) {
+            itemImage.src = imageURL;
+        }
+    }
+
 	function socialMediaLink(detailsList, user, site, logo = '') {
 	     var html = '';
 	     if (logo) {

--- a/scholia/app/templates/podcast-episode.html
+++ b/scholia/app/templates/podcast-episode.html
@@ -5,6 +5,7 @@
 {% block in_ready %}
 
 {{ sparql_to_table_post('data') }}
+{{ sparql_to_table_post('listings') }}
 {{ sparql_to_table_post('guests') }}
 
 {% endblock %}
@@ -18,11 +19,15 @@
 
 <div id="intro"></div>
 
+<div id="wembedder"></div>
+
 <div id="details"></div>
 
 <table class="table table-hover" id="data-table"></table>
 
-<div id="wembedder"></div>
+<h2 id="listings">Listings</h2>
+
+<table class="table table-hover" id="listings-table"></table>
 
 <h2 id="guests">Guests</h2>
 

--- a/scholia/app/templates/podcast-episode.html
+++ b/scholia/app/templates/podcast-episode.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+
+{% set aspect = "podcast-episode" %}
+
+{% block in_ready %}
+
+{{ sparql_to_table_post('data') }}
+{{ sparql_to_table_post('guests') }}
+
+{% endblock %}
+
+{% block page_actions %}
+{{ super() }}
+{% endblock %}
+
+{% block page_content %}
+<h1 id="h1">Podcast Episode</h1>
+
+<div id="intro"></div>
+
+<div id="details"></div>
+
+<table class="table table-hover" id="data-table"></table>
+
+<div id="wembedder"></div>
+
+<h2 id="guests">Guests</h2>
+
+<table class="table table-hover" id="guests-table"></table>
+
+{% endblock %}
+    

--- a/scholia/app/templates/podcast-episode_data.sparql
+++ b/scholia/app/templates/podcast-episode_data.sparql
@@ -1,0 +1,12 @@
+PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
+
+SELECT DISTINCT ?description ?value ?valueUrl
+WHERE {
+  BIND(target: AS ?podcast)
+  {
+    BIND(1 AS ?order)
+    BIND("Title" AS ?description)
+    ?podcast wdt:P1476 ?value .
+  }
+} 
+ORDER BY ?order

--- a/scholia/app/templates/podcast-episode_data.sparql
+++ b/scholia/app/templates/podcast-episode_data.sparql
@@ -8,5 +8,73 @@ WHERE {
     BIND("Title" AS ?description)
     ?podcast wdt:P1476 ?value .
   }
+  UNION
+  {
+    SELECT
+      (2 AS ?order)
+      ("Presenters" AS ?description)
+      (GROUP_CONCAT(?value_; separator=", ") AS ?value)
+      (CONCAT("../authors/", GROUP_CONCAT(?q; separator=",")) AS ?valueUrl)
+    {
+      BIND(1 AS ?dummy)
+      target: wdt:P371 ?iri .
+      BIND(SUBSTR(STR(?iri), 32) AS ?q) 
+      ?iri rdfs:label ?value_string . 
+      FILTER (LANG(?value_string) = 'en')
+      BIND(COALESCE(?value_string, ?q) AS ?value_)
+    }
+    GROUP BY ?dummy
+  }
+  UNION
+  {
+    ?podcast wdt:P179 ?iri .
+    BIND(SUBSTR(STR(?iri), 32) AS ?q) 
+    ?iri rdfs:label ?value_string .
+    FILTER (LANG(?value_string) = 'en')
+    BIND(STR(?value_string) AS ?value)
+    BIND(CONCAT("../podcast/", ?q) AS ?valueUrl)
+    BIND(3 AS ?order)
+    BIND("Podcast" AS ?description)
+  }
+  UNION
+  {
+    ?podcast wdt:P577 ?publication_datetime .
+    BIND(xsd:date(?publication_datetime) AS ?value)
+    BIND(4 AS ?order)
+    BIND("Publication date" AS ?description)
+  }
+  UNION
+  {
+    ?podcast wdt:P4908 ?iri .
+    BIND(SUBSTR(STR(?iri), 32) AS ?q) 
+    ?iri rdfs:label ?value_string .
+    FILTER (LANG(?value_string) = 'en')
+    BIND(STR(?value_string) AS ?value)
+    BIND(CONCAT("../podcast-season/", ?q) AS ?valueUrl)
+    BIND(5 AS ?order)
+    BIND("Season" AS ?description)
+  }
+  UNION
+  {
+    ?podcast wdt:P155 ?iri .
+    BIND(SUBSTR(STR(?iri), 32) AS ?q) 
+    ?iri rdfs:label ?value_string .
+    FILTER (LANG(?value_string) = 'en')
+    BIND(STR(?value_string) AS ?value)
+    BIND(CONCAT("../podcast-episode/", ?q) AS ?valueUrl)
+    BIND(6 AS ?order)
+    BIND("Previous episode" AS ?description)
+  }
+  UNION
+  {
+    ?podcast wdt:P156 ?iri .
+    BIND(SUBSTR(STR(?iri), 32) AS ?q) 
+    ?iri rdfs:label ?value_string .
+    FILTER (LANG(?value_string) = 'en')
+    BIND(STR(?value_string) AS ?value)
+    BIND(CONCAT("../podcast-episode/", ?q) AS ?valueUrl)
+    BIND(7 AS ?order)
+    BIND("Next episode" AS ?description)
+  }
 } 
 ORDER BY ?order

--- a/scholia/app/templates/podcast-episode_guests.sparql
+++ b/scholia/app/templates/podcast-episode_guests.sparql
@@ -1,0 +1,9 @@
+PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
+
+SELECT DISTINCT ?guest ?guestLabel
+  (CONCAT("/", SUBSTR(STR(?guest), 32)) AS ?guestUrl)
+WHERE {
+  BIND(target: AS ?episode)
+  ?episode wdt:P5030 ?guest .
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+}

--- a/scholia/app/templates/podcast-episode_listings.sparql
+++ b/scholia/app/templates/podcast-episode_listings.sparql
@@ -1,0 +1,32 @@
+PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
+
+# title: listings for this podcast
+SELECT
+  ?Identifier ?IdentifierLabel
+  ?value (SAMPLE(?idUrls) as ?valueUrl)
+  ?IdentifierDescription
+WITH {
+  SELECT ?Identifier ?Value ?formatterurl WHERE {
+    target: ?IDdir ?Value .
+    ?Identifier wikibase:directClaim ?IDdir ;
+            wdt:P31 wd:Q84574746 .
+    OPTIONAL { 
+      ?Identifier wdt:P1630 ?formatterurl .
+    }
+  } LIMIT 500
+} AS %RESULTS {
+  { SELECT * WHERE {
+      INCLUDE %RESULTS
+      BIND(IRI(REPLACE(?formatterurl, '\\\\$1', ENCODE_FOR_URI(str(?Value)))) AS ?idUrls).
+    }
+  } UNION {
+    SELECT * WHERE {
+      INCLUDE %RESULTS
+      BIND(IRI(REPLACE(?formatterurl, '\\\\$1', str(?Value))) AS ?idUrls).
+    }
+  }
+  BIND(CONCAT(?Value, " ↗") AS ?value)
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+}
+GROUP BY ?Identifier ?IdentifierLabel ?IdentifierDescription ?value
+ORDER BY ASC(?IdentifierLabel)

--- a/scholia/app/templates/podcast-index.html
+++ b/scholia/app/templates/podcast-index.html
@@ -52,9 +52,11 @@ Audio and video podcasts.
 	    </div>
 	    <div class="card-body">
 
-<ul>
-  <li><a href="../podcast-season/Q69152103">"Within the Wires season 1"</a> (English)</li>
-</ul>
+	  <ul>
+	    <li><a href="../podcast-season/Q69152103">Within the Wires season 1</a> (English)</li>
+	    <li><a href="../podcast-season/Q116869651">Das kleine Fernsehballett, season 12</a> (German)</li>
+	  </ul>
+
 	    </div>
 	</div>
 

--- a/scholia/app/templates/podcast-index.html
+++ b/scholia/app/templates/podcast-index.html
@@ -5,9 +5,9 @@
 
 {% block in_ready %}
 
+{{ sparql_to_table_post('languages') }}
+
 {% endblock %}
-
-
 
 {% block page_content %}
 
@@ -73,7 +73,16 @@ Audio and video podcasts.
 
         </div>
     </div>
+
+    <h2 id="languages">Languages</h2>
+    
+    This table shows the languages in which the podcasts are spoken.
+    
+    <table class="table table-hover" id="languages-table"></table>
+
 </div>
+
+
 <!--  -->
 {% endblock %}
 

--- a/scholia/app/templates/podcast-index.html
+++ b/scholia/app/templates/podcast-index.html
@@ -1,0 +1,77 @@
+{% extends "base.html" %}
+
+{% set aspect = "podcast-index" %}
+{% block title %}Podcast - Scholia{% endblock %}
+
+{% block in_ready %}
+
+{% endblock %}
+
+
+
+{% block page_content %}
+
+<h1>Podcast</h1>
+
+Audio and video podcasts.
+
+<p>
+    <div class="btn-group">
+	<a title="Sample a random work among all works. This query takes several seconds."
+	   href="random"
+	   class="btn btn-primary">Random podcast</a>
+    </div>
+    <div class="btn-group">
+</p>
+
+<div class="container">
+
+    <h2>Examples</h2>
+
+    <div class="card-deck mb-3">
+	<div class="card mb-4 box-shadow">
+            <div class="card-header">
+		<h4 class="my-0 font-weight-normal">Podcasts</h4>
+            </div>
+            <div class="card-body">
+
+	  <ul>
+	    <li><a href="Q124363332">Science, Quickly</a> (English)</li>
+	    <li><a href="Q124360854">JOSSCast: Open Source for Researchers</a> (English)</li>
+	    <li><a href="Q64023922">Wikipediapodden</a> (Swedish)</li>
+	    <li><a href="Q124262264">De Nedersaksen</a> (Dutch)</li>
+	  </ul>
+
+      </div>
+
+	</div>
+	    
+        <div class="card mb-4 box-shadow">
+	    <div class="card-header">
+		<h4 class="my-0 font-weight-normal">Podcast Seasons</h4>
+	    </div>
+	    <div class="card-body">
+
+<ul>
+  <li><a href="../podcast-season/Q69152103">"Within the Wires season 1"</a> (English)</li>
+</ul>
+	    </div>
+	</div>
+
+        <div class="card mb-4 box-shadow">
+	    <div class="card-header">
+		<h4 class="my-0 font-weight-normal">Podcast Episodes</h4>
+	    </div>
+	    <div class="card-body">
+	  <ul>
+	    <li><a href="../podcast-episode/Q61041513">#46 - Entropy</a> (Polish)</li>
+	    <li><a href="../podcast-episode/Q67590634">Wiki Loves Monuments, kvinnoprojekt, skrivstugor</a> (Swedish)</li>
+	  </ul>
+	    </div>
+
+        </div>
+    </div>
+</div>
+<!--  -->
+{% endblock %}
+

--- a/scholia/app/templates/podcast-index_languages.sparql
+++ b/scholia/app/templates/podcast-index_languages.sparql
@@ -1,0 +1,10 @@
+SELECT ?language ?languageLabel (CONCAT("/podcast/language/", SUBSTR(STR(?language), 32)) AS ?languageUrl)
+  (COUNT(DISTINCT ?podcast) AS ?podcasts)
+WHERE {
+  ?podcast wdt:P31 wd:Q24634210 ; wdt:P407 ?language .
+  BIND(SUBSTR(STR(?language), 32) AS ?q)
+  ?language rdfs:label ?value_string . 
+  FILTER (LANG(?value_string) = 'en')
+  BIND(COALESCE(?value_string, ?q) AS ?languageLabel)
+} GROUP BY ?language ?languageLabel
+  ORDER BY DESC(?podcasts)

--- a/scholia/app/templates/podcast-language.html
+++ b/scholia/app/templates/podcast-language.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+
+{% set aspect = "podcast-language" %}
+
+{% block in_ready %}
+
+{{ sparql_to_table_post('recent-episodes') }}
+{{ sparql_to_table_post('podcast-list') }}
+
+{% endblock %}
+
+{% block page_actions %}
+{{ super() }}
+{% endblock %}
+
+{% block page_content %}
+<h1 id="h1">Podcast</h1>
+
+This page shows information about podcasts in this language.
+
+<div id="details"></div>
+
+<table class="table table-hover" id="data-table"></table>
+
+<h2 id="recent-episodes">Recent notable episodes</h2>
+
+<table class="table table-hover" id="recent-episodes-table"></table>
+
+<h2 id="podcast-list">Podcasts</h2>
+
+<table class="table table-hover" id="podcast-list-table"></table>
+
+{% endblock %}
+    

--- a/scholia/app/templates/podcast-language_podcast-list.sparql
+++ b/scholia/app/templates/podcast-language_podcast-list.sparql
@@ -1,0 +1,16 @@
+PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
+
+SELECT ?podcast ?podcastLabel (CONCAT("/podcast/", SUBSTR(STR(?podcast), 32)) AS ?podcastUrl)
+  (GROUP_CONCAT(?genreWDLabel; separator=", ") AS ?genre)
+WHERE {
+  ?podcast wdt:P31 wd:Q24634210 ; wdt:P407 target: .
+  OPTIONAL {
+    ?podcast wdt:P136 ?iri
+    BIND(SUBSTR(STR(?iri), 32) AS ?q) 
+    ?iri rdfs:label ?value_string . 
+    FILTER (LANG(?value_string) = 'en')
+    BIND(COALESCE(?value_string, ?q) AS ?genreWDLabel)
+  }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+} GROUP BY ?podcast ?podcastLabel
+  ORDER BY DESC(?podcastLabel)

--- a/scholia/app/templates/podcast-language_recent-episodes.sparql
+++ b/scholia/app/templates/podcast-language_recent-episodes.sparql
@@ -1,0 +1,21 @@
+PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
+
+SELECT ?publication_date 
+  ?podcast ?podcastLabel (CONCAT("/podcast/", SUBSTR(STR(?podcast), 32)) AS ?podcastUrl)
+  ?episode ?episodeLabel (CONCAT("/podcast-episode/", SUBSTR(STR(?episode), 32)) AS ?episodeUrl)
+WITH {
+  SELECT DISTINCT ?episode ?podcast (MIN(?publication_date_) AS ?publication_date) WHERE {
+    ?episode wdt:P31 wd:Q61855877 ; wdt:P179 ?podcast .
+    ?podcast wdt:P407 target: .
+    OPTIONAL {
+      ?episode wdt:P577 ?publication_datetime .
+      BIND(xsd:date(?publication_datetime) AS ?publication_date_)
+    }
+  } GROUP BY ?episode ?podcast
+    ORDER BY DESC(?publication_date)
+    LIMIT 50
+} AS %EPISODES WHERE {
+  INCLUDE %EPISODES
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+} GROUP BY ?publication_date ?episode ?episodeLabel ?podcast ?podcastLabel
+  ORDER BY DESC(?publication_date)

--- a/scholia/app/templates/podcast-season.html
+++ b/scholia/app/templates/podcast-season.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+
+{% set aspect = "podcast-season" %}
+
+{% block in_ready %}
+
+{{ sparql_to_table_post('data') }}
+{{ sparql_to_table_post('episodes') }}
+
+{% endblock %}
+
+{% block page_actions %}
+{{ super() }}
+{% endblock %}
+
+{% block page_content %}
+<h1 id="h1">Podcast Season</h1>
+
+<div id="intro"></div>
+
+<div id="details"></div>
+
+<table class="table table-hover" id="data-table"></table>
+
+<div id="wembedder"></div>
+
+<h2 id="seasons">Episodes</h2>
+
+<table class="table table-hover" id="episodes-table"></table>
+
+{% endblock %}
+    

--- a/scholia/app/templates/podcast-season_data.sparql
+++ b/scholia/app/templates/podcast-season_data.sparql
@@ -1,0 +1,32 @@
+PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
+
+SELECT DISTINCT ?description ?value ?valueUrl
+WHERE {
+  BIND(target: AS ?series)
+  {
+    BIND(1 AS ?order)
+    BIND("Title" AS ?description)
+    ?series wdt:P1476 ?value .
+  }
+  UNION
+  {
+    ?series wdt:P179 ?iri .
+    BIND(SUBSTR(STR(?iri), 32) AS ?q) 
+    ?iri rdfs:label ?value_string .
+    FILTER (LANG(?value_string) = 'en')
+    BIND(STR(?value_string) AS ?value)
+    BIND(CONCAT("../podcast/", ?q) AS ?valueUrl)
+    BIND(2 AS ?order)
+    BIND("Podcast" AS ?description)
+  }
+  UNION
+  {
+    SELECT ?description ?order (MAX(?value_) AS ?value) WHERE {
+      BIND(target: AS ?series)
+      ?series wdt:P1113 ?value_ .
+      BIND(3 AS ?order)
+      BIND("Number of episodes" AS ?description)
+    } GROUP BY ?description ?order
+  }
+} 
+ORDER BY ?order

--- a/scholia/app/templates/podcast-season_data.sparql
+++ b/scholia/app/templates/podcast-season_data.sparql
@@ -28,5 +28,27 @@ WHERE {
       BIND("Number of episodes" AS ?description)
     } GROUP BY ?description ?order
   }
-} 
+  UNION
+  {
+    ?series wdt:P155 ?iri .
+    BIND(SUBSTR(STR(?iri), 32) AS ?q)
+    ?iri rdfs:label ?value_string .
+    FILTER (LANG(?value_string) = 'en')
+    BIND(STR(?value_string) AS ?value)
+    BIND(CONCAT("../podcast-season/", ?q) AS ?valueUrl)
+    BIND(6 AS ?order)
+    BIND("Previous season" AS ?description)
+  }
+  UNION
+  {
+    ?series wdt:P156 ?iri .
+    BIND(SUBSTR(STR(?iri), 32) AS ?q)
+    ?iri rdfs:label ?value_string .
+    FILTER (LANG(?value_string) = 'en')
+    BIND(STR(?value_string) AS ?value)
+    BIND(CONCAT("../podcast-season/", ?q) AS ?valueUrl)
+    BIND(7 AS ?order)
+    BIND("Next season" AS ?description)
+  }
+}
 ORDER BY ?order

--- a/scholia/app/templates/podcast-season_episodes.sparql
+++ b/scholia/app/templates/podcast-season_episodes.sparql
@@ -1,0 +1,8 @@
+PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
+
+SELECT DISTINCT ?episode ?episodeLabel
+  (CONCAT("/podcast-episode/", SUBSTR(STR(?episode), 32)) AS ?episodeUrl)
+WHERE {
+  ?episode wdt:P31 wd:Q61855877 ; wdt:P4908 target: .
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+}

--- a/scholia/app/templates/podcast.html
+++ b/scholia/app/templates/podcast.html
@@ -20,11 +20,11 @@
 
 <div id="intro"></div>
 
+<div id="wembedder"></div>
+
 <div id="details"></div>
 
 <table class="table table-hover" id="data-table"></table>
-
-<div id="wembedder"></div>
 
 <h2 id="recent-episodes">Recent episodes</h2>
 

--- a/scholia/app/templates/podcast.html
+++ b/scholia/app/templates/podcast.html
@@ -1,0 +1,44 @@
+{% extends "base.html" %}
+
+{% set aspect = "podcast" %}
+
+{% block in_ready %}
+
+{{ sparql_to_table_post('data') }}
+{{ sparql_to_table_post('recent-episodes') }}
+{{ sparql_to_iframe('topics') }}
+{{ sparql_to_table_post('seasons') }}
+
+{% endblock %}
+
+{% block page_actions %}
+{{ super() }}
+{% endblock %}
+
+{% block page_content %}
+<h1 id="h1">Podcast</h1>
+
+<div id="intro"></div>
+
+<div id="details"></div>
+
+<table class="table table-hover" id="data-table"></table>
+
+<div id="wembedder"></div>
+
+<h2 id="recent-episodes">Recent episodes</h2>
+
+<table class="table table-hover" id="recent-episodes-table"></table>
+
+<h3 id="topics">Topic scores</h3>
+
+<div class="embed-responsive embed-responsive-4by3">
+    <iframe class="embed-responsive-item" id="topics-iframe"></iframe>
+</div>
+
+<h2 id="seasons">Seasons</h2>
+
+<table class="table table-hover" id="seasons-table"></table>
+
+{% endblock %}
+    

--- a/scholia/app/templates/podcast.html
+++ b/scholia/app/templates/podcast.html
@@ -5,6 +5,7 @@
 {% block in_ready %}
 
 {{ sparql_to_table_post('data') }}
+{{ sparql_to_table_post('listings') }}
 {{ sparql_to_table_post('recent-episodes') }}
 {{ sparql_to_iframe('topics') }}
 {{ sparql_to_table_post('seasons') }}
@@ -25,6 +26,10 @@
 <div id="details"></div>
 
 <table class="table table-hover" id="data-table"></table>
+
+<h2 id="listings">Listings</h2>
+
+<table class="table table-hover" id="listings-table"></table>
 
 <h2 id="recent-episodes">Recent episodes</h2>
 

--- a/scholia/app/templates/podcast_data.sparql
+++ b/scholia/app/templates/podcast_data.sparql
@@ -70,6 +70,14 @@ WHERE {
   }
   UNION
   {
+    BIND(7.5 AS ?order)
+    BIND("Google Podcasts" AS ?description)
+    ?podcast wdt:P9003 ?valueUrl_ .
+    BIND(CONCAT("https://www.deezer.com/show/", ENCODE_FOR_URI(?valueUrl_)) AS ?valueUrl)
+    BIND(CONCAT(?valueUrl_, " ↗") AS ?value)
+  }
+  UNION
+  {
     BIND(8 AS ?order)
     BIND("Podchaser" AS ?description)
     ?podcast wdt:P7998 ?valueUrl_ .

--- a/scholia/app/templates/podcast_data.sparql
+++ b/scholia/app/templates/podcast_data.sparql
@@ -52,45 +52,5 @@ WHERE {
     ?podcast wdt:P1019 ?valueUrl .
     BIND("feed" AS ?value)
   }
-  UNION
-  {
-    BIND(6 AS ?order)
-    BIND("Apple Podcasts" AS ?description)
-    ?podcast wdt:P5842 ?valueUrl_ .
-    BIND(CONCAT("https://podcasts.apple.com/podcast/id", ENCODE_FOR_URI(?valueUrl_)) AS ?valueUrl)
-    BIND(CONCAT(?valueUrl_, " ↗") AS ?value)
-  }
-  UNION
-  {
-    BIND(7 AS ?order)
-    BIND("Deezer" AS ?description)
-    ?podcast wdt:P5988 ?valueUrl_ .
-    BIND(CONCAT("https://www.deezer.com/show/", ENCODE_FOR_URI(?valueUrl_)) AS ?valueUrl)
-    BIND(CONCAT(?valueUrl_, " ↗") AS ?value)
-  }
-  UNION
-  {
-    BIND(7.5 AS ?order)
-    BIND("Google Podcasts" AS ?description)
-    ?podcast wdt:P9003 ?valueUrl_ .
-    BIND(CONCAT("https://www.deezer.com/show/", ENCODE_FOR_URI(?valueUrl_)) AS ?valueUrl)
-    BIND(CONCAT(?valueUrl_, " ↗") AS ?value)
-  }
-  UNION
-  {
-    BIND(8 AS ?order)
-    BIND("Podchaser" AS ?description)
-    ?podcast wdt:P7998 ?valueUrl_ .
-    BIND(CONCAT("https://www.podchaser.com/podcasts/", ENCODE_FOR_URI(?valueUrl_)) AS ?valueUrl)
-    BIND(CONCAT(?valueUrl_, " ↗") AS ?value)
-  }
-  UNION
-  {
-    BIND(9 AS ?order)
-    BIND("Spotify" AS ?description)
-    ?podcast wdt:P5916 ?valueUrl_ .
-    BIND(CONCAT("https://open.spotify.com/show/", ENCODE_FOR_URI(?valueUrl_)) AS ?valueUrl)
-    BIND(CONCAT(?valueUrl_, " ↗") AS ?value)
-  }
 } 
 ORDER BY ?order

--- a/scholia/app/templates/podcast_data.sparql
+++ b/scholia/app/templates/podcast_data.sparql
@@ -1,0 +1,56 @@
+PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
+
+SELECT DISTINCT ?description ?value ?valueUrl
+WHERE {
+  BIND(target: AS ?podcast)
+  {
+    BIND(1 AS ?order)
+    BIND("Title" AS ?description)
+    ?podcast wdt:P1476 ?value .
+  }
+  UNION
+  {
+    SELECT
+      (2 AS ?order)
+      ("Presenters" AS ?description)
+      (GROUP_CONCAT(?value_; separator=", ") AS ?value)
+      (CONCAT("../authors/", GROUP_CONCAT(?q; separator=",")) AS ?valueUrl)
+    {
+      BIND(1 AS ?dummy)
+      target: wdt:P371 ?iri .
+      BIND(SUBSTR(STR(?iri), 32) AS ?q) 
+      ?iri rdfs:label ?value_string . 
+      FILTER (LANG(?value_string) = 'en')
+      BIND(COALESCE(?value_string, ?q) AS ?value_)
+    }
+    GROUP BY ?dummy
+  }
+  UNION
+  {
+    BIND(3 AS ?order)
+    BIND("Language" AS ?description)
+    ?podcast wdt:P407 ?iri .
+    BIND(SUBSTR(STR(?iri), 32) AS ?q) 
+    ?iri rdfs:label ?value_string .
+    FILTER (LANG(?value_string) = 'en')
+    BIND(STR(?value_string) AS ?value)
+    BIND(CONCAT("../language/", ?q) AS ?valueUrl)
+  }
+  UNION
+  {
+    SELECT ?description ?order (MAX(?value_) AS ?value) WHERE {
+      BIND(target: AS ?podcast)
+      ?podcast wdt:P1113 ?value_ .
+      BIND(4 AS ?order)
+      BIND("Number of episodes" AS ?description)
+    } GROUP BY ?description ?order
+  }
+  UNION
+  {
+    BIND(5 AS ?order)
+    BIND("Web feed" AS ?description)
+    ?podcast wdt:P1019 ?valueUrl .
+    BIND("feed" AS ?value)
+  }
+} 
+ORDER BY ?order

--- a/scholia/app/templates/podcast_data.sparql
+++ b/scholia/app/templates/podcast_data.sparql
@@ -34,7 +34,7 @@ WHERE {
     ?iri rdfs:label ?value_string .
     FILTER (LANG(?value_string) = 'en')
     BIND(STR(?value_string) AS ?value)
-    BIND(CONCAT("../language/", ?q) AS ?valueUrl)
+    BIND(CONCAT("../podcast/language/", ?q) AS ?valueUrl)
   }
   UNION
   {

--- a/scholia/app/templates/podcast_data.sparql
+++ b/scholia/app/templates/podcast_data.sparql
@@ -52,5 +52,37 @@ WHERE {
     ?podcast wdt:P1019 ?valueUrl .
     BIND("feed" AS ?value)
   }
+  UNION
+  {
+    BIND(6 AS ?order)
+    BIND("Apple Podcasts" AS ?description)
+    ?podcast wdt:P5842 ?valueUrl_ .
+    BIND(CONCAT("https://podcasts.apple.com/podcast/id", ENCODE_FOR_URI(?valueUrl_)) AS ?valueUrl)
+    BIND(CONCAT(?valueUrl_, " ↗") AS ?value)
+  }
+  UNION
+  {
+    BIND(7 AS ?order)
+    BIND("Deezer" AS ?description)
+    ?podcast wdt:P5988 ?valueUrl_ .
+    BIND(CONCAT("https://www.deezer.com/show/", ENCODE_FOR_URI(?valueUrl_)) AS ?valueUrl)
+    BIND(CONCAT(?valueUrl_, " ↗") AS ?value)
+  }
+  UNION
+  {
+    BIND(8 AS ?order)
+    BIND("Podchaser" AS ?description)
+    ?podcast wdt:P7998 ?valueUrl_ .
+    BIND(CONCAT("https://www.podchaser.com/podcasts/", ENCODE_FOR_URI(?valueUrl_)) AS ?valueUrl)
+    BIND(CONCAT(?valueUrl_, " ↗") AS ?value)
+  }
+  UNION
+  {
+    BIND(9 AS ?order)
+    BIND("Spotify" AS ?description)
+    ?podcast wdt:P5916 ?valueUrl_ .
+    BIND(CONCAT("https://open.spotify.com/show/", ENCODE_FOR_URI(?valueUrl_)) AS ?valueUrl)
+    BIND(CONCAT(?valueUrl_, " ↗") AS ?value)
+  }
 } 
 ORDER BY ?order

--- a/scholia/app/templates/podcast_listings.sparql
+++ b/scholia/app/templates/podcast_listings.sparql
@@ -1,0 +1,32 @@
+PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
+
+# title: listings for this podcast
+SELECT
+  ?Identifier ?IdentifierLabel
+  ?value (SAMPLE(?idUrls) as ?valueUrl)
+  ?IdentifierDescription
+WITH {
+  SELECT ?Identifier ?Value ?formatterurl WHERE {
+    target: ?IDdir ?Value .
+    ?Identifier wikibase:directClaim ?IDdir ;
+            wdt:P31 wd:Q84612171 .
+    OPTIONAL { 
+      ?Identifier wdt:P1630 ?formatterurl .
+    }
+  } LIMIT 500
+} AS %RESULTS {
+  { SELECT * WHERE {
+      INCLUDE %RESULTS
+      BIND(IRI(REPLACE(?formatterurl, '\\\\$1', ENCODE_FOR_URI(str(?Value)))) AS ?idUrls).
+    }
+  } UNION {
+    SELECT * WHERE {
+      INCLUDE %RESULTS
+      BIND(IRI(REPLACE(?formatterurl, '\\\\$1', str(?Value))) AS ?idUrls).
+    }
+  }
+  BIND(CONCAT(?Value, " ↗") AS ?value)
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+}
+GROUP BY ?Identifier ?IdentifierLabel ?IdentifierDescription ?value
+ORDER BY ASC(?IdentifierLabel)

--- a/scholia/app/templates/podcast_recent-episodes.sparql
+++ b/scholia/app/templates/podcast_recent-episodes.sparql
@@ -1,0 +1,19 @@
+PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
+
+SELECT ?publication_date ?episode ?episodeLabel
+  (CONCAT("/podcast-episode/", SUBSTR(STR(?episode), 32)) AS ?episodeUrl)
+WITH {
+  SELECT DISTINCT ?episode (MIN(?publication_date_) AS ?publication_date) WHERE {
+    ?episode wdt:P31 wd:Q61855877 ; wdt:P179 target: .
+    OPTIONAL {
+      ?episode wdt:P577 ?publication_datetime .
+      BIND(xsd:date(?publication_datetime) AS ?publication_date_)
+    }
+  } GROUP BY ?episode
+    ORDER BY DESC(?publication_date)
+    LIMIT 50
+} AS %EPISODES WHERE {
+  INCLUDE %EPISODES
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+} GROUP BY ?publication_date ?episode ?episodeLabel
+ORDER BY DESC(?publication_date)

--- a/scholia/app/templates/podcast_seasons.sparql
+++ b/scholia/app/templates/podcast_seasons.sparql
@@ -1,0 +1,12 @@
+PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
+
+SELECT DISTINCT ?season ?seasonLabel
+  (CONCAT("/podcast-season/", SUBSTR(STR(?season), 32)) AS ?seasonUrl)
+  (MAX(?count) AS ?episodeCount)
+WHERE {
+  ?season wdt:P31 wd:Q69154911 ; wdt:P179 target: .
+  OPTIONAL {
+    ?season wdt:P1113 ?count .
+  }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+} GROUP BY ?season ?seasonLabel ?seasonUrl

--- a/scholia/app/templates/podcast_topics.sparql
+++ b/scholia/app/templates/podcast_topics.sparql
@@ -1,0 +1,29 @@
+#defaultView:BubbleChart
+PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
+
+SELECT ?score ?topic ?topicLabel
+WITH {
+  SELECT
+    (SUM(?score_) AS ?score)
+    ?topic
+  WHERE {
+    { 
+      target: wdt:P921 ?topic .
+      BIND(20 AS ?score_)
+    }
+    UNION
+    {
+      SELECT (3 AS ?score_) ?topic WHERE {
+        ?episode wdt:P179 target: ;
+              wdt:P921 ?topic . 
+      }
+    }
+  }
+  GROUP BY ?topic
+} AS %results 
+WHERE {
+  INCLUDE %results
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+}
+ORDER BY DESC(?score)
+LIMIT 200

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -1906,6 +1906,19 @@ def show_podcast_random():
     return redirect(url_for('app.show_podcast', q=q), code=302)
 
 
+@main.route('/podcast/language/' + q_pattern)
+def show_podcast_in_language(q):
+    """Redirect to random podcast.
+
+    Returns
+    -------
+    reponse : werkzeug.wrappers.Response
+        Redirect
+
+    """
+    return render_template('podcast-language.html', q=q)
+
+
 @main.route('/podcast/')
 def show_podcast_index():
     """Return rendered HTML index page for podcasts.

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -1850,7 +1850,6 @@ def show_podcast(q):
         Rendered HTML.
 
     """
-    entities = wb_get_entities([q])
     return render_template(
         'podcast.html', q=q)
 
@@ -1870,7 +1869,6 @@ def show_podcast_season(q):
         Rendered HTML.
 
     """
-    entities = wb_get_entities([q])
     return render_template(
         'podcast-season.html', q=q)
 
@@ -1890,7 +1888,6 @@ def show_podcast_episode(q):
         Rendered HTML.
 
     """
-    entities = wb_get_entities([q])
     return render_template(
         'podcast-episode.html', q=q)
 

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -22,7 +22,8 @@ from ..query import (arxiv_to_qs, cas_to_qs, atomic_symbol_to_qs, doi_to_qs,
                      twitter_to_qs, cordis_to_qs, mesh_to_qs, pubmed_to_qs,
                      lipidmaps_to_qs, ror_to_qs, wikipathways_to_qs,
                      pubchem_to_qs, atomic_number_to_qs, ncbi_taxon_to_qs,
-                     ncbi_gene_to_qs, uniprot_to_qs, random_work)
+                     ncbi_gene_to_qs, uniprot_to_qs, random_work,
+                     random_podcast)
 from ..utils import sanitize_q, remove_special_characters_url
 from ..wikipedia import q_to_bibliography_templates
 
@@ -1832,6 +1833,93 @@ def show_topics(qs):
         return redirect(url_for('app.show_topic', q=qs[0]), code=301)
     else:
         return render_template('topics.html', qs=qs)
+
+
+@main.route('/podcast/' + q_pattern)
+def show_podcast(q):
+    """Return html render page for a specific podcast.
+
+    Parameters
+    ----------
+    q : str
+        Wikidata item identifier.
+
+    Returns
+    -------
+    html : str
+        Rendered HTML.
+
+    """
+    entities = wb_get_entities([q])
+    return render_template(
+        'podcast.html', q=q)
+
+
+@main.route('/podcast-season/' + q_pattern)
+def show_podcast_season(q):
+    """Return html render page for a specific podcast season.
+
+    Parameters
+    ----------
+    q : str
+        Wikidata item identifier.
+
+    Returns
+    -------
+    html : str
+        Rendered HTML.
+
+    """
+    entities = wb_get_entities([q])
+    return render_template(
+        'podcast-season.html', q=q)
+
+
+@main.route('/podcast-episode/' + q_pattern)
+def show_podcast_episode(q):
+    """Return html render page for a specific podcast episode.
+
+    Parameters
+    ----------
+    q : str
+        Wikidata item identifier.
+
+    Returns
+    -------
+    html : str
+        Rendered HTML.
+
+    """
+    entities = wb_get_entities([q])
+    return render_template(
+        'podcast-episode.html', q=q)
+
+
+@main.route('/podcast/random')
+def show_podcast_random():
+    """Redirect to random podcast.
+
+    Returns
+    -------
+    reponse : werkzeug.wrappers.Response
+        Redirect
+
+    """
+    q = random_podcast()
+    return redirect(url_for('app.show_podcast', q=q), code=302)
+
+
+@main.route('/podcast/')
+def show_podcast_index():
+    """Return rendered HTML index page for podcasts.
+
+    Returns
+    -------
+    html : str
+        Rendered HTML index page for podcasts.
+
+    """
+    return render_template('podcast-index.html')
 
 
 @main.route('/chemical/' + q_pattern)

--- a/scholia/query.py
+++ b/scholia/query.py
@@ -1330,6 +1330,18 @@ def q_to_class(q):
             'Q22325163',  # macromolecular complex
             ]):
         class_ = 'complex'
+    elif set(classes).intersection([
+            'Q24634210',  # podcast
+            ]):
+        class_ = 'podcast'
+    elif set(classes).intersection([
+            'Q69154911',  # podcast season
+            ]):
+        class_ = 'podcast_season'
+    elif set(classes).intersection([
+            'Q61855877',  # podcast episode
+            ]):
+        class_ = 'podcast_episode'
     elif ('Q16695773' in classes):  # wikiproject
         class_ = 'wikiproject'
     else:

--- a/scholia/query.py
+++ b/scholia/query.py
@@ -25,6 +25,7 @@ Usage:
   scholia.query q-to-label <q>
   scholia.query q-to-class <q>
   scholia.query random-author
+  scholia.query random-podcast
   scholia.query random-work
   scholia.query ror-to-q <rorid>
   scholia.query twitter-to-q <twitter>
@@ -1748,6 +1749,43 @@ def random_work():
     else:
         # Fallback
         q = "Q21146099"
+    return q
+
+
+def random_podcast():
+    """Return random podcast.
+
+    Sample a podcast randomly from Wikidata by a call to the Wikidata
+    Query Service.
+
+    Returns
+    -------
+    q : str
+        Wikidata identifier.
+
+    Notes
+    -----
+    The work returned is not necessarily a podcast.
+
+    The algorithm uses a somewhat hopeful randomization and if no work is
+    found it falls back on Q21146099.
+
+    Examples
+    --------
+    >>> q = random_work()
+    >>> q.startswith('Q')
+    True
+
+    """
+    query = """SELECT ?podcast {{
+                 ?podcast wdt:P31 wd:Q24634210 .
+               }}"""
+    bindings = query_to_bindings(query)
+    if len(bindings) > 0:
+        q = bindings[randrange(1, len(bindings))]['podcast']['value'][31:]
+    else:
+        # Fallback
+        q = "Q124363332"
     return q
 
 


### PR DESCRIPTION
See https://github.com/WDscholia/scholia/issues/2414

### Description
Implements aspects for podcasts.
    
### Caveats
The current PR has reasonable stubs, but particularly the `podcast episode` aspect is a bit boring right now.

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [x]  This change requires a documentation update
    * [x]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

#### Codacy Warning

The current PR causes a Codacy warning for a line of code where a random call is made for the "Random podcast" button, following the approach of other random buttons:

![image](https://github.com/WDscholia/scholia/assets/26721/0c7cf419-654b-4144-a156-4e24393b213e)

I assume this risk is acceptable. I cannot think of an attack using this approach, e.g. allowing people to also end up on an advertisement item in Wikidata. Nor worse.

*If you make changes to the Python code*
  
* [x]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
The `podcast` index page has a number of examples: http://127.0.0.1:8100/podcast/ (see below screenshot)

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [ ] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [ ] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [ ] There are no remaining debug statements (print, console.log, ...)
