### PR TITLE
Allow setting the port number from the command line

### DIFF
--- a/runserver.py
+++ b/runserver.py
@@ -1,5 +1,5 @@
 from scholia.app import create_app
-
+import sys
 
 app = create_app(
     text_to_topic_q_text_enabled=False,
@@ -7,4 +7,7 @@ app = create_app(
 app.config['APPLICATION_ROOT'] = '/'
 
 if __name__ == '__main__':
-    app.run(debug=True, port=8100)
+    if len(sys.argv) == 2:
+        app.run(debug=True, port=sys.argv[1])
+    else:
+        app.run(debug=True, port=8100)


### PR DESCRIPTION
for testing with different backends. This allows starting two servers, with different configurations and in this way, compare the results with two or more different SPARQL endpoint.

This will help port SPARQL queries to SPARQL1.1 and see the impact of the WDQS graph split.

Implements #2540

![image](https://github.com/user-attachments/assets/95711053-1987-4b0c-81e1-1164e7b43457)
