### PR TITLE
Fix style issue in Faresh9 title modification

### DIFF
--- a/scholia/app/static/scholia.js
+++ b/scholia/app/static/scholia.js
@@ -418,11 +418,36 @@ function sparqlToDataTable(sparql, element, filename, options = {}) {
 function sparqlToIframe(sparql, element, filename) {
     let $iframe = $(element);
     var url = "https://query.wikidata.org/embed.html#" + encodeURIComponent(sparql);
-    $iframe.attr('src', url);
+    $iframe.attr('data-src', url);
     $iframe.attr('loading', 'lazy');
 
     const wikidata_sparql = "https://query.wikidata.org/sparql?query=" + encodeURIComponent(sparql);
     const wikidata_query = "https://query.wikidata.org/#" + encodeURIComponent(sparql);
+
+    // Define the options for the Intersection Observer
+    const options = {
+        root: null,
+        rootMargin: '0px',
+        threshold: 0.1 // Trigger when 10% of the element is visible
+    };
+
+    // Create a new Intersection Observer instance
+    const observer = new IntersectionObserver((entries, observer) => {
+        entries.forEach(entry => {
+            // If the iframe enters the viewport, load its content
+            if (entry.isIntersecting) {
+                const src = $iframe.attr('data-src');
+                if (src) {
+                    $iframe.attr('src', src);
+                    // Unobserve the iframe to stop observing once loaded
+                    observer.unobserve($iframe[0]);
+                }
+            }
+        });
+    }, options);
+
+    // Start observing the iframe
+    observer.observe($iframe[0]);
 
     $.ajax({
         url: wikidata_sparql,

--- a/scholia/app/static/scholia.js
+++ b/scholia/app/static/scholia.js
@@ -436,7 +436,7 @@ function sparqlToIframe(sparql, element, filename) {
         entries.forEach(entry => {
             // If the iframe enters the viewport, load its content
             if (entry.isIntersecting) {
-                const src = $iframe.attr('data-src');
+                const src = $iframe.data('src');
                 if (src) {
                     $iframe.attr('src', src);
                     // Unobserve the iframe to stop observing once loaded

--- a/scholia/app/templates/podcast-index_languages.sparql
+++ b/scholia/app/templates/podcast-index_languages.sparql
@@ -1,4 +1,4 @@
-SELECT ?language ?languageLabel (CONCAT("/podcast/language/", SUBSTR(STR(?language), 32)) AS ?languageUrl)
+SELECT ?language ?languageLabel (CONCAT("/language/", SUBSTR(STR(?language), 32), "/podcast") AS ?languageUrl)
   (COUNT(DISTINCT ?podcast) AS ?podcasts)
 WHERE {
   ?podcast wdt:P31 wd:Q24634210 ; wdt:P407 ?language .

--- a/scholia/app/templates/podcast_data.sparql
+++ b/scholia/app/templates/podcast_data.sparql
@@ -34,7 +34,7 @@ WHERE {
     ?iri rdfs:label ?value_string .
     FILTER (LANG(?value_string) = 'en')
     BIND(STR(?value_string) AS ?value)
-    BIND(CONCAT("../podcast/language/", ?q) AS ?valueUrl)
+    BIND(CONCAT("../language/", ?q, "/podcast") AS ?valueUrl)
   }
   UNION
   {

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -1906,7 +1906,7 @@ def show_podcast_random():
     return redirect(url_for('app.show_podcast', q=q), code=302)
 
 
-@main.route('/podcast/language/' + q_pattern)
+@main.route('/language/' + q_pattern + '/podcast')
 def show_podcast_in_language(q):
     """Redirect to random podcast.
 

--- a/scholia/scrape/ojs.py
+++ b/scholia/scrape/ojs.py
@@ -319,7 +319,6 @@ def scrape_paper_from_url(url):
     title = _fields_to_content(['citation_title', 'DC.Title',
                                 'DC.Title.Alternative'])
     if title is not None:
-        #original_title = title  # Store the original title
         q = paper_to_q(entry)
         if not q:  # If not identified before modification
             # Replace dash or colon without altering surrounding spaces

--- a/scholia/scrape/ojs.py
+++ b/scholia/scrape/ojs.py
@@ -319,7 +319,20 @@ def scrape_paper_from_url(url):
     title = _fields_to_content(['citation_title', 'DC.Title',
                                 'DC.Title.Alternative'])
     if title is not None:
-        entry['title'] = title
+        original_title = title  # Store the original title
+        q = paper_to_q(entry)
+        if not q:  # If not identified before modification
+            # Replace dash or colon without altering surrounding spaces
+            title = title.replace(" –", ":").replace("– ", ":")
+            entry['title'] = title
+            q = paper_to_q(entry)
+            if q:  # If identified after modification
+                entry['title'] = title  # Plug in the modified title
+            else:
+                entry['title'] = original_title  # Plug in the original title
+        else:
+            entry['title'] = original_title
+
 
     citation_date = _fields_to_content(['citation_date', 'DC.Date.issued'])
     if citation_date is not None:

--- a/scholia/scrape/ojs.py
+++ b/scholia/scrape/ojs.py
@@ -327,14 +327,14 @@ def scrape_paper_from_url(url):
                 entry['title'] = modified_title
                 q = paper_to_q(entry)
                 if q:  # If identified after modification
-                    entry['title'] = modified_title  # Plug in the modified title
+                    # Plug in the modified title
+                    entry['title'] = modified_title
                 else:
                     entry['title'] = title  # Plug in the original title
             else:
                 entry['title'] = title
         else:
             entry['title'] = title
-
 
     citation_date = _fields_to_content(['citation_date', 'DC.Date.issued'])
     if citation_date is not None:

--- a/scholia/scrape/ojs.py
+++ b/scholia/scrape/ojs.py
@@ -319,7 +319,7 @@ def scrape_paper_from_url(url):
     title = _fields_to_content(['citation_title', 'DC.Title',
                                 'DC.Title.Alternative'])
     if title is not None:
-        original_title = title  # Store the original title
+        #original_title = title  # Store the original title
         q = paper_to_q(entry)
         if not q:  # If not identified before modification
             # Replace dash or colon without altering surrounding spaces
@@ -330,11 +330,11 @@ def scrape_paper_from_url(url):
                 if q:  # If identified after modification
                     entry['title'] = modified_title  # Plug in the modified title
                 else:
-                    entry['title'] = original_title  # Plug in the original title
+                    entry['title'] = title  # Plug in the original title
             else:
-                entry['title'] = original_title
+                entry['title'] = title
         else:
-            entry['title'] = original_title
+            entry['title'] = title
 
 
     citation_date = _fields_to_content(['citation_date', 'DC.Date.issued'])

--- a/scholia/scrape/ojs.py
+++ b/scholia/scrape/ojs.py
@@ -323,13 +323,16 @@ def scrape_paper_from_url(url):
         q = paper_to_q(entry)
         if not q:  # If not identified before modification
             # Replace dash or colon without altering surrounding spaces
-            title = title.replace(" –", ":").replace("– ", ":")
-            entry['title'] = title
-            q = paper_to_q(entry)
-            if q:  # If identified after modification
-                entry['title'] = title  # Plug in the modified title
+            modified_title = title.replace(" –", ":").replace("– ", ":")
+            if modified_title != title:  # Check if replacement is made
+                entry['title'] = modified_title
+                q = paper_to_q(entry)
+                if q:  # If identified after modification
+                    entry['title'] = modified_title  # Plug in the modified title
+                else:
+                    entry['title'] = original_title  # Plug in the original title
             else:
-                entry['title'] = original_title  # Plug in the original title
+                entry['title'] = original_title  
         else:
             entry['title'] = original_title
 

--- a/scholia/scrape/ojs.py
+++ b/scholia/scrape/ojs.py
@@ -332,7 +332,7 @@ def scrape_paper_from_url(url):
                 else:
                     entry['title'] = original_title  # Plug in the original title
             else:
-                entry['title'] = original_title  
+                entry['title'] = original_title
         else:
             entry['title'] = original_title
 


### PR DESCRIPTION
Fixes style issue related to #2426

This was the problem:
```
scholia/scrape/ojs.py:330:80: E501 line too long (81 > 79 characters)
scholia/scrape/ojs.py:339:5: E303 too many blank lines (2)
```
