### PR TITLE
Add the ability to select a batch of QuickStatements to run

### DIFF
--- a/scholia/app/static/css/scholia.css
+++ b/scholia/app/static/css/scholia.css
@@ -239,6 +239,11 @@ a.dropdown-item.active {
     animation-delay: 2s;
 }
 
+.large-checkbox {
+    width: 18.5px;
+    height: 18.5px;
+}
+
 @keyframes scholia {
     33% {
         border-color: var(--theme-red);

--- a/scholia/app/templates/id-to-quickstatements.html
+++ b/scholia/app/templates/id-to-quickstatements.html
@@ -11,9 +11,11 @@
 <form action="" id="form" method="GET" class="form-horizontal mb-3">
   <div class="input-group">
     {% if query %}
-    <input type="text" class="form-control" placeholder="Enter a single or list of arXiv IDs or DOIs" value="{{ query }}" id="searchterm" name="query"/>
+    <input type="text" class="form-control" placeholder="Enter a single or list of arXiv IDs or DOIs"
+      value="{{ query }}" id="searchterm" name="query" />
     {% else %}
-    <input type="text" class="form-control" placeholder="Enter a single or list of arXiv IDs or DOIs" id="searchterm" name="query"/>
+    <input type="text" class="form-control" placeholder="Enter a single or list of arXiv IDs or DOIs" id="searchterm"
+      name="query" />
     {% endif %}
     <span class="input-group-append">
       <button class="btn btn-primary" type="submit">
@@ -23,15 +25,21 @@
   </div>
 </form>
 
-<p>Enter a single or list of <a href="https://arxiv.org">arXiv</a> identifiers or <a href="https://doi.org">DOIs</a> to retrieve their Wikidata items or QuickStatements to create items for them.</p>
+<p>Enter a single or list of <a href="https://arxiv.org">arXiv</a> identifiers or <a href="https://doi.org">DOIs</a> to
+  retrieve their Wikidata items or QuickStatements to create items for them.</p>
 
-<p>Bare IDs (such as "1703.06103" or "10.1371/JOURNAL.PONE.0029797") or URLs (such as "https://arxiv.org/abs/1703.06103" or "https://doi.org/10.1371/JOURNAL.PONE.0029797") can be used and the list can be
-comma, space, pipe or tab separated. Note that new items in Wikidata may not be immediately found because of caching.</p>
+<p>Bare IDs (such as "1703.06103" or "10.1371/JOURNAL.PONE.0029797") or URLs (such as "https://arxiv.org/abs/1703.06103"
+  or "https://doi.org/10.1371/JOURNAL.PONE.0029797") can be used and the list can be
+  comma, space, pipe or tab separated. Note that new items in Wikidata may not be immediately found because of caching.
+</p>
 
 <h2>Result</h2>
 {% if error %}
 <div class="alert alert-warning" role="alert">
-  No results returned, potentially due to the upstream server being down. Please try again later. If the issue persists <a href="https://github.com/WDscholia/scholia/issues/new?assignees=&labels=bug&projects=&template=bug_report.md&title=">submit a bug report on GitHub</a>.
+  No results returned, potentially due to the upstream server being down. Please try again later. If the issue persists
+  <a
+    href="https://github.com/WDscholia/scholia/issues/new?assignees=&labels=bug&projects=&template=bug_report.md&title=">submit
+    a bug report on GitHub</a>.
 </div>
 {% endif %}
 
@@ -48,11 +56,11 @@ comma, space, pipe or tab separated. Note that new items in Wikidata may not be 
 {% if (qs|length) > 1 %}
 
 <div id="searchresult">In Wikidata:
-<ul>
-  {% for q in qs %}
-  <li>{{ q[0] }}: <a href="work/{{ q[1] }}">{{ q[1] }}</a></li>
-  {% endfor %}
-</ul>
+  <ul>
+    {% for q in qs %}
+    <li>{{ q[0] }}: <a href="work/{{ q[1] }}">{{ q[1] }}</a></li>
+    {% endfor %}
+  </ul>
 </div>
   
 
@@ -61,30 +69,41 @@ comma, space, pipe or tab separated. Note that new items in Wikidata may not be 
 {% if (quickstatements|length) > 0 %}
 <h2>{{(quickstatements|length)}} Not Found</h2>
 
-<blockquote>Select statements which you want to contribute and use the buttons at the bottom of the section to complete the action.</blockquote>
-
-<button class="btn btn-secondary">Select all</button>
+<blockquote>Select statements which you want to contribute and use the buttons at the bottom of the section to complete
+  the action.</blockquote>
+<input type="checkbox" class="d-none" id="select-all-state" />
+<button class="btn btn-secondary select-all">Select all</button> <button class="btn btn-secondary invert-selection">Invert selection</button>
 <div class="container">
-{% for quickstatement in quickstatements %}
+  {% for quickstatement in quickstatements %}
   <div class="row">
-      <div class="col-1 align-self-center">
-        <input type="checkbox" class="select-item checkbox large-checkbox" name="select-item" value="{{loop.index}}" />
-      </div>
-    <div class="col-8"><pre>{{ quickstatement }}</pre></div>
-    <div class="d-none" id="qs-{{loop.index}}">{{ quickstatement | replace('\t', '|') | replace('\n', '||') | urlencode | replace('/','%2F') }}</div>
+    <div class="col-1 align-self-center">
+      <input type="checkbox" class="select-item checkbox large-checkbox" name="select-item" value="{{loop.index}}" />
+    </div>
+    <div class="col-8">
+      <pre>{{ quickstatement }}</pre>
+    </div>
+    <div class="d-none" id="qs-{{loop.index}}">{{ quickstatement | replace('\t', '|') | replace('\n', '||') | urlencode
+      | replace('/','%2F') }}</div>
     <div class="col-3 align-self-center">
-      <a href="https://quickstatements.toolforge.org/#/v1={{ quickstatement | replace('\t', '|') | replace('\n', '||') | urlencode | replace('/','%2F') }}"><button class="btn btn-outline-secondary">Submit to Quickstatements ↗</button></a>
-      <button class="btn btn-outline-secondary">Copy to clipboard</button></div>
+      <a
+        href="https://quickstatements.toolforge.org/#/v1={{ quickstatement | replace('\t', '|') | replace('\n', '||') | urlencode | replace('/','%2F') }}"><button
+          class="btn btn-outline-secondary">Submit to Quickstatements ↗</button></a>
+      <button class="btn btn-outline-secondary">Copy to clipboard</button>
+    </div>
   </div>
-{% endfor %}
+  {% endfor %}
 </div>
 
 <div class="d-flex justify-content-between">
-  <button class="btn btn-primary">Select all</button>
+  <div>
+    <button class="btn btn-primary select-all">Select all</button>
+    <button class="btn btn-primary invert-selection">Invert selection</button>
+  </div>
   <div>
     <button class="btn btn-primary ml-auto">Submit to Quickstatements ↗</button> <button class="btn btn-primary">Copy to
-      clipboard</button></div>
+      clipboard</button>
   </div>
+</div>
 </div>
 
 
@@ -94,11 +113,39 @@ comma, space, pipe or tab separated. Note that new items in Wikidata may not be 
 <h2>{{(failed|length)}} Failed</h2>
 
 <ul>
-{% for fail in failed %}
-<li>{{ fail[0] }}: {{ fail[1] }}</a></li>
-{% endfor %}
+  {% for fail in failed %}
+  <li>{{ fail[0] }}: {{ fail[1] }}</a></li>
+  {% endfor %}
 </ul>
 {% endif %}
 
 
+{% endblock %}
+
+{% block scripts %}
+{{super()}}
+<script type="text/javascript">
+  const select_alls = document.getElementsByClassName("select-all");
+  const select_all_state = document.getElementById("select-all-state");
+  for (const select_all of select_alls) {
+    select_all.addEventListener("click", () => {
+      select_all_state.checked = !select_all_state.checked;
+      const checked = select_all_state.checked;
+      const checkboxes = document.getElementsByClassName("checkbox");
+      for (const checkbox of checkboxes) {
+        checkbox.checked = checked;
+      }
+    })
+  }
+
+  const invert_selections = document.getElementsByClassName("invert-selection");
+  for (const invert_selection of invert_selections) {
+    invert_selection.addEventListener("click", () => {
+      const checkboxes = document.getElementsByClassName("checkbox");
+      for (const checkbox of checkboxes) {
+        checkbox.checked = !checkbox.checked;
+      }
+    })
+  }
+</script>
 {% endblock %}

--- a/scholia/app/templates/id-to-quickstatements.html
+++ b/scholia/app/templates/id-to-quickstatements.html
@@ -61,13 +61,33 @@ comma, space, pipe or tab separated. Note that new items in Wikidata may not be 
 {% if (quickstatements|length) > 0 %}
 <h2>{{(quickstatements|length)}} Not Found</h2>
 
-{% for quickstatement in quickstatements %}
-<div id="quickstatements"><pre>{{ quickstatement }}</pre></div>
+<blockquote>Select statements which you want to contribute and use the buttons at the bottom of the section to complete the action.</blockquote>
 
-<a href="https://quickstatements.toolforge.org/#/v1={{ quickstatement | replace('\t', '|') | replace('\n', '||') | urlencode | replace('/','%2F') }}">
-  <button class="btn btn-primary">Submit to Quickstatements ↗</button>
-</a>
+<button class="btn btn-secondary">Select all</button>
+<div class="container">
+{% for quickstatement in quickstatements %}
+  <div class="row">
+      <div class="col-1 align-self-center">
+        <input type="checkbox" class="select-item checkbox large-checkbox" name="select-item" value="{{loop.index}}" />
+      </div>
+    <div class="col-8"><pre>{{ quickstatement }}</pre></div>
+    <div class="d-none" id="qs-{{loop.index}}">{{ quickstatement | replace('\t', '|') | replace('\n', '||') | urlencode | replace('/','%2F') }}</div>
+    <div class="col-3 align-self-center">
+      <a href="https://quickstatements.toolforge.org/#/v1={{ quickstatement | replace('\t', '|') | replace('\n', '||') | urlencode | replace('/','%2F') }}"><button class="btn btn-outline-secondary">Submit to Quickstatements ↗</button></a>
+      <button class="btn btn-outline-secondary">Copy to clipboard</button></div>
+  </div>
 {% endfor %}
+</div>
+
+<div class="d-flex justify-content-between">
+  <button class="btn btn-primary">Select all</button>
+  <div>
+    <button class="btn btn-primary ml-auto">Submit to Quickstatements ↗</button> <button class="btn btn-primary">Copy to
+      clipboard</button></div>
+  </div>
+</div>
+
+
 {% endif %}
 
 {% if (failed|length) > 0 %}

--- a/scholia/app/templates/id-to-quickstatements.html
+++ b/scholia/app/templates/id-to-quickstatements.html
@@ -103,7 +103,7 @@
   </div>
   <div>
     <button class="btn btn-primary ml-auto">Submit to Quickstatements ↗</button>
-    <button class="btn btn-primary copy-all-buttton">Copy to clipboard</button>
+    <button class="btn btn-primary" id="copy-all-button">Copy to clipboard</button>
   </div>
 </div>
 </div>
@@ -160,5 +160,25 @@
       }
     })
   }
