### PR TITLE
[WIP] Use ConfigParser to allow configuration of the server details

### DIFF
--- a/scholia/query.py
+++ b/scholia/query.py
@@ -835,7 +835,7 @@ def omim_to_qs(omimID):
     query = 'select ?disease where {{ ?disease wdt:P492 "{omimID}" }}'.format(
         omimID=escape_string(omimID))
 
-    url = 'https://query.wikidata.org/sparql'
+    url = SPARQL_ENDPOINT
     params = {'query': query, 'format': 'json'}
     response = requests.get(url, params=params, headers=HEADERS)
     data = response.json()
@@ -1835,6 +1835,34 @@ def random_podcast():
         # Fallback
         q = "Q124363332"
     return q
+
+
+def get_config():
+    """Return the Scholia configuration.
+
+    ConfigParser instance with the default configuration or the configuration
+    from one of the following files: scholia.cfg, ~/etc/scholia.cfg, or ~/scholia.cfg.
+
+    Notes
+    -----
+    The default configuration file looks like this:
+
+    [server]
+    sparql_endpoint = https://query.wikidata.org/sparql
+
+    Returns
+    -------
+    config : ConfigParser
+        ConfigParser object.
+
+    Examples
+    --------
+    >>> config = get_config()
+    >>> SPARQL_ENDPOINT = config['server']['sparql_endpoint']
+    https://query.wikidata.org/sparql
+
+    """
+    return config
 
 
 def main():

--- a/scholia/query.py
+++ b/scholia/query.py
@@ -61,7 +61,40 @@ from simplejson import JSONDecodeError
 
 from six import u
 
-SPARQL_ENDPOINT = "https://query.wikidata.org/sparql"
+try:
+    import ConfigParser as configparser
+except ImportError:
+    import configparser
+
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+
+from os.path import exists, expanduser
+
+CONFIG_FILENAMES = [
+    'scholia.cfg',
+    '~/etc/scholia.cfg',
+    '~/scholia.cfg']
+
+DEFAULTS = """
+[server]
+sparql_endpoint = https://query.wikidata.org/sparql
+"""
+
+config = configparser.ConfigParser()
+
+config.read_file(StringIO(DEFAULTS))
+
+for filename in CONFIG_FILENAMES:
+    full_filename = expanduser(filename)
+    if exists(full_filename):
+        print('Reading configuration file from {}'.format(full_filename))
+        config.read(full_filename)
+        break
+
+SPARQL_ENDPOINT = config['server']['sparql_endpoint']
 
 USER_AGENT = 'Scholia'
 

--- a/scholia/rss.py
+++ b/scholia/rss.py
@@ -49,8 +49,9 @@ from re import sub
 
 from six import u
 
-from .query import SPARQL_ENDPOINT
+from .query import get_config
 
+SPARQL_ENDPOINT = get_config()['server']['sparql_endpoint']
 
 WORK_ITEM_RSS = u("""
     <item>
@@ -358,7 +359,7 @@ def wb_get_venue_latest_works(q):
                 'type="application/rss+xml" />\n'
 
     query = VENUE_SPARQL_QUERY.format(q=q)
-    url = 'https://query.wikidata.org/bigdata/namespace/wdq/sparql'
+    url = SPARQL_ENDPOINT
     params = {'query': query, 'format': 'json'}
     response = requests.get(url, params=params)
     data = response.json()
@@ -402,7 +403,7 @@ def wb_get_topic_latest_works(q):
                 'type="application/rss+xml" />\n'
 
     query = TOPIC_SPARQL_QUERY.format(q=q)
-    url = 'https://query.wikidata.org/bigdata/namespace/wdq/sparql'
+    url = SPARQL_ENDPOINT
     params = {'query': query, 'format': 'json'}
     response = requests.get(url, params=params)
     data = response.json()
@@ -448,7 +449,7 @@ def wb_get_organization_latest_works(q):
                 'type="application/rss+xml" />\n'
 
     query = ORGANIZATION_SPARQL_QUERY.format(q=q)
-    url = 'https://query.wikidata.org/bigdata/namespace/wdq/sparql'
+    url = SPARQL_ENDPOINT
     params = {'query': query, 'format': 'json'}
     response = requests.get(url, params=params)
     data = response.json()
@@ -494,7 +495,7 @@ def wb_get_sponsor_latest_works(q):
                 'type="application/rss+xml" />\n'
 
     query = SPONSOR_SPARQL_QUERY.format(q=q)
-    url = 'https://query.wikidata.org/bigdata/namespace/wdq/sparql'
+    url = SPARQL_ENDPOINT
     params = {'query': query, 'format': 'json'}
     response = requests.get(url, params=params)
     data = response.json()


### PR DESCRIPTION
Fixes #2429

### Description
This patch (in progress) is rewriting Scholia to make various server-side details (e.g. SPARQL endpoint) configurable with a properties file.
    
### Caveats
* [X]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies: `configparser`, `StringIO`, `os.path`

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
The patch defaults use the WDQS and with the following `scholia.cfg` it will use the QLever Wikidata endpoint:

```
to be done
```

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [ ] My changes generate no new warnings
* [ ] I have not used code from external sources without attribution
* [ ] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [ ] There are no remaining debug statements (print, console.log, ...)
