### PR TITLE
Fix #2490 Broaden reviewer statistics query

### DIFF
--- a/scholia/app/templates/author.html
+++ b/scholia/app/templates/author.html
@@ -116,7 +116,7 @@ Resources used in authored works.
 <table class="table table-hover" id="venue-statistics-table"></table>
 
 <h2 id="review-statistics">Review statistics</h2>
-<p>This author has reviewed for the following journals.</p>
+<p>This author has reviewed for the following journals and events.</p>
 <table class="table table-hover" id="review-statistics-table"></table>
 
 <h2 id="coauthors" data-toogle="tooltip" title="Co-author graph for the author (up to 1000 links)">Co-author graph</h2>

--- a/scholia/app/templates/author_review-statistics.sparql
+++ b/scholia/app/templates/author_review-statistics.sparql
@@ -12,11 +12,27 @@ WITH {
     (GROUP_CONCAT(DISTINCT ?topic_label; separator=", ") AS ?topics)
     (CONCAT("../topics/", GROUP_CONCAT(DISTINCT SUBSTR(STR(?topic), 32); separator=",")) AS ?topicsUrl)
   WHERE {
-    ?work wdt:P4032 target: .
-    ?work wdt:P1433 ?venue .
+    {
+      ?work wdt:P4032 target: ;
+            wdt:P1433 ?venue .
+    }
+    UNION
+    {
+      # program committee member for event in a series (work is here the event)
+      ?work wdt:P179 ?venue ;
+            wdt:P5804 target: 
+    }
+    UNION
+    {
+      # program committee member for event not in a series
+      ?venue wdt:P5804 target: .
+      MINUS { ?venue wdt:P179 [] }
+      BIND("dummy" AS ?work)
+    }
     OPTIONAL {
       ?venue wdt:P921 ?topic .
-      ?topic rdfs:label ?topic_label . FILTER(LANG(?topic_label) = 'en') }
+      ?topic rdfs:label ?topic_label . FILTER(LANG(?topic_label) = 'en')
+    }
   }
   GROUP BY ?venue
 } AS %result


### PR DESCRIPTION
Now include program committee work

Fixes #2490

### Description
Broaden SPARQL query to include program committee work.
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* Looked up a couple of researchers.
* Test B

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
