### PR TITLE
Fix #2532 Change death emoji

### DIFF
--- a/scholia/app/templates/author_timeline.sparql
+++ b/scholia/app/templates/author_timeline.sparql
@@ -102,7 +102,7 @@ WHERE {
   UNION
   {
     target: wdt:P570 ?beginning .
-    BIND(CONCAT("💀 died") AS ?label) .
+    BIND(CONCAT("🥀 died") AS ?label) .
   }
 			    
 } 


### PR DESCRIPTION
Changed death emoji in timeline on author aspect from skull to "Wilting Flower"

Fixes #2532

### Description
Changed death emoji in timeline on author aspect from skull to "Wilting Flower"
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* http://127.0.0.1:8100/author/Q7085#timeline


### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
