### PR TITLE
Moved the 'details' <div> element right after the 'wembedder' <div> in dataset.html to match the HTML structure of the other templates.

### DIFF
--- a/scholia/app/templates/dataset.html
+++ b/scholia/app/templates/dataset.html
@@ -23,13 +23,14 @@
 
 <div id="intro"></div>
 
+<div id="details"></div>
+
 <div id="wembedder"></div>
 
 <h2 id="identifiers">Identifiers</h2>
 
 <table class="table table-hover" id="identifiers-table"></table>
 
-<div id="details"></div>
 
 <table class="table table-hover" id="data-table"></table>
 

--- a/scholia/app/templates/dataset.html
+++ b/scholia/app/templates/dataset.html
@@ -23,9 +23,9 @@
 
 <div id="intro"></div>
 
-<div id="details"></div>
-
 <div id="wembedder"></div>
+
+<div id="details"></div>
 
 <h2 id="identifiers">Identifiers</h2>
 


### PR DESCRIPTION
Fixes #2421 

### Description
Moved the  'details' `<div>` element right after the 'wembedder' `<div>` in `dataset.html` to match the HTML structure of the other templates, the details of the dataset is now appropriately placed like other templates. 

### Caveats
No breaking changes introduced. No new dependencies added.

### Testing
Tested the updated HTML and the URL is placed perfectly

### Checklist
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered accessibility in my implementation
* [x] There are no remaining debug statements (print, console.log, ...)