### PR TITLE
Demonstrate rendering author's publication list via SnapQuery

### DIFF
--- a/scholia/app/templates/author.html
+++ b/scholia/app/templates/author.html
@@ -59,7 +59,7 @@
     <td>{{ publication.date }}</td>
     <td><a href="{{ publication.work }}">{{ publication.workLabel }}</a></td>
     <td>{{ publication.type }}</td>
-    <td>{% if publication.pages %}{{ publication.pages|int }}{% endif %}</td>
+    <td align="right">{% if publication.pages %}{{ publication.pages|int }}{% endif %}</td>
     <td><a href="{{ publication.venue }}">{{ publication.venueLabel }}</a></td>
     <td><a href="{{ publication.authorsUrl }}">{{ publication.authors }}</a></td>
 </tr>

--- a/scholia/app/templates/author.html
+++ b/scholia/app/templates/author.html
@@ -4,7 +4,6 @@
 
 {% block in_ready %}
 
-{{ sparql_to_table('list-of-publications') }}
 {{ sparql_to_table('venue-statistics') }}
 {{ sparql_to_table('review-statistics') }}
 {{ sparql_to_table('topics') }}
@@ -43,8 +42,30 @@
 
 <h2 id="list-of-publications">List of publications <a href="{{ url_for('app.show_author_index') }}{{ q }}/latest-works/rss"><img height="24" width="48" src="{{ url_for('static', filename='images/rss-40674_320.png') }}" alt="RSS icon" /></a></h2>
 
-<table class="table table-hover" id="list-of-publications-table"></table>
-
+<table class="table table-hover" id="list-of-publications-table">
+<thead>
+<tr>
+<th>Date</th>
+<th>Work</th>
+<th>Type</th>
+<th>Pages</th>
+<th>Venue</th>
+<th>Authors</th>
+</tr>
+</thead>
+<tbody>
+{%- for publication in list_of_publications %}
+<tr>
+    <td>{{ publication.date }}</td>
+    <td><a href="{{ publication.work }}">{{ publication.workLabel }}</a></td>
+    <td>{{ publication.type }}</td>
+    <td>{% if publication.pages %}{{ publication.pages|int }}{% endif %}</td>
+    <td><a href="{{ publication.venue }}">{{ publication.venueLabel }}</a></td>
+    <td><a href="{{ publication.authorsUrl }}">{{ publication.authors }}</a></td>
+</tr>
+{%- endfor %}
+</tbody>
+</table>
 
 <!--      SourceMD does currently not work
 

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -402,7 +402,12 @@ def show_author(q):
     else:
         first_initial, last_name = '', ''
 
