### PR TITLE
Replaced the Twitter examples with ISSN and ROR

### DIFF
--- a/scholia/app/templates/index.html
+++ b/scholia/app/templates/index.html
@@ -158,12 +158,11 @@
       <p>If you know the external identifier of a concept, then Scholia can make a lookup based on it:</p>
       
       <dl>
-	<dt><a href="twitter/utafrith">twitter/utafrith</a></dt>
-	<dd>Look up by Twitter username @utafrith. This will identify
-	  the London-based researcher Uta Frith and redirect to her Scholia page.</dd>
+	<dt><a href="issn/2050-084X">issn/2050-084X</a></dt>
+	<dd>Look up by ISSN. This will identify the eLife journal.</dd>
 	
-	<dt><a href="twitter/mitpress">twitter/mitpress</a></dt>
-	<dd>Redirect also works for organizations, here MIT Press</dd>
+	<dt><a href="ror/032q98j12">ror/032q98j12</a></dt>
+	<dd>Redirect also works for organizations with the Research Organisation Registry (ROR) identifier, here the Wikimedia Foundation.</dd>
 
 	<dt><a href="orcid/0000-0002-5494-8126">orcid/0000-0002-5494-8126</a></dt>
 	<dd>Lookup 0000-0002-5494-8126 that is identifying Carol Greider.</dd>


### PR DESCRIPTION
Fixes #2612

### Description
Replaced the Twitter examples from the front page with ISSN and ROR examples, for eLife and the Wikimedia Foundation, respectively.
    
### Caveats
Maybe the choice of journal and organisation is inappropriate.

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

### Testing

* Go to http://127.0.0.1:8100/
* Test the third column which no longer should show Twitter accounts

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
