### PR TITLE
Added three more relevant CiTO intention types

### DIFF
--- a/scholia/app/templates/work_data.sparql
+++ b/scholia/app/templates/work_data.sparql
@@ -207,7 +207,7 @@ WHERE {
   {
     SELECT (COUNT(DISTINCT ?citationStatement) AS ?value) ?order ?description ?valueUrl WHERE {
       VALUES ?work { wd:{{ q }} }
-      VALUES ?intention { wd:Q96472102 wd:Q101149476 }
+      VALUES ?intention { wd:Q96472102 wd:Q101149476 wd:Q96471820 }
       ?work ^ps:P2860 ?citationStatement . ?citationStatement pq:P3712 ?intention .
       BIND(20 AS ?order)
       BIND("Data or method used by" AS ?description)
@@ -218,7 +218,7 @@ WHERE {
   {
     SELECT (COUNT(DISTINCT ?citationStatement) AS ?value) ?order ?description ?valueUrl WHERE {
       VALUES ?work { wd:{{ q }} }
-      VALUES ?intention { wd:Q107687829 wd:Q107710355 }
+      VALUES ?intention { wd:Q107687829 wd:Q107710355 wd:Q117121923 wd:Q117121932 }
       ?work ^ps:P2860 ?citationStatement . ?citationStatement pq:P3712 ?intention .
       BIND(21 AS ?order)
       BIND("Disagreed with by" AS ?description)


### PR DESCRIPTION
### Description
Currently, the data table of an article has rows for "reuse" and "disagreement". But not all CiTO intention types were included (because they did not exist at the time when the current query was written).
    
### Caveats

This could make the query a bit more slow.

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

### Testing
The following page before the patch does not show a "disagreement" but after it should:

* https://scholia.toolforge.org/work/Q87908797

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [ ] My changes generate no new warnings
* [ ] I have not used code from external sources without attribution
* [ ] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [ ] There are no remaining debug statements (print, console.log, ...)
