### PR TITLE
Fix #2444 Remove simplejson package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ Flask>=3.0.0
 Flask-Bootstrap
 lxml>=4.6.5
 requests
-simplejson
 werkzeug>=3.0.3
 urllib3>=1.25.1
 certifi>=2022.12.7

--- a/scholia/query.py
+++ b/scholia/query.py
@@ -57,8 +57,6 @@ from random import randrange
 
 import requests
 
-from simplejson import JSONDecodeError
-
 from six import u
 
 SPARQL_ENDPOINT = "https://query.wikidata.org/sparql"
@@ -1104,7 +1102,7 @@ def q_to_class(q):
     response = requests.get(url, params=params, headers=HEADERS)
     try:
         data = response.json()
-    except JSONDecodeError:
+    except requests.exceptions.JSONDecodeError:
         # If the Wikidata MediaWiki API does not return a proper
         # response, then fallback on nothing.
         classes = []


### PR DESCRIPTION
The requirement of the simplejson package is removed The exception class now uses the one from the requests package.

Fixes #2444

### Description
Remove dependency on the `simplejson` package
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [x]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* Ran `tox -r`

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
