### PR TITLE
Reports articles with CiTO annotation only once, and sample the venu

### DIFF
--- a/scholia/app/templates/cito-index_recent-articles.sparql
+++ b/scholia/app/templates/cito-index_recent-articles.sparql
@@ -1,9 +1,13 @@
 select distinct ?date ?work ?workLabel ?venue ?venueLabel where {
-  ?work wdt:P577 ?dates ;
-        p:P2860 / pq:P3712 / wdt:P31 wd:Q96471816 .
-  BIND(xsd:date(?dates) AS ?date)
-  ?work wdt:P31 wd:Q109229154 . bind("explicit" as ?type_)
-  ?work wdt:P1433 ?venue .
+  {
+    select distinct ?date ?work (SAMPLE(?venue_) AS ?venue) where {
+      ?work wdt:P577 ?dates ;
+            p:P2860 / pq:P3712 / wdt:P31 wd:Q96471816 .
+      BIND(xsd:date(?dates) AS ?date)
+      ?work wdt:P31 wd:Q109229154 . bind("explicit" as ?type_)
+      ?work wdt:P1433 ?venue_ .
+    } GROUP BY ?date ?work
+  }
   SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
 } ORDER BY DESC(?date)
   LIMIT 50


### PR DESCRIPTION
Fixes #2616 

### Description
This patch uses a `SAMPLE()` in the SPARQL query to list articles with explicit CiTO annotation only once.

I put effort in making the query not use `WITH` and is relatively easy to port to QLever.
    
### Caveats
Cannot think of any.

Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

### Testing
* Go to [Recent articles with explicit CiTO-annotation](https://scholia.toolforge.org/cito/#recent-articles)
* Check if articles are listed only once (see screenshot in bug report for duplication)

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [ ] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