-    list_of_publications = get_snapquery_records("author_list-of-publications", q=q)
+    endpoint_name = request.args.get("endpoint_name", default="wikidata")
+    list_of_publications = get_snapquery_records(
+        "author_list-of-publications",
+        q=q,
+        endpoint_name=endpoint_name,
+    )
 
     return render_template(
         'author.html',

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -30,6 +30,7 @@ from ..utils import (remove_special_characters_url, sanitize_q, string_to_list,
                      string_to_type)
 from ..wikipedia import q_to_bibliography_templates
 from ..config import config
+from ..snap import get_snapquery_records
 
 
 class RegexConverter(BaseConverter):
@@ -400,9 +401,19 @@ def show_author(q):
         first_initial, last_name = name[0], name.split()[-1]
     else:
         first_initial, last_name = '', ''
-    return render_template('author.html', q=q, first_initial=first_initial,
-                           last_name=last_name, sparql_endpoint=ep,
-                           sparql_editURL=editurl, sparql_embedURL=embedurl)
+
+    list_of_publications = get_snapquery_records("author_list-of-publications", q=q)
+
+    return render_template(
+        'author.html',
+        q=q,
+        first_initial=first_initial,
+        last_name=last_name,
+        sparql_endpoint=ep,
+        sparql_editURL=editurl,
+        sparql_embedURL=embedurl,
+        list_of_publications=list_of_publications,
+    )
 
 
 @main.route('/author/' + q_pattern + '/latest-works/rss')

--- a/scholia/snap.py
+++ b/scholia/snap.py
@@ -1,0 +1,55 @@
+from typing import Any
+
+from snapquery.snapquery_core import QueryName, NamedQueryManager, QueryBundle
+
+__all__ = [
+    "get_snapquery_records",
+]
+
+#: See documentation at https://snapquery.bitplan.com/docs
+API_ENDPOINT_FMT = "https://snapquery.bitplan.com/api/query/{domain}/{namespace}/{name}"
+
+type Result = dict[str, Any]
+type Results = list[Result]
+
+
+def get_snapquery_records(name: str, q: str) -> Results:
+    return from_programmatic_api(
+        name=name,
+        domain="scholia.toolforge.org",
+        namespace="named_queries",
+        params={"q": q},
+    )
+
+
+def from_programmatic_api(
+    name: str,
+    namespace: str,
+    domain: str,
+    *,
+    endpoint_name: str = "wikidata",
+    params: dict[str, Any] | None = None,
+    limit: int | None = None,
+) -> Results:
+    if params is not None and {"q"} != set(params):
+        raise NotImplementedError("can only support a single parameter, `q`")
+
+    query_manager = NamedQueryManager.from_samples()
+    query_name: QueryName = QueryName.from_query_id(query_id=name, namespace=namespace, domain=domain)
+    query_bundle: QueryBundle = query_manager.get_query(
+        query_name=query_name,
+        endpoint_name=endpoint_name,
+        limit=limit,
+    )
+    rv = query_bundle.sparql.queryAsListOfDicts(query_bundle.query.query, param_dict=params)
+    # would be nice to extend get_lod to
+    # rv = query_bundle.get_lod(param_dict=params)
+    return rv
+
+
+def main():
+    """"""
+    # TODO make sure you load up the queries into the local database
+    # snapquery --import /Users/cthoyt/dev/snapquery/snapquery/samples/scholia.json
+
+    # see https://snapquery.bitplan.com/query/scholia.toolforge.org/named_queries/author_list-of-publications

--- a/scholia/snap.py
+++ b/scholia/snap.py
@@ -13,12 +13,15 @@ type Result = dict[str, Any]
 type Results = list[Result]
 
 
-def get_snapquery_records(name: str, q: str) -> Results:
+def get_snapquery_records(
+    name: str, q: str, *, endpoint_name: str | None = None,
+) -> Results:
     return from_programmatic_api(
         name=name,
         domain="scholia.toolforge.org",
         namespace="named_queries",
         params={"q": q},
+        endpoint_name=endpoint_name,
     )
 
 
@@ -27,7 +30,7 @@ def from_programmatic_api(
     namespace: str,
     domain: str,
     *,
-    endpoint_name: str = "wikidata",
+    endpoint_name: str | None = None,
     params: dict[str, Any] | None = None,
     limit: int | None = None,
 ) -> Results:
@@ -35,13 +38,21 @@ def from_programmatic_api(
         raise NotImplementedError("can only support a single parameter, `q`")
 
     query_manager = NamedQueryManager.from_samples()
-    query_name: QueryName = QueryName.from_query_id(query_id=name, namespace=namespace, domain=domain)
+    query_name: QueryName = QueryName.from_query_id(
+        query_id=name,
+        namespace=namespace,
+        domain=domain,
+    )
     query_bundle: QueryBundle = query_manager.get_query(
         query_name=query_name,
-        endpoint_name=endpoint_name,
+        endpoint_name=endpoint_name or "wikidata",
         limit=limit,
     )
-    rv = query_bundle.sparql.queryAsListOfDicts(query_bundle.query.query, param_dict=params)
+    rv = query_bundle.sparql.queryAsListOfDicts(
+        query_bundle.query.query,
+        param_dict=params,
+        # {"q": "Q80"}  # Tim Berners-Lee
+    )
     # would be nice to extend get_lod to
     # rv = query_bundle.get_lod(param_dict=params)
     return rv


### PR DESCRIPTION
Note, before you run this, you have to run `snapquery --import /Users/cthoyt/dev/snapquery/snapquery/samples/scholia.json` to import the scholia query definitions.

You can also add endpoint_name with one of `'wikidata', 'qlever-wikidata', 'qlever-dblp', 'qlever-dblp-plus', 'wikidata-openlinksw'` - http://127.0.0.1:8100/author/Q47475003?endpoint_name=wikidata-qlever. By default, if none is given, it uses `wikidata`
