### PR TITLE
Fix #2577 Disallowing indexing

### DIFF
--- a/scholia/app/templates/base.html
+++ b/scholia/app/templates/base.html
@@ -61,7 +61,7 @@ askQuery("{{ panel }}", `# tool: scholia
 
 {% block metas %}
 <meta charset="UTF-8">
-<meta name="robots" content="index, nofollow">
+<meta name="robots" content="noindex, nofollow">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
 <meta name="og:url" content="{{ 'https://scholia.toolforge.org' + request.path }}" />

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -2751,20 +2751,28 @@ def show_robots_txt():
     User-agent: *
     Disallow: /
 
-    Scholia's function returns a robots.txt with 'Allow' for all. We would like
-    bots to index, but not crawl Scholia. Crawling is also controlled by the
-    HTML meta tag 'robots' thatis set to the content: noindex, nofollow on all
-    pages. So Scholia's robots.txt is:
+    We would like bots to index, but not crawl Scholia. Crawling is
+    also controlled by the HTML meta tag 'robots' that is set to the
+    content: noindex, nofollow on all pages.
 
     User-agent: *
     Allow: /
 
-    If this results in too much crawling or load on the Toolforge
+    This results in too much crawling or load on the Toolforge
     infrastructure then it should be changed.
+
+    Given that most of the content on Scholia does not get indexed,
+    there are little reason to index Scholia's pages, perhaps other
+    than the main page and the about page.
+
+    Thus for now the `robots.txt` is set to
+
+    User-agent: *
+    Disallow: /
 
     """
     ROBOTS_TXT = ('User-agent: *\n'
-                  'Allow: /\n')
+                  'Disallow: /\n')
     return Response(ROBOTS_TXT, mimetype="text/plain")
 
 


### PR DESCRIPTION
There are probably a lot of bot requests on Scholia and there is little to index, so to lower the load this change disallow in robots.txt and noindex in meta tag.
- This will not help for malicious bots
- main page and about page could have been exempted

Fixes #2577

### Description
Bot load issue
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [x]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* python runserver.py
* Check meta tag
* Check http://127.0.0.1:8100/robots.txt

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
