### PR TITLE
fix: update versioneer.py for Python 3 compatibility

### DIFF
--- a/versioneer.py
+++ b/versioneer.py
@@ -339,9 +339,13 @@ def get_config_from_root(root):
     # configparser.NoOptionError (if it lacks "VCS="). See the docstring at
     # the top of versioneer.py for instructions on writing your setup.cfg .
     setup_cfg = os.path.join(root, "setup.cfg")
-    parser = configparser.SafeConfigParser()
+#    parser = configparser.SafeConfigParser()
+    parser = configparser.ConfigParser()
+
     with open(setup_cfg, "r") as f:
-        parser.readfp(f)
+#        parser.readfp(f)
+        parser.read_file(f)
+
     VCS = parser.get("versioneer", "VCS")  # mandatory
 
     def get(parser, name):


### PR DESCRIPTION
### Description

This PR updates `versioneer.py` to make it compatible with Python 3 by replacing deprecated methods that were causing issues during the setup phase of the project.

**Changes made:**
- Replaced `configparser.SafeConfigParser()` with `configparser.ConfigParser()`
- Replaced `parser.readfp(f)` with `parser.read_file(f)`

These methods were deprecated and removed in Python 3.2+ and 3.9 respectively, causing the following errors:
- `AttributeError: module 'configparser' has no attribute 'SafeConfigParser'`
- `AttributeError: 'ConfigParser' object has no attribute 'readfp'`

**Impact:**
These changes ensure that contributors and users running the project on Python 3.8 and above won't face installation issues caused by versioneer's setup logic.

This fix does not alter any runtime logic of the application itself — it only affects the project setup process.

### Caveats

- [x] Not a breaking change
- [ ] No changes to documentation needed
- [ ] No new dependencies introduced
### Testing

I verified the fix locally by running:

- `python setup.py --version` → This successfully outputs the version number using the updated versioneer logic.
- Ran `tox` in Python 3.8 and 3.9 environments, and the setup succeeded without configparser errors.

**Environment:**
- OS: Linux Mint 21.3
- Python: 3.8.18
### Checklist

- [x] My code passes the [tox](https://tox.readthedocs.io/en/latest/) check
- [x] My changes generate no new warnings
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have not used code from external sources without attribution
- [x] There are no remaining debug statements
- [ ] I have considered accessibility (N/A for backend config)
