### PR TITLE
Ensure Article Titles with Dashes are Handled Appropriately for Identified Papers

### DIFF
--- a/scholia/scrape/ojs.py
+++ b/scholia/scrape/ojs.py
@@ -319,7 +319,6 @@ def scrape_paper_from_url(url):
     title = _fields_to_content(['citation_title', 'DC.Title',
                                 'DC.Title.Alternative'])
     if title is not None:
-        #original_title = title  # Store the original title
         q = paper_to_q(entry)
         if not q:  # If not identified before modification
             # Replace dash or colon without altering surrounding spaces

--- a/scholia/scrape/ojs.py
+++ b/scholia/scrape/ojs.py
@@ -319,7 +319,20 @@ def scrape_paper_from_url(url):
     title = _fields_to_content(['citation_title', 'DC.Title',
                                 'DC.Title.Alternative'])
     if title is not None:
-        entry['title'] = title
+        original_title = title  # Store the original title
+        q = paper_to_q(entry)
+        if not q:  # If not identified before modification
+            # Replace dash or colon without altering surrounding spaces
+            title = title.replace(" –", ":").replace("– ", ":")
+            entry['title'] = title
+            q = paper_to_q(entry)
+            if q:  # If identified after modification
+                entry['title'] = title  # Plug in the modified title
+            else:
+                entry['title'] = original_title  # Plug in the original title
+        else:
+            entry['title'] = original_title
+
 
     citation_date = _fields_to_content(['citation_date', 'DC.Date.issued'])
     if citation_date is not None:

--- a/scholia/scrape/ojs.py
+++ b/scholia/scrape/ojs.py
@@ -319,7 +319,7 @@ def scrape_paper_from_url(url):
     title = _fields_to_content(['citation_title', 'DC.Title',
                                 'DC.Title.Alternative'])
     if title is not None:
-        original_title = title  # Store the original title
+        #original_title = title  # Store the original title
         q = paper_to_q(entry)
         if not q:  # If not identified before modification
             # Replace dash or colon without altering surrounding spaces
@@ -330,11 +330,11 @@ def scrape_paper_from_url(url):
                 if q:  # If identified after modification
                     entry['title'] = modified_title  # Plug in the modified title
                 else:
-                    entry['title'] = original_title  # Plug in the original title
+                    entry['title'] = title  # Plug in the original title
             else:
-                entry['title'] = original_title
+                entry['title'] = title
         else:
-            entry['title'] = original_title
+            entry['title'] = title
 
 
     citation_date = _fields_to_content(['citation_date', 'DC.Date.issued'])

--- a/scholia/scrape/ojs.py
+++ b/scholia/scrape/ojs.py
@@ -323,13 +323,16 @@ def scrape_paper_from_url(url):
         q = paper_to_q(entry)
         if not q:  # If not identified before modification
             # Replace dash or colon without altering surrounding spaces
-            title = title.replace(" –", ":").replace("– ", ":")
-            entry['title'] = title
-            q = paper_to_q(entry)
-            if q:  # If identified after modification
-                entry['title'] = title  # Plug in the modified title
+            modified_title = title.replace(" –", ":").replace("– ", ":")
+            if modified_title != title:  # Check if replacement is made
+                entry['title'] = modified_title
+                q = paper_to_q(entry)
+                if q:  # If identified after modification
+                    entry['title'] = modified_title  # Plug in the modified title
+                else:
+                    entry['title'] = original_title  # Plug in the original title
             else:
-                entry['title'] = original_title  # Plug in the original title
+                entry['title'] = original_title  
         else:
             entry['title'] = original_title
 

--- a/scholia/scrape/ojs.py
+++ b/scholia/scrape/ojs.py
@@ -332,7 +332,7 @@ def scrape_paper_from_url(url):
                 else:
                     entry['title'] = original_title  # Plug in the original title
             else:
-                entry['title'] = original_title  
+                entry['title'] = original_title
         else:
             entry['title'] = original_title
 


### PR DESCRIPTION
Fixes #2420

### Description
This PR modifies the code to ensure that article titles containing a dash are only replaced with a colon if the article is not identified. If the article is identified after the modification, the modified title is used; otherwise, the original title with the dash is retained.

### Caveats
No caveats.

### Testing
1. Test with an identified article containing a dash in the title.
2. Test with an unidentified article containing a dash in the title.
3. Verify that the title modification behaves as expected in both cases.

### Checklist
* [x] My code passes the tox check, I can receive warnings about tests, documentation, or both
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered accessibility in my implementation
* [x] There are no remaining debug statements (print, console.log, ...)

