### PR TITLE
Delete the previous content, like a 'time out' error message

### DIFF
--- a/scholia/app/static/scholia.js
+++ b/scholia/app/static/scholia.js
@@ -395,9 +395,10 @@ function sparqlToDataTable2(url, editURL, sparql, element, filename, options = {
                 }
 
                 $("#" + loaderID).remove(); // remove loader
+                tableElement = document.getElementById(element.slice(1))
+                if (tableElement) tableElement.innerHTML = ''
 
                 if ($.fn.dataTable.isDataTable(element)) {
-                    // $(element).DataTable().clear();
                     $(element).DataTable().rows.add(convertedData.data).draw();
                 } else {
                     $(element).DataTable({
@@ -420,6 +421,8 @@ function sparqlToDataTable2(url, editURL, sparql, element, filename, options = {
                 }
             } else {
                 $('#' + loaderID).remove(); // remove loader
+                tableElement = document.getElementById(element.slice(1))
+                if (tableElement) tableElement.innerHTML = ''
 
                 if (!$.fn.dataTable.isDataTable(element)) {
                     $(element).DataTable({

--- a/scholia/app/static/scholia.js
+++ b/scholia/app/static/scholia.js
@@ -395,6 +395,7 @@ function sparqlToDataTable2(url, editURL, sparql, element, filename, options = {
                 }
 
                 $("#" + loaderID).remove(); // remove loader
+                // remove old content, like a 'time out' error message:
                 tableElement = document.getElementById(element.slice(1))
                 if (tableElement) tableElement.innerHTML = ''
 
@@ -421,6 +422,7 @@ function sparqlToDataTable2(url, editURL, sparql, element, filename, options = {
                 }
             } else {
                 $('#' + loaderID).remove(); // remove loader
+                // remove old content, like a 'time out' error message:
                 tableElement = document.getElementById(element.slice(1))
                 if (tableElement) tableElement.innerHTML = ''
 


### PR DESCRIPTION
Fixes #2560

### Description
This patch resets the content of the HTML table element, e.g. the `<p`> element with a 'time out' error message. 
    
### Caveats
It looks that it does the right thing, e.g. for the test page in the bug report.

Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

### Testing
From the bug report:

* https://scholia.toolforge.org/authors/Q21264190,Q30103188,Q43200797,Q51366847,Q53103589,Q54806715,Q112275836,Q56447936,Q57062249,Q57225833,Q57243435,Q57302902,Q57552918,Q61044058,Q61665725,Q63865447,Q88152670,Q90750787,Q92675346,Q95981554,Q101086361,Q102429134,Q102430988,Q102552081,Q108730193,Q111394757

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [ ] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [ ] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
