### PR TITLE
Change LIMIT for text-to-topic query #2441

### DIFF
--- a/scholia/text.py
+++ b/scholia/text.py
@@ -50,7 +50,7 @@ WITH {
           wdt:P921 [] .
   }
   # The arbitratry limit here is to avoid timeout
-  LIMIT 200000
+  LIMIT 100000
 } AS %works
 WITH {
   SELECT DISTINCT ?topic WHERE {


### PR DESCRIPTION
Test on GitHub often fails when trying to setup the data for the text-to-topic function. By reducing the data the error could possibly be avoided.

Fixes #2441

### Description
Change LIMIT on text-to-topics query to avoid problem with testing, - and possible other effects.
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* `python -m scholia.text text-to-topics-url "schizophrenia"`


### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