+
+  const copy_all = document.getElementById("copy-all-button");
+  copy_all.addEventListener("click", () => {
+    var items = [];
+    document.querySelectorAll("input.select-item:checked:checked").forEach((item, index) => { 
+      console.log(index)
+      console.log(item)
+      const qs_id = item["value"];
+      const quickstatements = document.getElementById("qs-" + qs_id + "-plain");
+      items.push(quickstatements.innerText);
+    });
+    if (items.length < 1) {
+      // alert("no selected items!!!");
+    } else {
+      var values = items.join('\n\n');
+      if (navigator.clipboard) {
+        navigator.clipboard.writeText(values)
+      }
+    }
+  });
 </script>
 {% endblock %}

--- a/scholia/app/templates/id-to-quickstatements.html
+++ b/scholia/app/templates/id-to-quickstatements.html
@@ -102,7 +102,7 @@
     <button class="btn btn-primary invert-selection">Invert selection</button>
   </div>
   <div>
-    <button class="btn btn-primary ml-auto">Submit to Quickstatements ↗</button>
+    <button class="btn btn-primary ml-auto" id="submit-all-button">Submit to Quickstatements ↗</button>
     <button class="btn btn-primary" id="copy-all-button">Copy to clipboard</button>
   </div>
 </div>
@@ -164,7 +164,7 @@
   const copy_all = document.getElementById("copy-all-button");
   copy_all.addEventListener("click", () => {
     var items = [];
-    document.querySelectorAll("input.select-item:checked:checked").forEach((item, index) => { 
+    document.querySelectorAll("input.select-item:checked:checked").forEach((item, index) => {
       console.log(index)
       console.log(item)
       const qs_id = item["value"];
@@ -172,12 +172,30 @@
       items.push(quickstatements.innerText);
     });
     if (items.length < 1) {
-      // alert("no selected items!!!");
+      const parent = copy_all.parentNode.parentNode;
+      parent.insertAdjacentHTML('afterend', `<div class="alert alert-warning" role="alert">Select at least one row using the checkbox on the left</div>`);
     } else {
       var values = items.join('\n\n');
       if (navigator.clipboard) {
         navigator.clipboard.writeText(values)
       }
+    }
+  });
+
+  const submit_all = document.getElementById("submit-all-button");
+  submit_all.addEventListener("click", () => {
+    var items = [];
+    document.querySelectorAll("input.select-item:checked:checked").forEach((item, index) => {
+      const qs_id = item["value"];
+      const quickstatements = document.getElementById("qs-" + qs_id + "-url");
+      items.push(quickstatements.innerText);
+    });
+    if (items.length < 1) {
+      const parent = submit_all.parentNode.parentNode;
+      parent.insertAdjacentHTML('afterend', `<div class="alert alert-warning" role="alert">Select at least one row using the checkbox on the left</div>`);
+    } else {
+      const values = items.join('||');
+      window.location.href = "https://quickstatements.toolforge.org/#/v1=" + values
     }
   });
 </script>

--- a/scholia/app/templates/id-to-quickstatements.html
+++ b/scholia/app/templates/id-to-quickstatements.html
@@ -84,7 +84,7 @@
     </div>
     <div class="d-none" id="qs-{{loop.index}}-url">{{ quickstatement | replace('\t', '|') | replace('\n', '||') | urlencode
       | replace('/','%2F') }}</div>
-    <div class="d-none" id="qs-{{loop.index}}-plain">{{ quickstatement | replace('\t', '|') | replace('\n', '||') 
+    <div class="d-none" id="qs-{{loop.index}}-plain">{{ quickstatement | replace('\t', '|') | replace('\n', '||')
       | replace('/','%2F') }}</div>
     <div class="col-3 align-self-center">
       <a
@@ -105,7 +105,6 @@
     <button class="btn btn-primary ml-auto" id="submit-all-button">Submit to Quickstatements ↗</button>
     <button class="btn btn-primary" id="copy-all-button">Copy to clipboard</button>
   </div>
-</div>
 </div>
 
 
@@ -165,8 +164,6 @@
   copy_all.addEventListener("click", () => {
     var items = [];
     document.querySelectorAll("input.select-item:checked:checked").forEach((item, index) => {
-      console.log(index)
-      console.log(item)
       const qs_id = item["value"];
       const quickstatements = document.getElementById("qs-" + qs_id + "-plain");
       items.push(quickstatements.innerText);

--- a/scholia/app/templates/id-to-quickstatements.html
+++ b/scholia/app/templates/id-to-quickstatements.html
@@ -82,13 +82,15 @@
     <div class="col-8">
       <pre>{{ quickstatement }}</pre>
     </div>
-    <div class="d-none" id="qs-{{loop.index}}">{{ quickstatement | replace('\t', '|') | replace('\n', '||') | urlencode
+    <div class="d-none" id="qs-{{loop.index}}-url">{{ quickstatement | replace('\t', '|') | replace('\n', '||') | urlencode
+      | replace('/','%2F') }}</div>
+    <div class="d-none" id="qs-{{loop.index}}-plain">{{ quickstatement | replace('\t', '|') | replace('\n', '||') 
       | replace('/','%2F') }}</div>
     <div class="col-3 align-self-center">
       <a
         href="https://quickstatements.toolforge.org/#/v1={{ quickstatement | replace('\t', '|') | replace('\n', '||') | urlencode | replace('/','%2F') }}"><button
           class="btn btn-outline-secondary">Submit to Quickstatements ↗</button></a>
-      <button class="btn btn-outline-secondary">Copy to clipboard</button>
+      <button class="btn btn-outline-secondary copy-button" name="{{loop.index}}">Copy to clipboard</button>
     </div>
   </div>
   {% endfor %}
@@ -100,8 +102,8 @@
     <button class="btn btn-primary invert-selection">Invert selection</button>
   </div>
   <div>
-    <button class="btn btn-primary ml-auto">Submit to Quickstatements ↗</button> <button class="btn btn-primary">Copy to
-      clipboard</button>
+    <button class="btn btn-primary ml-auto">Submit to Quickstatements ↗</button>
+    <button class="btn btn-primary copy-all-buttton">Copy to clipboard</button>
   </div>
 </div>
 </div>
@@ -144,6 +146,17 @@
       const checkboxes = document.getElementsByClassName("checkbox");
       for (const checkbox of checkboxes) {
         checkbox.checked = !checkbox.checked;
+      }
+    })
+  }
+
+  const copy_buttons = document.getElementsByClassName("copy-button");
+  for (const copy_button of copy_buttons) {
+    copy_button.addEventListener("click", () => {
+      const qs_id = copy_button["name"];
+      const quickstatements = document.getElementById("qs-" + qs_id + "-plain");
+      if (navigator.clipboard) {
+        navigator.clipboard.writeText(quickstatements.innerText)
       }
     })
   }


### PR DESCRIPTION
Rebase of [2345](https://github.com/WDscholia/scholia/pull/2345)

### Description
> Please include a summary of the change, relevant motivation and context. If possible and applicable, include before and after screenshots and a URL where the changes can be seen.
    
This PR adds the ability to act on many QuickStatements rather than running them individually

![image](https://github.com/WDscholia/scholia/assets/6676843/850e7770-70e2-4a2a-bbff-e4d67130d7cc)
![image](https://github.com/WDscholia/scholia/assets/6676843/306440c6-3077-45fb-82ed-5ddf81ac5a44)


### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* Tested functionality with 10 quickstatements

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [ ] My changes generate no new warnings
* [ ] I have not used code from external sources without attribution
* [ ] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)

