### PR TITLE
Fix #2385 long titles were shorten

### DIFF
--- a/scholia/qs.py
+++ b/scholia/qs.py
@@ -125,13 +125,18 @@ def paper_to_quickstatements(paper):
     title = paper.get('title')
     if title:
         # "Label must be no more than 250 characters long"
-        short_title = normalize_string(title)[:250]
+        normalized_title = normalize_string(title)
+        short_title = normalized_title[:250]
+
+        # String datatype support 1,500 characters
+        # https://www.wikidata.org/wiki/Help:Data_type#String-based_data_types
+        long_title = normalized_title[:1500]
 
         # Label
         qs += u('LAST\tLen\t"{}"\n').format(short_title)
 
         # Title property
-        qs += u('LAST\tP1476\t{}:"{}"\n').format(iso639, short_title)
+        qs += u('LAST\tP1476\t{}:"{}"\n').format(iso639, long_title)
 
     # Description
     date = paper.get('date')


### PR DESCRIPTION
Now the title property can have up to 1,500 characters. This change was based on @DaxServer #2402 PR

Fixes #2385

### Description
Fix long titles not added for OJS, - was an issue for the quickstatement generation.
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [x]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.



### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
