### PR TITLE
fix-2514: Fix ceurws scraper where URN is unavailable

### DIFF
--- a/scholia/scrape/ceurws.py
+++ b/scholia/scrape/ceurws.py
@@ -355,15 +355,19 @@ def proceedings_url_to_proceedings(url, return_tree=False):
         if len(acronym_elements) == 1:
             proceedings['shortname'] = acronym_elements[0].text
 
-    proceedings['urn'] = \
-        tree.xpath("//span[@class='CEURURN']")[0].text
+    urn_elements = tree.xpath("//span[@class='CEURURN']")
+    if len(urn_elements) == 1:
+        proceedings['urn'] = urn_elements[0].text
 
-    proceedings['title'] = re.sub(
-        r'\s+', ' ',
-        tree.xpath("//span[@class='CEURFULLTITLE']")[0].text).strip()
+    title_elements = tree.xpath("//span[@class='CEURFULLTITLE']")
+    if len(title_elements) == 1:
+        proceedings['title'] = re.sub(
+            r'\s+', ' ',
+            title_elements[0].text).strip()
 
-    proceedings['date'] = \
-        tree.xpath("//span[@class='CEURPUBDATE']")[0].text
+    date_elements = tree.xpath("//span[@class='CEURPUBDATE']")
+    if len(date_elements) == 1:
+        proceedings['date'] = date_elements[0].text
 
     proceedings['published_in_q'] = 'Q27230297'
 


### PR DESCRIPTION
Fixes #2514 
    
### Caveats

Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* I ran the command `python -m scholia.scrape.ceurws proceedings-url-to-quickstatements https://ceur-ws.org/Vol-175/` which printed QS statements.

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
