### PR TITLE
Fix #2505 command-line arxiv-to-qs

### DIFF
--- a/scholia/__main__.py
+++ b/scholia/__main__.py
@@ -26,6 +26,7 @@ from __future__ import absolute_import, division, print_function
 import os
 
 from . import arxiv
+from .qs import paper_to_quickstatements
 from .query import orcid_to_qs
 from .utils import string_to_type
 
@@ -48,7 +49,7 @@ def main():
     if arguments['arxiv-to-quickstatements']:
         arxiv_id = arguments['<arxiv>']
         metadata = arxiv.get_metadata(arxiv_id)
-        quickstatements = arxiv.metadata_to_quickstatements(metadata)
+        quickstatements = paper_to_quickstatements(metadata)
         os.write(output_file, quickstatements.encode(output_encoding))
 
     elif arguments['orcid-to-q']:


### PR DESCRIPTION
Command-line version did not work for arxiv-to-quickstatements.

Fixes #2505

### Description
A previous PR moved a function to another module.
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* `python -m scholia arxiv-to-quickstatements 2405.04453`

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
