### PR TITLE
Fix askQuery endpoint configuration

### DIFF
--- a/scholia/app/static/scholia.js
+++ b/scholia/app/static/scholia.js
@@ -740,7 +740,15 @@ function sparqlToShortInchiKey(sparql, key,  element, filename) {
 
 
 function askQuery(panel, askQuery, callback) {
-     var endpointUrl = 'https://query.wikidata.org/sparql';
+    askQuery2(
+        "https://query.wikidata.org/sparql",
+        panel, askQuery, callback
+    );
+}
+
+
+function askQuery2(endpointUrl, panel, askQuery, callback) {
+     if (!endpointUrl) endpointUrl = "https://query.wikidata.org/sparql";
      
      var settings = {
        headers: { Accept: 'application/sparql-results+json' },

--- a/scholia/app/templates/base.html
+++ b/scholia/app/templates/base.html
@@ -78,7 +78,7 @@ sparqlToShortInchiKey(`# tool: scholia
 
 {% macro ask_query_callback(panel) -%}
 // {{ panel }} ask query
-askQuery("{{ panel }}", `# tool: scholia
+askQuery2("{{ sparql_endpoint }}", "{{ panel }}", `# tool: scholia
 {% include 'ask_' + aspect + '_' + panel + '.sparql' %}`, 
 () => {
     {{ caller() }};


### PR DESCRIPTION
Fixes #2629 

### Description
This patch adds the complementary `askQuery2` method that uses the endpoint configuration data. Similar to the #2631 patch.

The `askQuery()` method is used in the macro defined in `base.html` and that macro is used in three aspects, together four times:

```
$ grep -ri "ask_query_callback" scholia
scholia/app/templates/work.html:{% call ask_query_callback('cito') %}
scholia/app/templates/work.html:{% call ask_query_callback('gallery') %}
scholia/app/templates/venue.html:{% call ask_query_callback('cito') %}
scholia/app/templates/author.html:{% call ask_query_callback('retractions') %}
scholia/app/templates/base.html:{% macro ask_query_callback(panel) -%}
```
    
### Caveats

Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [x]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Earlier the three aspects are listed that use the `askQuery()` functionality: `work`, `venue`, and `author`.

* Test the three aspects.
    * For `author` test an author that has retractions
    * For `venue` and `work`, test the CiTO annotation
    * For `work`, test the "gallery" functonality

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
