### PR TITLE
Lazy loading of table and iframe panels

### DIFF
--- a/scholia/app/templates/base.html
+++ b/scholia/app/templates/base.html
@@ -12,13 +12,13 @@ options={{ options | tojson }});
 
 {% macro sparql_to_table(panel, options={}) -%}
 // {{ panel }} table
-console.log('adding an observer to: #{{ panel }}-table');
+// console.log('adding an observer to: #{{ panel }}-table');
 const {{ panel | replace("-", "") }}Observer = new IntersectionObserver({{ panel | replace("-", "") }}HandleIntersection);
 {{ panel | replace("-", "") }}Observer.observe(document.querySelector('#{{ panel }}-table'));
 function {{ panel | replace("-", "") }}HandleIntersection(entries, observer){
   entries.forEach(entry => {
     if (entry.intersectionRatio > 0) {
-      console.log('Element is in the viewport! #{{ panel }}-table');
+      // console.log('Element is in the viewport! #{{ panel }}-table');
       sparqlToDataTable2("{{ sparql_endpoint }}", "{{ sparql_editURL }}",
         `# tool: scholia
         {% include aspect + '_' + panel + '.sparql' %}
@@ -34,13 +34,13 @@ function {{ panel | replace("-", "") }}HandleIntersection(entries, observer){
 
 {% macro sparql_to_iframe(panel) -%}
 // {{ panel }} iframe
-console.log('adding an observer to: #{{ panel }}-iframe');
+// console.log('adding an observer to: #{{ panel }}-iframe');
 const {{ panel | replace("-", "") }}Observer = new IntersectionObserver({{ panel | replace("-", "") }}HandleIntersection);
 {{ panel | replace("-", "") }}Observer.observe(document.querySelector('#{{ panel }}-iframe'));
 function {{ panel | replace("-", "") }}HandleIntersection(entries, observer){
   entries.forEach(entry => {
     if (entry.intersectionRatio > 0) {
-      console.log('Element is in the viewport! #{{ panel }}-iframe');
+      // console.log('Element is in the viewport! #{{ panel }}-iframe');
       sparqlToIframe2("{{ sparql_endpoint }}", "{{ sparql_editURL }}",
         "{{ sparql_embedURL }}", `# tool: scholia
         {% include aspect + '_' + panel + '.sparql' %}`,

--- a/scholia/app/templates/base.html
+++ b/scholia/app/templates/base.html
@@ -12,12 +12,24 @@ options={{ options | tojson }});
 
 {% macro sparql_to_table(panel, options={}) -%}
 // {{ panel }} table
-sparqlToDataTable2("{{ sparql_endpoint }}", "{{ sparql_editURL }}",
-`# tool: scholia
-{% include aspect + '_' + panel + '.sparql' %}
-`,
-"#{{ panel }}-table", "{{ aspect }}_{{ panel }}.sparql",
-options={{ options | tojson }});
+console.log('adding an observer to: #{{ panel }}-table');
+const {{ panel | replace("-", "") }}Observer = new IntersectionObserver({{ panel | replace("-", "") }}HandleIntersection);
+{{ panel | replace("-", "") }}Observer.observe(document.querySelector('#{{ panel }}-table'));
+function {{ panel | replace("-", "") }}HandleIntersection(entries, observer){
+  entries.forEach(entry => {
+    if (entry.intersectionRatio > 0) {
+      console.log('Element is in the viewport! #{{ panel }}-table');
+      sparqlToDataTable2("{{ sparql_endpoint }}", "{{ sparql_editURL }}",
+        `# tool: scholia
+        {% include aspect + '_' + panel + '.sparql' %}
+        `,
+        "#{{ panel }}-table", "{{ aspect }}_{{ panel }}.sparql",
+        options={{ options | tojson }}
+      );
+      {{ panel | replace("-", "") }}Observer.unobserve(entry.target);
+    }
+  });
+}
 {%- endmacro %}
 
 {% macro sparql_to_iframe(panel) -%}
@@ -106,7 +118,7 @@ askQuery("{{ panel }}", `# tool: scholia
 	       '&format=json&callback=?';
     
     const currentAspect = window.location.pathname.split("/")[1];
-     
+
     $.getJSON(url, function (data) {
 	 var item = data.entities["{{ q }}"];
 	 if ('en' in item.labels) {

--- a/scholia/app/templates/base.html
+++ b/scholia/app/templates/base.html
@@ -34,10 +34,24 @@ function {{ panel | replace("-", "") }}HandleIntersection(entries, observer){
 
 {% macro sparql_to_iframe(panel) -%}
 // {{ panel }} iframe
-sparqlToIframe2("{{ sparql_endpoint }}", "{{ sparql_editURL }}",
-"{{ sparql_embedURL }}", `# tool: scholia
-{% include aspect + '_' + panel + '.sparql' %}`,
-"#{{ panel }}-iframe", "{{ aspect }}_{{ panel }}.sparql");
+console.log('adding an observer to: #{{ panel }}-iframe');
+const {{ panel | replace("-", "") }}Observer = new IntersectionObserver({{ panel | replace("-", "") }}HandleIntersection);
+{{ panel | replace("-", "") }}Observer.observe(document.querySelector('#{{ panel }}-iframe'));
+function {{ panel | replace("-", "") }}HandleIntersection(entries, observer){
+  entries.forEach(entry => {
+    if (entry.intersectionRatio > 0) {
+      console.log('Element is in the viewport! #{{ panel }}-iframe');
+      sparqlToIframe2("{{ sparql_endpoint }}", "{{ sparql_editURL }}",
+        "{{ sparql_embedURL }}", `# tool: scholia
+        {% include aspect + '_' + panel + '.sparql' %}`,
+        "#{{ panel }}-iframe", "{{ aspect }}_{{ panel }}.sparql"
+      );
+      {{ panel | replace("-", "") }}Observer.unobserve(entry.target);
+    }
+  });
+}
+
+
 {%- endmacro %}
 
 {% macro sparql_to_matrix(panel) -%}


### PR DESCRIPTION
Fixes #2602

### Description
The patch uses the `Intersection Observer API`. For each panel, it creates a unique observer. When a panel becomes visible, the (unique) handler is called. This is followed by an unobserve to ensure that the SPARQL query is run only once.
    
### Caveats
This browser compability page shows that the `Intersection Observer API` is widely available, but not on old browsers: https://caniuse.com/intersectionobserver

* [x]  Breaking change (unsupported for old browsers)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

### Testing
Open up as many pages as possible and see if you see irregularities.

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [ ] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [ ] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
