### PR TITLE
The `dataset.html` template still had the 'Taxon' template title

### DIFF
--- a/scholia/app/templates/dataset.html
+++ b/scholia/app/templates/dataset.html
@@ -18,7 +18,7 @@
 {% endblock %}
 
 {% block page_content %}
-<h1 id="h1">Taxon</h1>
+<h1 id="h1">Dataset</h1>
 <script type="application/ld+json" id="bioschemas"></script>
 
 <div id="intro"></div>


### PR DESCRIPTION
No issue reported, because of trivial patch.

### Description
The template was still saying "Taxon" but should obviously be "Dataset". With the (relatively) slower server this is now running on, this is more visible.
    
### Testing

* Try any dataset in the `dataset` aspect, e.g. https://scholia.toolforge.org/dataset/Q1767082
* Watch the default title `<h1>` previously being Taxon now Dataset, before it gets replaced by the fetched title of the dataset