### PR TITLE
Fix #2545 Make page production query faster

### DIFF
--- a/scholia/app/templates/organization_page-production.sparql
+++ b/scholia/app/templates/organization_page-production.sparql
@@ -6,29 +6,36 @@ PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 SELECT
   ?year
   (SUM(?pages_per_author) AS ?number_of_pages)
-  ?researcher_label
-WHERE {
-  {
+  ?researcher ?researcherLabel
+WITH {
+  SELECT 
+    DISTINCT ?researcher
+  WHERE {
+    ?researcher wdt:P108 | wdt:P463 | (wdt:P1416 / wdt:P361*) target: .
+  }
+} AS %researchers
+WITH {
     SELECT
-      ?researcher_label ?work ?year
+      ?researcher ?work ?year
       (SAMPLE(?pages) / COUNT(?researcher_of_paper) AS ?pages_per_author)
     WHERE {
-      # Find authors associated with organization
-      FILTER EXISTS { ?researcher wdt:P108 | wdt:P463 | (wdt:P1416 / wdt:P361*) target: . }
+      INCLUDE %researchers
       
-      ?work (wdt:P50|wdt:P2093) ?researcher_of_paper .
+      ?work (wdt:P50 | wdt:P2093) ?researcher_of_paper .
       
       # Disabled to only look on scholarly articles
       # ?work wdt:P31 wd:Q13442814 .
       
-      ?work wdt:P50 ?researcher .
-      ?work wdt:P1104 ?pages .
-      ?work wdt:P577 ?date . 
+      ?work wdt:P50 ?researcher ;
+            wdt:P1104 ?pages ;
+            wdt:P577 ?date . 
       BIND(STR(YEAR(?date)) AS ?year) 
-      ?researcher rdfs:label ?researcher_label . FILTER(LANG(?researcher_label) = 'en')
     } 
-    GROUP BY ?work ?researcher_label ?year
-  }
+    GROUP BY ?work ?researcher ?year
+} AS %results
+WHERE {
+  INCLUDE %results
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }
-GROUP BY ?year ?researcher_label 
+GROUP BY ?year ?researcher ?researcherLabel
 ORDER BY ?year


### PR DESCRIPTION
In the organization aspect the page production query was slow. The new version makes a subquery to identify authors

Fixes #2545

### Description
Modify SPARQL query with a WITH subquery
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* http://127.0.0.1:8100/organization/Q1269766#page-production - a university

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
