### PR TITLE
Fix DOI to QS generation on DOI 404 page

### DIFF
--- a/scholia/app/templates/404-doi.html
+++ b/scholia/app/templates/404-doi.html
@@ -5,11 +5,11 @@
 
 <script src="{{ url_for('static', filename='js/citation.js') }}"></script>
 <script>
-const c = require('citation-js')
+const Cite = require('citation-js').Cite
 try {
-  let example = new c.Cite([ '{{ doi }}' ])
+  let example = new Cite('https://doi.org/{{ doi }}', { forceType: '@doi/api' })
   let output = example.format('quickstatements')
-  $( '#qs' ).append( output );
+  $( '#qs' ).text( output );
   output = encodeURIComponent(
     output.replaceAll('\t', '|')
           .replaceAll('\n', '||'))


### PR DESCRIPTION
### Description
- Bypass the DOI detection system of Citation.js to always attempt to query the route parameter as a DOI. E.g. https://scholia.toolforge.org/doi/10.1021/ci040131+
- Same DOI: makes sure HTML cannot be injected, even if it's just `<i>`
- Do not pollute the `c` variable in the global scope

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
