### PR TITLE
Further detail of the use of nanopublications for CiTO annotations

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,11 +11,11 @@ jobs:
         python-version: ["3.8", "3.9", "3.10"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install lxml dependencies
         run: sudo apt install libxml2-dev libxslt-dev
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Cython for lxml installation

--- a/scholia/app/templates/cito-index_statistics.sparql
+++ b/scholia/app/templates/cito-index_statistics.sparql
@@ -46,7 +46,18 @@ WITH {
   }
 } AS %citoDatasets
 WITH {
-  SELECT (COUNT(DISTINCT ?citoNanopub) AS ?count) WHERE {
+  SELECT (COUNT(DISTINCT ?citationStatement) AS ?count) WHERE {
+    ?citoNanopub p:P2860 ?citationStatement .
+    ?citationStatement pq:P3712 / wdt:P31 wd:Q96471816 ;
+      prov:wasDerivedFrom / ( pr:P854 | pr:P12545 ) ?referenceURL .
+    FILTER (
+      strstarts(str(?referenceURL), "https://w3id.org/np/") ||
+      strstarts(str(?referenceURL), "http://purl.org/np/")
+    )
+  }
+} AS %citoCitationFromNanopubs
+WITH {
+  SELECT (COUNT(DISTINCT ?referenceURL) AS ?count) WHERE {
     ?citoNanopub p:P2860 ?citationStatement .
     ?citationStatement pq:P3712 / wdt:P31 wd:Q96471816 ;
       prov:wasDerivedFrom / ( pr:P854 | pr:P12545 ) ?referenceURL .
@@ -56,6 +67,17 @@ WITH {
     )
   }
 } AS %citoNanopubs
+WITH {
+  SELECT (COUNT(DISTINCT ?citoNanopub) AS ?count) WHERE {
+    ?citoNanopub p:P2860 ?citationStatement .
+    ?citationStatement pq:P3712 / wdt:P31 wd:Q96471816 ;
+      prov:wasDerivedFrom / ( pr:P854 | pr:P12545 ) ?referenceURL .
+    FILTER (
+      strstarts(str(?referenceURL), "https://w3id.org/np/") ||
+      strstarts(str(?referenceURL), "http://purl.org/np/")
+    )
+  }
+} AS %artsWithcitoNanopubs
 WHERE {
   {
     INCLUDE %annotions
@@ -103,8 +125,18 @@ WHERE {
   }
   UNION
   {
+    INCLUDE %citoCitationFromNanopubs
+    BIND("Number of annotations defined in nanopublications" AS ?description)
+  }
+  UNION
+  {
+    INCLUDE %artsWithcitoNanopubs
+    BIND("Number of articles with annotations defined in nanopublications" AS ?description)
+  }
+  UNION
+  {
     INCLUDE %citoNanopubs
-    BIND("Number of nanopublications with explicit CiTO annotation" AS ?description)
+    BIND("Number of nanopublications that define explicit CiTO annotations" AS ?description)
   }
 }
 ORDER BY DESC(?count)


### PR DESCRIPTION
Does not fix anything but implements some extra detail of CiTO annotations from nanopublications.

### Description
This patch adds two extra statistics lines, resulting in three nanopub related statistics:

* number of nanopublications with CiTO annotations (existing, but better description)
* number of CiTO annotations (new)
* number of articles with CITO annotations defined in nanopubs (new)
    
![image](https://github.com/WDscholia/scholia/assets/26721/2ed60da2-8327-41f6-907a-273005614b2d)

### Caveats
None anticipated.

Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

### Testing
* see the stats table at https://scholia.toolforge.org/cito/

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [ ] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
