### PR TITLE
Fix sparql to matrix endpoint configuration

### DIFF
--- a/scholia/app/static/scholia.js
+++ b/scholia/app/static/scholia.js
@@ -532,10 +532,17 @@ function sparqlToIframe2(url, editURL, embedURL, sparql, element, filename) {
 
 
 function sparqlToMatrix(sparql, element, filename){
-    
+    sparqlToMatrix2(
+        "https://query.wikidata.org/sparql",
+        sparql, element, filename
+    );
+}
+
+
+function sparqlToMatrix2(endpointUrl, sparql, element, filename){
     window.onresize = resize(element);
 
-    sparqlToResponse(sparql, function(response) {
+    sparqlToResponse2(endpointUrl, sparql, function(response) {
         var data = response.results.bindings;
 
         var qToLabel = new Object();

--- a/scholia/app/templates/base.html
+++ b/scholia/app/templates/base.html
@@ -56,7 +56,7 @@ function {{ panel | replace("-", "") }}HandleIntersection(entries, observer){
 
 {% macro sparql_to_matrix(panel) -%}
 // {{ panel }} matrix
-sparqlToMatrix(`# tool: scholia
+sparqlToMatrix2("{{ sparql_endpoint }}", `# tool: scholia
 {% include aspect + '_' + panel + '.sparql' %}`,
 "#{{ panel }}", "{{ aspect }}_{{ panel }}.sparql");
 {%- endmacro %}


### PR DESCRIPTION
Fixes #2630

### Description
This patch adds the complementary `sparqlToMatrix2` method that uses the endpoint configuration data. The oldest patch adds the method, the newest uses it.
    
### Caveats
None that I am aware of. The use seems to be limited to the `author` aspect, which is tested below.

Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

### Testing
* Go to http://127.0.0.1:8100/author/Q5443996
* Scroll down to `Topics-works matrix`
* Check if the matrix shows up properly
* (Optional) Repeat for other authors)

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
