### PR TITLE
Match editurl with where the query is run

### DIFF
--- a/scholia/config.py
+++ b/scholia/config.py
@@ -20,7 +20,7 @@ CONFIG_FILENAMES = [
 DEFAULTS = """
 [query-server]
 sparql_endpoint = https://query-legacy-full.wikidata.org/sparql
-sparql_editurl = https://query.wikidata.org/#
+sparql_editurl = https://query-legacy-full.wikidata.org/#
 sparql_embedurl = https://query-legacy-full.wikidata.org/embed.html#
 
 [requests]


### PR DESCRIPTION
Fixes #2593

### Description
Match editurl with where the query is run. Previously, it was pointing to the main EP.
    
### Caveats
The label of the link is unchanged. I just noticed that that label for the same link under `iframe`s says "WDQS legacy full graph" but we do not have any configuration for this, and I suggest to not change that.