### PR TITLE
Added the datatable footer

### DIFF
--- a/scholia/app/static/scholia.js
+++ b/scholia/app/static/scholia.js
@@ -420,6 +420,7 @@ function sparqlToDataTable2(url, editURL, sparql, element, filename, options = {
                         },
                     });
                 }
+                $(element).append(datatableFooter);
             } else {
                 $('#' + loaderID).remove(); // remove loader
                 // remove old content, like a 'time out' error message:
@@ -442,6 +443,7 @@ function sparqlToDataTable2(url, editURL, sparql, element, filename, options = {
                         },
                     });
                 }
+                $(element).append(datatableFooter);
             }
         }).fail(function () {
             $('#' + loaderID).remove(); // remove loader


### PR DESCRIPTION
Fixes #2634

### Description
It is not clear to me what the problem is, but this patch adds the datatable footer after the table is created.
    
### Caveats
I have not been able to isolate the problem. It seems related with the lazy loading, but the lazy loading was using the exact same method, so that doesn't make sense to me. The bug report links to #2608, but that patch only is supposed to remove content when the reload functionality is used. So, I can only speculate that that removing of content always happens, and not only when reload was used.

Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing

* Open any page
* See the loading in action
* Notice the links in the footer after the results table shows up

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [ ] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
