### PR TITLE
Lists retracted articles on the author aspect

### DIFF
--- a/scholia/app/templates/ask_author_retractions.sparql
+++ b/scholia/app/templates/ask_author_retractions.sparql
@@ -1,0 +1,4 @@
+ASK {
+    ?work wdt:P50 wd:{{q}} . BIND("author-retractions" AS ?aspectsubpage)
+    { ?work wdt:P31 wd:Q45182324 } UNION { ?work wdt:P793 wd:Q7316896 . } UNION { ?work wdt:P5824 [] . }
+}

--- a/scholia/app/templates/author.html
+++ b/scholia/app/templates/author.html
@@ -26,6 +26,14 @@
 
 {{ sparql_to_matrix('topics-works-matrix') }}
 
+{% call ask_query_callback('retractions') %}
+
+{{ sparql_to_table('list-of-retracted-articles') }}
+
+{{ sparql_to_iframe('retracted-articles-per-year') }}
+
+{% endcall %}
+
 
 {% endblock %}
 
@@ -69,6 +77,15 @@ div>
     <iframe class="embed-responsive-item" id="publications-per-year-iframe"></iframe>
 </div>
 
+<div id="retractions" class="d-none">
+<h3 id="list-of-retracted-articles">Number of retracted articles per year</h3>
+
+<div class="embed-responsive embed-responsive-16by9">
+  <iframe class="embed-responsive-item" id="retracted-articles-per-year-iframe"></iframe>
+</div>
+
+<table class="table table-hover" id="list-of-retracted-articles-table"></table>
+</div>
 
 <h3 id="pages-per-year">Number of pages per year</h3>
 

--- a/scholia/app/templates/author_list-of-retracted-articles.sparql
+++ b/scholia/app/templates/author_list-of-retracted-articles.sparql
@@ -1,0 +1,28 @@
+#defaultView:Table
+PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
+
+SELECT
+  (MIN(?dates) AS ?date)
+  ?work ?workLabel
+  (GROUP_CONCAT(DISTINCT ?type_label; separator=", ") AS ?type)
+  (SAMPLE(?pages_) AS ?pages)
+  ?venue ?venueLabel
+  (GROUP_CONCAT(DISTINCT ?author_label; separator=", ") AS ?authors)
+  (CONCAT("../authors/", GROUP_CONCAT(DISTINCT SUBSTR(STR(?author), 32); separator=",")) AS ?authorsUrl)
+WHERE {
+  ?work wdt:P50 target: .
+  ?work wdt:P50 ?author .
+  { ?work wdt:P31 wd:Q45182324 } UNION { ?work wdt:P793 wd:Q7316896 . } UNION { ?work wdt:P5824 [] . }
+  OPTIONAL {
+    ?author rdfs:label ?author_label_ . FILTER (LANG(?author_label_) = 'en')
+  }
+  BIND(COALESCE(?author_label_, SUBSTR(STR(?author), 32)) AS ?author_label)
+  OPTIONAL { ?work wdt:P31 ?type_ . ?type_ rdfs:label ?type_label . FILTER (LANG(?type_label) = 'en') }
+  ?work wdt:P577 ?datetimes .
+  BIND(xsd:date(?datetimes) AS ?dates)
+  OPTIONAL { ?work wdt:P1104 ?pages_ }
+  OPTIONAL { ?work wdt:P1433 ?venue }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
+}
+GROUP BY ?work ?workLabel ?venue ?venueLabel
+ORDER BY DESC(?date)

--- a/scholia/app/templates/author_retracted-articles-per-year.sparql
+++ b/scholia/app/templates/author_retracted-articles-per-year.sparql
@@ -1,0 +1,49 @@
+#defaultView:BarChart
+PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
+
+# Inspired from LEGOLAS - http://abel.lis.illinois.edu/legolas/
+# Shubhanshu Mishra, Vetle Torvik
+select ?year (count(?work) as ?number_of_publications) ?role where {
+  {
+    select (str(?year_) as ?year) (0 as ?pages) ("_" as ?role) where {
+      # default values = 0
+      ?year_item wdt:P31 wd:Q577 .
+      ?year_item wdt:P585 ?date .
+      bind(year(?date) as ?year_)
+      {
+        select (min(?year_) as ?earliest_year)  (max(?year_) as ?latest_year) where {
+          ?work wdt:P50 target: .
+          ?work wdt:P577 ?publication_date .
+          { ?work wdt:P31 wd:Q45182324 } UNION { ?work wdt:P793 wd:Q7316896 . } UNION { ?work wdt:P5824 [] . }
+          bind(year(?publication_date) as ?year_)
+        }
+      }
+      bind(year(now())+1 as ?next_year)
+      filter (?year_ >= ?earliest_year && ?year_ <= ?latest_year)
+    }
+  }
+  union {
+  {
+    select ?work (min(?years) as ?year) (count(?coauthors) as ?number_of_authors) ?author_number where {
+      ?work (p:P50|p:P2093) ?author_statement .
+      ?author_statement ps:P50 target: .
+      optional { ?author_statement pq:P1545 ?author_number . }
+      ?work (wdt:P50|wdt:P2093) ?coauthors .
+      ?work wdt:P577 ?dates .
+      { ?work wdt:P31 wd:Q45182324 } UNION { ?work wdt:P793 wd:Q7316896 . } UNION { ?work wdt:P5824 [] . }
+      bind(str(year(?dates)) as ?years) .
+    }
+    group by ?work ?author_number
+  }
+  bind(coalesce(if(?number_of_authors = 1,
+            'Solo author',
+            if(xsd:integer(?author_number) = 1,
+               'First author',
+               if(xsd:integer(?author_number) = ?number_of_authors,
+                  'Last author',
+                  'Middle author'))), 'Unknown')
+       as ?role)
+   }
+}
+group by ?year ?role
+order by ?year


### PR DESCRIPTION
Fixes #2521

### Description
This patch adds a conditional section to the `/author/` aspect. If the author is author of retracted articles, then a 'number of retracted articles' and table with the retracted article gets added to the page. If there are none, nothing is shown.
 
### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* Author without retractions: http://127.0.0.1:8100/author/Q20895241
* Author *with* retractions: http://127.0.0.1:8100/author/Q1545025#list-of-retracted-articles

In the latter case, something like this should be visible on the page:

![image](https://github.com/user-attachments/assets/94e0fac4-1150-4ba4-ba5d-ef9df56fe917)

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [ ] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
