### PR TITLE
Fix #2593 Change sparql_editurl to legacy-full

### DIFF
--- a/scholia/config.py
+++ b/scholia/config.py
@@ -20,7 +20,7 @@ CONFIG_FILENAMES = [
 DEFAULTS = """
 [query-server]
 sparql_endpoint = https://query-legacy-full.wikidata.org/sparql
-sparql_editurl = https://query.wikidata.org/#
+sparql_editurl = https://query-legacy-full.wikidata.org/#
 sparql_embedurl = https://query-legacy-full.wikidata.org/embed.html#
 
 [requests]


### PR DESCRIPTION
Fixes #2593

### Description
Make correspondence between SPARQL links
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* View the link on a page and clicked

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
