### PR TITLE
Update work_related-works.sparql

### DIFF
--- a/scholia/app/templates/work_related-works.sparql
+++ b/scholia/app/templates/work_related-works.sparql
@@ -11,6 +11,7 @@ WITH {
     FILTER (target: != ?work)
   }
   GROUP BY ?work
+  ORDER BY DESC(?count)
   LIMIT 500
 } AS %result
 WHERE {


### PR DESCRIPTION
Fixes #2635

### Description
Orders also before the selecting of 500 items to continue with. Because selecting 500 on the unsorted list, highly co-cited works can be missed, as indicated in the bug report.
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

### Testing

* See the queries in the bug report. Works for that item, but should be easy enough to repeat for other works 

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [ ] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
