### PR TITLE
2498 remove online events from related based on time and location

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ Flask>=3.0.0
 Flask-Bootstrap
 lxml>=4.6.5
 requests
-simplejson
 werkzeug>=3.0.3
 urllib3>=1.25.1
 certifi>=2022.12.7

--- a/scholia/app/templates/event_related-events-timelocation.sparql
+++ b/scholia/app/templates/event_related-events-timelocation.sparql
@@ -50,13 +50,15 @@ WITH {
         BIND((200 / (1 + geof:distance(?geo, ?geo0))) AS ?inverse_distance)
       }
       GROUP BY ?event
-    }  
-    UNION
-    {
-      VALUES ?online_event { wd:Q1543677 wd:Q98381855 wd:Q98381912 }
-      ?event wdt:P31 ?online_event .
-      BIND(200 AS ?location_scores)
     }
+
+    # Should online event be listed? 
+    # UNION
+    # {
+    #   VALUES ?online_event { wd:Q1543677 wd:Q98381855 wd:Q98381912 }
+    #   ?event wdt:P31 ?online_event .
+    #   BIND(200 AS ?location_scores)
+    # }
   
     BIND((?time_scores * ?location_scores) AS ?scores)
   }

--- a/scholia/query.py
+++ b/scholia/query.py
@@ -57,8 +57,6 @@ from random import randrange
 
 import requests
 
-from simplejson import JSONDecodeError
-
 from six import u
 
 SPARQL_ENDPOINT = "https://query.wikidata.org/sparql"
@@ -1104,7 +1102,7 @@ def q_to_class(q):
     response = requests.get(url, params=params, headers=HEADERS)
     try:
         data = response.json()
-    except JSONDecodeError:
+    except requests.exceptions.JSONDecodeError:
         # If the Wikidata MediaWiki API does not return a proper
         # response, then fallback on nothing.
         classes = []


### PR DESCRIPTION
Fixes #2498

### Description
Remove online events from related based on time and location. This edit just comment out the relevant part of the SPARQL.
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* http://127.0.0.1:8100/event/Q124439501

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
