### PR TITLE
hotfix: nanopub id is now a Wikidata property

### DIFF
--- a/scholia/app/templates/cito-index_articles-by-year.sparql
+++ b/scholia/app/templates/cito-index_articles-by-year.sparql
@@ -14,7 +14,7 @@ select ?year (count(?work) as ?number_of_publications) ?role where {
       OPTIONAL {
         bind("nanopub" as ?type_) bind("Nanopublication" as ?venue)
         ?citesStatement prov:wasDerivedFrom ?reference .
-        ?reference pr:P854 ?referenceURL .
+        ?reference pr:P854 | pr:P12545 ?referenceURL .
         FILTER (
           strstarts(str(?referenceURL), "https://w3id.org/np/") ||
           strstarts(str(?referenceURL), "http://purl.org/np/")

--- a/scholia/app/templates/cito-index_statistics.sparql
+++ b/scholia/app/templates/cito-index_statistics.sparql
@@ -49,7 +49,7 @@ WITH {
   SELECT (COUNT(DISTINCT ?citoNanopub) AS ?count) WHERE {
     ?citoNanopub p:P2860 ?citationStatement .
     ?citationStatement pq:P3712 / wdt:P31 wd:Q96471816 ;
-      prov:wasDerivedFrom / pr:P854 ?referenceURL .
+      prov:wasDerivedFrom / ( pr:P854 | pr:P12545 ) ?referenceURL .
     FILTER (
       strstarts(str(?referenceURL), "https://w3id.org/np/") ||
       strstarts(str(?referenceURL), "http://purl.org/np/")


### PR DESCRIPTION
As discussed just now on signal:

when https://github.com/WDscholia/scholia/pull/2432 was written, there was no property for `Nanopublication ID` yet, but since a few days we have: https://www.wikidata.org/wiki/Property:P12545

This patch fixed the original PR with the new property.