### PR TITLE
Fix #2427 language index time out

### DIFF
--- a/scholia/app/templates/language-index_works-written-in-the-language.sparql
+++ b/scholia/app/templates/language-index_works-written-in-the-language.sparql
@@ -1,6 +1,9 @@
 SELECT
   ?count
-  ?language ?languageLabel ?languageDescription (CONCAT("/language/", SUBSTR(STR(?language), 32)) AS ?languageUrl)
+  
+  ?language ?languageLabel
+  (CONCAT("/language/", SUBSTR(STR(?language), 32)) AS ?languageUrl)
+   ?languageDescription 
 WITH {
   SELECT
     (COUNT(*) AS ?count)
@@ -12,6 +15,10 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
+
+  # This is to get rid of a language number of unknown values
+  FILTER EXISTS { ?language ?p [] }
+
   SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
 }
 ORDER BY DESC(?count)


### PR DESCRIPTION
Table of works in language for language index timed out. This fix uses the Synia query which takes long time, but does not time out.

Fixes #2427

### Description
Change the SPARQL query slightly.
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* Checked http://127.0.0.1:8100/language

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
