### PR TITLE
Fix #2550 Fix WDQS link

### DIFF
--- a/scholia/app/static/scholia.js
+++ b/scholia/app/static/scholia.js
@@ -244,7 +244,7 @@ function sparqlDataToSimpleData(response) {
 function sparqlToDataTablePost(sparql, element, filename, options = {}) {
     sparqlToDataTablePost2(
         "https://query.wikidata.org/sparql",
-        "https://query.wikidata.org/",
+        "https://query.wikidata.org/#",
         sparql, element, filename, options
     );
 }
@@ -253,7 +253,10 @@ function sparqlToDataTablePost(sparql, element, filename, options = {}) {
 function sparqlToDataTablePost2(url, editURL, sparql, element, filename, options = {}) {
     // Options: paging=
     if (!url) url = "https://query.wikidata.org/sparql";
-    if (!editURL) editURL = "https://query.wikidata.org/";
+
+    /* The edit URL needs a hashmark.  */
+    if (!editURL) editURL = "https://query.wikidata.org/#";
+    
     var paging = (typeof options.paging === 'undefined') ? true : options.paging;
     var sDom = (typeof options.sDom === 'undefined') ? 'lfrtip' : options.sDom;
 
@@ -315,15 +318,17 @@ function sparqlToDataTable(sparql, element, filename, options = {}) {
 function sparqlToDataTable2(url, editURL, sparql, element, filename, options = {}) {
     // Options: paging=true
     if (!url) url = "https://query.wikidata.org/sparql";
-    if (!editURL) editURL = "https://query.wikidata.org/";
+
+    /* The edit URL needs a hashmark.  */
+    if (!editURL) editURL = "https://query.wikidata.org/#";
+
     var paging = (typeof options.paging === 'undefined') ? true : options.paging;
     var sDom = (typeof options.sDom === 'undefined') ? 'lfrtip' : options.sDom;
     var url = url + "?query=" + encodeURIComponent(sparql) + '&format=json';
 
     const datatableFooter =
         '<caption><span style="float:left; font-size:smaller;"><a href="' + editURL +
-        encodeURIComponent(sparql) +
-        '">Wikidata Query Service</a></span>' +
+        encodeURIComponent(sparql) + '">Wikidata Query Service</a></span>' +
         '<span style="float:right; font-size:smaller;"><a href="https://github.com/WDscholia/scholia/blob/master/scholia/app/templates/' +
         filename +
         '">' +
@@ -445,7 +450,7 @@ function sparqlToDataTable2(url, editURL, sparql, element, filename, options = {
 function sparqlToIframe(sparql, element, filename) {
     sparqlToIframe2(
         "https://query.wikidata.org/sparql",
-        "https://query.wikidata.org/",
+        "https://query.wikidata.org/#",
         "https://query.wikidata.org/embed.html#",
         sparql, element, filename, options
     );
@@ -455,7 +460,10 @@ function sparqlToIframe(sparql, element, filename) {
 function sparqlToIframe2(url, editURL, embedURL, sparql, element, filename) {
     let $iframe = $(element);
     if (!url) url = "https://query.wikidata.org/sparql";
-    if (!editURL) editURL = "https://query.wikidata.org/";
+
+    /* The edit URL needs a hashmark.  */
+    if (!editURL) editURL = "https://query.wikidata.org/#";
+
     if (!embedURL) embedURL = "https://query.wikidata.org/embed.html#";
 
     const wikidata_sparql = url + "?query=" + encodeURIComponent(sparql);


### PR DESCRIPTION
Now includes a hashmark in the base URL for the Wikidata Query Service.

Fixes #2550

### Description
Add hash mark to default parameter
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* http://127.0.0.1:8100/author/Q18016466
* http://127.0.0.1:8100/work/

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [ ] There are no remaining debug statements (print, console.log, ...)
