### PR TITLE
added birth and death dates to author timeline

### DIFF
--- a/scholia/app/templates/author_timeline.sparql
+++ b/scholia/app/templates/author_timeline.sparql
@@ -94,5 +94,15 @@ WHERE {
     BIND(CONCAT("🏆 ",?award_label) AS ?label)
     ?award_statement pq:P585 ?beginning .
   }
-
+  UNION
+  {
+    target: wdt:P569 ?beginning .
+    BIND(CONCAT("👶 born ") AS ?label) .
+  }
+  UNION
+  {
+    target: wdt:P570 ?beginning .
+    BIND(CONCAT("💀 died") AS ?label) .
+  }
+			    
 } 


### PR DESCRIPTION
Fixes # (issue number, if applicable) 

### Description
> added birth and death dates to the author timeline
    
### Caveats

* I've only tested this on https://query.wikidata.org/ , I don't have a full local stack to test on. 
* This is my first contribution to this project and my first SPARQL contribution to any project.
* No changes to python code. Two new stanzas in SPQARL query.

### Testing

I ran the SPQARL query on https://query.wikidata.org/. the query is too long to use the URL shortener.

### Checklist
* [ X  ] My changes generate no new warnings
* [ X ] I have not used code from external sources without attribution
* [ X ] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [ X ] There are no remaining debug statements (print, console.log, ...)
