### PR TITLE
fix: redirect topic links to correct topic aspect in event panel

### DIFF
--- a/scholia/app/templates/event_topic-scores.sparql
+++ b/scholia/app/templates/event_topic-scores.sparql
@@ -2,7 +2,8 @@
 
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
-SELECT ?score ?topic ?topicLabel ?topicDescription
+ SELECT ?score ?topic ?topicLabel ?topicDescription
+  (CONCAT("/topic/", STRAFTER(STR(?topic), "http://www.wikidata.org/entity/")) AS ?topicUrl)
 WITH {
   SELECT
     DISTINCT ?person


### PR DESCRIPTION
Fixes #2568

### Description

This PR fixes the redirection of topic links in the event panel. Previously, clicking on a topic in the "Topic scores" table of the event aspect would redirect to the *event aspect* instead of the *topic aspect*. This caused confusion and disrupted the expected navigation flow.

**What’s fixed:**
- Modified `event_topic-scores.sparql` so that the topic links correctly redirect to the topic aspect.

### Before and After
- **Before:** Clicking on a topic inside the event panel → redirected to the **event** aspect.
- **After:** Clicking on a topic inside the event panel → correctly redirects to the **topic** aspect.

No visual UI changes; only corrected URL logic.

### Caveats

- None

Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*

* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing

Manual testing performed:

* Navigated to an event page on the local dev server.
* Clicked on a topic inside the "Topic scores" section.
* Verified that it correctly redirects to the topic aspect page.

### Checklist

* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas (if applicable)
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation
* [x] There are no remaining debug statements (print, console.log, ...)
