### PR TITLE
Fix #2462 Uppercase DOI in quickstatements

### DIFF
--- a/scholia/qs.py
+++ b/scholia/qs.py
@@ -61,6 +61,8 @@ def paper_to_quickstatements(paper):
     The label is shortened to 250 characters due if the title is longer than
     that due to a limitation in Wikidata.
 
+    Letters in DOI are uppercased in accordance with Wikidata convention.
+
     """
     qs = u("CREATE\n")
 
@@ -82,7 +84,9 @@ def paper_to_quickstatements(paper):
 
     # DOI
     if 'doi' in paper:
-        qs += u('LAST\tP356\t"{}"\n').format(paper['doi'])
+        # By Wikidata convention letters in a DOI should be uppercase
+        doi = paper['doi'].upper()
+        qs += u('LAST\tP356\t"{}"\n').format(doi)
 
     # Authors
     if 'authors' in paper:

--- a/scholia/utils.py
+++ b/scholia/utils.py
@@ -200,8 +200,6 @@ def metadata_to_quickstatements(metadata):
     format so it can copy and pasted into Magnus Manske quickstatement web tool
     to populate Wikidata.
 
-    This function does not check whether the item already exists.
-
     Parameters
     ----------
     metadata : dict
@@ -211,6 +209,12 @@ def metadata_to_quickstatements(metadata):
     -------
     quickstatements : str
         String with quickstatements.
+
+    Notes
+    -----
+    This function does not check whether the item already exists.
+
+    Letters in DOI are uppercased in accordance with Wikidata convention.
 
     References
     ----------
@@ -256,6 +260,8 @@ def metadata_to_quickstatements(metadata):
 
     doi = metadata.get("doi")
     if doi:
+        # By Wikidata convention letters in a DOI should be uppercase
+        doi = doi.upper()
         qs += f'LAST\tP356\t"{_clean(doi)}"\n'
 
     authornames = metadata.get("authornames", [])


### PR DESCRIPTION
Letters in DOIs were not uppercased when generating quickstatements.

Fixes #2462

### Description
Uppercased DOIs in quickstatements
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [x]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* http://127.0.0.1:8100/id-to-quickstatements?query=https%3A%2F%2Flink.springer.com%2Fdoi%2F10.1007%2Fs00376-023-3062-1++https%3A%2F%2Fdoi.org%2F10.1073%252Fpnas.2317444121


### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
