### PR TITLE
Implement different podcast language page URL pattern

### DIFF
--- a/scholia/app/templates/podcast-index_languages.sparql
+++ b/scholia/app/templates/podcast-index_languages.sparql
@@ -1,4 +1,4 @@
-SELECT ?language ?languageLabel (CONCAT("/podcast/language/", SUBSTR(STR(?language), 32)) AS ?languageUrl)
+SELECT ?language ?languageLabel (CONCAT("/language/", SUBSTR(STR(?language), 32), "/podcast") AS ?languageUrl)
   (COUNT(DISTINCT ?podcast) AS ?podcasts)
 WHERE {
   ?podcast wdt:P31 wd:Q24634210 ; wdt:P407 ?language .

--- a/scholia/app/templates/podcast_data.sparql
+++ b/scholia/app/templates/podcast_data.sparql
@@ -34,7 +34,7 @@ WHERE {
     ?iri rdfs:label ?value_string .
     FILTER (LANG(?value_string) = 'en')
     BIND(STR(?value_string) AS ?value)
-    BIND(CONCAT("../podcast/language/", ?q) AS ?valueUrl)
+    BIND(CONCAT("../language/", ?q, "/podcast") AS ?valueUrl)
   }
   UNION
   {

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -1906,7 +1906,7 @@ def show_podcast_random():
     return redirect(url_for('app.show_podcast', q=q), code=302)
 
 
-@main.route('/podcast/language/' + q_pattern)
+@main.route('/language/' + q_pattern + '/podcast')
 def show_podcast_in_language(q):
     """Redirect to random podcast.
 


### PR DESCRIPTION
Fixes #2422

### Description
Changes the URL pattern for the page about podcasts in a certain language. See the request in the issue report.
    
### Caveats
I scanned the code and tests the local live instance, and I think I got all the places where the URL pattern is used. This is in the routing table, but also in two places where there is a link to the language.
  
### Testing

* Go to http://127.0.0.1:8100/podcast/Q124262264 (and notice the `Dutch` language in the data table)
* Click the language link to http://127.0.0.1:8100/language/Q7411/podcast

Before this patch, it linked to https://scholia.toolforge.org/podcast/language/Q7411 which is should not anymore.

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
