### PR TITLE
Fix #2534 and #2535 Test in wikipedia and arxiv

### DIFF
--- a/scholia/arxiv.py
+++ b/scholia/arxiv.py
@@ -66,8 +66,8 @@ def get_metadata(arxiv):
     >>> metadata = get_metadata('1503.00759')
     >>> metadata['doi'] == '10.1109/JPROC.2015.2483592'
     True
-    >>> get_metadata('5432.01234')
-    {'error': 'Not found'}
+    >>> 'error' in get_metadata('5432.01234')
+    True
 
     """
     arxiv = arxiv.strip()

--- a/scholia/wikipedia.py
+++ b/scholia/wikipedia.py
@@ -110,7 +110,8 @@ def q_to_bibliography_templates(q):
     query = BIBLIOGRAPHY_SPARQL_QUERY.format(q=q)
     url = SPARQL_ENDPOINT
     params = {'query': query, 'format': 'json'}
-    response = requests.get(url, params=params)
+    headers = {'User-Agent': config['requests'].get('user_agent')}
+    response = requests.get(url, params=params, headers=headers)
     data = response.json()
 
     wikitext = ('<!-- Generated with scholia.wikipedia '


### PR DESCRIPTION
Doctest in arxiv.py failed because of change in error message from the arxiv server. A more general test is now done in the doctest which is not dependent on the specicific error message.

A doctest in wikipedia.py failed because the default requests user agent was banned by the Wikidata Query Service. Now the user agent is set based on the Scholia configuration.

Fixes #2534 and #2535

### Description
> Please include a summary of the change, relevant motivation and context. If possible and applicable, include before and after screenshots and a URL where the changes can be seen.
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [x]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* tox

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
