### PR TITLE
Add lazy loading for iframe content in sparqlToIframe function

### DIFF
--- a/scholia/app/static/scholia.js
+++ b/scholia/app/static/scholia.js
@@ -418,11 +418,36 @@ function sparqlToDataTable(sparql, element, filename, options = {}) {
 function sparqlToIframe(sparql, element, filename) {
     let $iframe = $(element);
     var url = "https://query.wikidata.org/embed.html#" + encodeURIComponent(sparql);
-    $iframe.attr('src', url);
+    $iframe.attr('data-src', url);
     $iframe.attr('loading', 'lazy');
 
     const wikidata_sparql = "https://query.wikidata.org/sparql?query=" + encodeURIComponent(sparql);
     const wikidata_query = "https://query.wikidata.org/#" + encodeURIComponent(sparql);
+
+    // Define the options for the Intersection Observer
+    const options = {
+        root: null,
+        rootMargin: '0px',
+        threshold: 0.1 // Trigger when 10% of the element is visible
+    };
+
+    // Create a new Intersection Observer instance
+    const observer = new IntersectionObserver((entries, observer) => {
+        entries.forEach(entry => {
+            // If the iframe enters the viewport, load its content
+            if (entry.isIntersecting) {
+                const src = $iframe.attr('data-src');
+                if (src) {
+                    $iframe.attr('src', src);
+                    // Unobserve the iframe to stop observing once loaded
+                    observer.unobserve($iframe[0]);
+                }
+            }
+        });
+    }, options);
+
+    // Start observing the iframe
+    observer.observe($iframe[0]);
 
     $.ajax({
         url: wikidata_sparql,


### PR DESCRIPTION
Fixes #1652 Pr which seems lazy loading not working and causing memory problems.

### Description
Enhances the `sparqlToIframe` function by implementing lazy loading for `iframe` content. The function now utilizes Intersection Observer to defer the loading of iframe content until it enters the viewport, improving page load performance by only loading content when it becomes visible to the user. The URL for the iframe content is stored in a data-src attribute, and the src attribute is set dynamically when the iframe enters the viewport. 

### Caveats

No caveats.

### Testing
Tested some of #615 with google lighthouse and saw performance improvements and better memory usage.   

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
