### PR TITLE
Fix #2467: participants and acceptance

### DIFF
--- a/scholia/app/templates/event_data.sparql
+++ b/scholia/app/templates/event_data.sparql
@@ -1,31 +1,31 @@
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
-SELECT DISTINCT ?description ?value ?valueUrl
+SELECT
+  ?description ?descriptionLabel ?descriptionUrl
+
+  ?value ?valueLabel ?valueUrl
+
 WHERE {
-  BIND(target: AS ?work)
   {
     BIND(1 AS ?order)
-    BIND("Part of series" AS ?description)
-    ?work wdt:P179 ?iri .
-    BIND(SUBSTR(STR(?iri), 32) AS ?q) 
-    ?iri rdfs:label ?value_string . 
-    FILTER (LANG(?value_string) = 'en')
-    BIND(COALESCE(?value_string, ?q) AS ?value)
-    BIND(CONCAT("../event-series/", ?q) AS ?valueUrl)
+    BIND("Event series" AS ?description)
+    BIND("/event-series" AS ?descriptionUrl)
+    target: wdt:P179 ?value .
+    BIND(CONCAT("/event-series/", SUBSTR(STR(?value), 32)) AS ?valueUrl)
   }
   UNION
   {
     BIND(2 AS ?order)
     BIND("Short name" AS ?description)
-    ?work wdt:P1813 ?value .
+    target: wdt:P1813 ?value .
   }
   UNION
   {
     SELECT
-      (3 AS ?order)
+      (5 AS ?order)
       ("Organizers" AS ?description)
       (GROUP_CONCAT(?value_; separator=", ") AS ?value)
-      (CONCAT("../authors/", GROUP_CONCAT(?q; separator=",")) AS ?valueUrl)
+      (CONCAT("/authors/", GROUP_CONCAT(?q; separator=",")) AS ?valueUrl)      
     {
       BIND(1 AS ?dummy)
       target: wdt:P664 ?iri .
@@ -36,5 +36,27 @@ WHERE {
     }
     GROUP BY ?dummy
   }
+  UNION
+  {
+    BIND(10 AS ?order)
+    BIND("Number of participants" AS ?description)
+    
+    target: wdt:P1132 ?value .
+  }
+  UNION
+  {
+    BIND(11 AS ?order)
+    BIND("Acceptance&nbsp;rate" AS ?description)
+    
+    target: p:P5822 ?value_statement .
+    ?value_statement ps:P5822 ?acceptance_rate .
+    OPTIONAL {
+      ?value_statement  pq:P518 / rdfs:label ?track .
+      FILTER (LANG(?track) = "en")
+    }
+    BIND(IF(BOUND(?track), CONCAT(STR(?acceptance_rate * 100), " % (", ?track, ")"), STR(?acceptance_rate * 100)) AS ?value)
+  }
+
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
 } 
 ORDER BY ?order


### PR DESCRIPTION
This add lines with number of participants and acceptance rate to data table on the event aspect.
It was taken from Synia's template:
https://www.wikidata.org/w/index.php?title=Wikidata:Synia:scientificevent&oldid=2126890956

Fixes #2467

### Description
> Please include a summary of the change, relevant motivation and context. If possible and applicable, include before and after screenshots and a URL where the changes can be seen.
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* http://127.0.0.1:8100/event/Q124727137
* http://127.0.0.1:8100/event/Q119153957

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution (my own Synia code)
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
