### PR TITLE
Fix #2554 LIMIT retracted works returns

### DIFF
--- a/scholia/app/templates/work-index_recently-retracted-works.sparql
+++ b/scholia/app/templates/work-index_recently-retracted-works.sparql
@@ -1,7 +1,11 @@
 SELECT DISTINCT
-  ?retracted_work ?retracted_workLabel (CONCAT("/work/", SUBSTR(STR(?retracted_work), 32)) AS ?retracted_workUrl)
+  ?retracted_work ?retracted_workLabel
+  (CONCAT("/work/", SUBSTR(STR(?retracted_work), 32)) AS ?retracted_workUrl)
+  
   ?date
-  ?retraction ?retractionLabel (CONCAT("/work/", SUBSTR(STR(?retraction), 32)) AS ?retractionUrl)
+  
+  ?retraction ?retractionLabel
+  (CONCAT("/work/", SUBSTR(STR(?retraction), 32)) AS ?retractionUrl)
 WITH {
   # Find retracted papers indicated by instance of retracted paper, 
   # by retraction notice property or by significant event
@@ -26,3 +30,4 @@ WHERE {
   SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 }
 ORDER BY DESC(?date)
+LIMIT 500


### PR DESCRIPTION
Add LIMIT to SPARQL query on work index page for recently retracted works.

Fixes #2554

### Description
Add LIMIT to SPARQL.
Style in SPARQL
    
The query and table built-up does not seem to be faster.

### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* http://127.0.0.1:8100/work/

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
