### PR TITLE
Added titles for the chemistry aspect panels

### DIFF
--- a/scholia/app/templates/chemical-class_class-hierarchy.sparql
+++ b/scholia/app/templates/chemical-class_class-hierarchy.sparql
@@ -1,3 +1,4 @@
+# title: network depiction of the class hierarchy
 #defaultView:Graph
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 

--- a/scholia/app/templates/chemical-class_found-in-taxon.sparql
+++ b/scholia/app/templates/chemical-class_found-in-taxon.sparql
@@ -1,3 +1,4 @@
+# title: taxons in which this chemical class is found
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
 SELECT

--- a/scholia/app/templates/chemical-class_identifiers.sparql
+++ b/scholia/app/templates/chemical-class_identifiers.sparql
@@ -1,3 +1,4 @@
+# title: identifiers for this chemical class
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
 SELECT

--- a/scholia/app/templates/chemical-class_publications-per-year.sparql
+++ b/scholia/app/templates/chemical-class_publications-per-year.sparql
@@ -1,3 +1,4 @@
+# title: histogram of the number of articles per year about this chemical class
 #defaultView:BarChart
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 

--- a/scholia/app/templates/chemical-class_recent-literature.sparql
+++ b/scholia/app/templates/chemical-class_recent-literature.sparql
@@ -1,3 +1,4 @@
+# title: recent literature for this chemical class
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
 SELECT

--- a/scholia/app/templates/chemical-class_related-chemicals.sparql
+++ b/scholia/app/templates/chemical-class_related-chemicals.sparql
@@ -1,3 +1,4 @@
+# title: lists related chemicals for this class
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
 SELECT ?mol ?molLabel ?InChIKey ?CAS ?CASUrl ?ChemSpider ?ChemSpiderUrl ?PubChem_CID ?PubChem_CIDUrl WITH {

--- a/scholia/app/templates/chemical-element_allotropes.sparql
+++ b/scholia/app/templates/chemical-element_allotropes.sparql
@@ -1,3 +1,4 @@
+# title: list known allotropes
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
 SELECT DISTINCT ?allotrope ?allotropeLabel ?density ?densityUnit ?densityUnitLabel WITH {

--- a/scholia/app/templates/chemical-element_data.sparql
+++ b/scholia/app/templates/chemical-element_data.sparql
@@ -1,3 +1,4 @@
+# title: data for this chemical element
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
 SELECT DISTINCT ?description ?value ?valueUrl

--- a/scholia/app/templates/chemical-element_isotopes.sparql
+++ b/scholia/app/templates/chemical-element_isotopes.sparql
@@ -1,3 +1,4 @@
+# title: list the isotopes for this chemical element
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
 SELECT ?isotope ?isotopeLabel ?protons ?neutrons ?mass ?massUnit ?massUnitLabel ?halflife ?halflifeUnit?halflifeUnitLabel

--- a/scholia/app/templates/chemical-element_recent-literature.sparql
+++ b/scholia/app/templates/chemical-element_recent-literature.sparql
@@ -1,3 +1,4 @@
+# title: recent literature about this chemical element
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
 SELECT ?date ?work ?workLabel ?type ?topics

--- a/scholia/app/templates/chemical_biological-processes.sparql
+++ b/scholia/app/templates/chemical_biological-processes.sparql
@@ -1,3 +1,4 @@
+# title: biological processes in which this chemical is involved
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
 SELECT DISTINCT

--- a/scholia/app/templates/chemical_found-in-taxon.sparql
+++ b/scholia/app/templates/chemical_found-in-taxon.sparql
@@ -1,3 +1,4 @@
+# title: lists the taxons in which this chemical is found
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
 SELECT DISTINCT ?taxon ?taxonLabel (CONCAT("/taxon/", SUBSTR(STR(?taxon), 32)) AS ?taxonUrl)


### PR DESCRIPTION
Adds missing query titles, needed for downstream use.

### Description
Not all `chemical` aspect queries have titles:

![image](https://github.com/user-attachments/assets/af1373fe-0623-4300-9d6d-2cb221880c5e)

This patch adds a good number of them.
    
### Caveats
The titles are listed as comments in the SPARQL. If not well-formed, it can break running the SPARQL query.

### Testing
Check if the following aspects still show content in all panels:

* `chemical`
* `chemical-class`
* `chemical-element`

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [ ] My changes generate no new warnings
* [ ] I have not used code from external sources without attribution
* [ ] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [ ] There are no remaining debug statements (print, console.log, ...)
