### PR TITLE
Update CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,9 +1,6 @@
 cff-version: 1.2.0
 message: Please cite the following works when using this software.
 type: software
-abstract: >-
-  November 2021 version in relation to the end of the Robustifying Scholia
-  project.
 authors:
   - family-names: Nielsen
     given-names: Finn Årup
@@ -11,16 +8,11 @@ authors:
     given-names: Daniel
   - family-names: Willighagen
     given-names: Egon
-date-released: 2021-11-30
 doi: 10.5281/ZENODO.2647462
 identifiers:
   - type: doi
     value: 10.5281/ZENODO.2647462
-  - type: url
-    value: https://zenodo.org/record/2647462
-title: Scholia, v0.3
-url: https://zenodo.org/record/2647462
-version: v0.3
+title: Scholia
 preferred-citation:
   authors:
     - family-names: Nielsen

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,5 +1,9 @@
-cff-version: 1.1.0
+cff-version: 1.2.0
 message: Please cite the following works when using this software.
+type: software
+abstract: >-
+  November 2021 version in relation to the end of the Robustifying Scholia
+  project.
 authors:
   - family-names: Nielsen
     given-names: Finn Årup
@@ -7,11 +11,45 @@ authors:
     given-names: Daniel
   - family-names: Willighagen
     given-names: Egon
-doi: 10.1007/978-3-319-70407-4_36
+date-released: 2021-11-30
+doi: 10.5281/ZENODO.2647462
 identifiers:
   - type: doi
-    value: 10.1007/978-3-319-70407-4_36
+    value: 10.5281/ZENODO.2647462
   - type: url
-    value: http://www2.imm.dtu.dk/pubdb/views/edoc_download.php/7010/pdf/imm7010.pdf
-title: Scholia, Scientometrics and Wikidata
-url: http://www2.imm.dtu.dk/pubdb/views/edoc_download.php/7010/pdf/imm7010.pdf
+    value: https://zenodo.org/record/2647462
+title: Scholia, v0.3
+url: https://zenodo.org/record/2647462
+version: v0.3
+preferred-citation:
+  authors:
+    - family-names: Nielsen
+      given-names: Finn Årup
+    - family-names: Mietchen
+      given-names: Daniel
+    - family-names: Willighagen
+      given-names: Egon
+  doi: 10.1007/978-3-319-70407-4_36
+  collection-title: "The Semantic Web: ESWC 2017 Satellite Events"
+  conference:
+    name: ESWC 2017 Satellite Events
+    date-start: 2017-05-28
+    date-end: 2017-06-01
+    city: Portorož
+    country: SI
+  identifiers:
+    - type: doi
+      value: 10.1007/978-3-319-70407-4_36
+    - type: url
+      value: http://dx.doi.org/10.1007/978-3-319-70407-4_36
+  title: Scholia, Scientometrics and Wikidata
+  url: http://dx.doi.org/10.1007/978-3-319-70407-4_36
+  year: 2017
+  isbn: '9783319704067'
+  issn: 0302-9743
+  journal: Lecture Notes in Computer Science
+  publisher:
+    name: Springer International Publishing
+  start: '237'
+  end: '259'
+  type: conference-paper


### PR DESCRIPTION
### Description
The CITATION.cff was version 1.1.0 instead of 1.2.0; additionally, the top-level (main) reference should describe the software/dataset itself. Preferred citations such as the 2017 conference paper should go in `preferred-citation`.
    
### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

    pipx run cffconvert --validate --url https://raw.githubusercontent.com/larsgw/scholia/refs/heads/larsgw-patch-2/CITATION.cff
