### PR TITLE
Added support for nanopublications as source

### DIFF
--- a/scholia/app/templates/cito-index_articles-by-year.sparql
+++ b/scholia/app/templates/cito-index_articles-by-year.sparql
@@ -3,12 +3,22 @@ select ?year (count(?work) as ?number_of_publications) ?role where {
   {
     select ?work (min(?years) as ?year) ?type_ ?venue where {
       ?work wdt:P577 ?dates ;
-            p:P2860 / pq:P3712 / wdt:P31 wd:Q96471816 .
+            p:P2860 ?citesStatement .
+      ?citesStatement pq:P3712 / wdt:P31 wd:Q96471816 .
       bind(str(year(?dates)) as ?years) .
       OPTIONAL {
         ?work wdt:P31 wd:Q109229154 . bind("explicit" as ?type_)
         ?work wdt:P1433 ?venue_ . ?venue_ rdfs:label ?venue . FILTER (LANG(?venue) = "en")
         MINUS { ?venue_ wdt:P31 wd:Q1143604 }
+      }
+      OPTIONAL {
+        bind("nanopub" as ?type_) bind("Nanopublication" as ?venue)
+        ?citesStatement prov:wasDerivedFrom ?reference .
+        ?reference pr:P854 ?referenceURL .
+        FILTER (
+          strstarts(str(?referenceURL), "https://w3id.org/np/") ||
+          strstarts(str(?referenceURL), "http://purl.org/np/")
+        )
       }
     }
     group by ?work ?type_ ?venue

--- a/scholia/app/templates/cito-index_statistics.sparql
+++ b/scholia/app/templates/cito-index_statistics.sparql
@@ -45,6 +45,17 @@ WITH {
     ?citoDataset wdt:P31 wd:Q117357566 .
   }
 } AS %citoDatasets
+WITH {
+  SELECT (COUNT(DISTINCT ?citoNanopub) AS ?count) WHERE {
+    ?citoNanopub p:P2860 ?citationStatement .
+    ?citationStatement pq:P3712 / wdt:P31 wd:Q96471816 ;
+      prov:wasDerivedFrom / pr:P854 ?referenceURL .
+    FILTER (
+      strstarts(str(?referenceURL), "https://w3id.org/np/") ||
+      strstarts(str(?referenceURL), "http://purl.org/np/")
+    )
+  }
+} AS %citoNanopubs
 WHERE {
   {
     INCLUDE %annotions
@@ -89,6 +100,11 @@ WHERE {
   {
     INCLUDE %citoJournalsExplicit
     BIND("Number of venues with explicit CiTO annotation" AS ?description)
+  }
+  UNION
+  {
+    INCLUDE %citoNanopubs
+    BIND("Number of nanopublications with explicit CiTO annotation" AS ?description)
   }
 }
 ORDER BY DESC(?count)


### PR DESCRIPTION
### Description
This patch implements support for CiTO intention annotations from nanopublications. After a [discussion on Mastodon](https://social.edu.nl/@egonw/112011219884262416), there now is a [nanopublication template](https://nanodash.knowledgepixels.com/publish?2&template=https://w3id.org/np/RAX_4tWTyjFpO6nz63s14ucuejd64t2mK3IBlkwZ7jjLo&template-version=latest) for such annotation and a [SPARQL query](https://tinyurl.com/get-cito-nanopubs) can extract this and add this in an automated fashion to Wikidata.

I have [proposed to write a FAIR CookBook recipe](https://github.com/FAIRplus/the-fair-cookbook/issues/628).
    
### Caveats

None that I can think of. The runtime is still quite fast.

### Testing

Patch one: The query now adds a "Nanopublication" source (venue), as shown below after "unselecting" the other sources:

![image](https://github.com/WDscholia/scholia/assets/26721/0b843cbe-b4c2-48fc-8681-b3030568f399)

Patch two: this adds a `Number of nanopublications with explicit CiTO annotation` line to the statistics panel, like:

![image](https://github.com/WDscholia/scholia/assets/26721/6751a5c6-5c29-46af-9c3b-5b7c2621ee6f)


### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [ ] My changes generate no new warnings
* [ ] I have not used code from external sources without attribution
* [ ] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [ ] There are no remaining debug statements (print, console.log, ...)
