### PR TITLE
Fix #2513 Attempt to fix author sorting in author list

### DIFF
--- a/scholia/app/templates/author_list-of-publications.sparql
+++ b/scholia/app/templates/author_list-of-publications.sparql
@@ -9,13 +9,25 @@ SELECT
   ?venue ?venueLabel
   (GROUP_CONCAT(DISTINCT ?author_label; separator=", ") AS ?authors)
   (CONCAT("../authors/", GROUP_CONCAT(DISTINCT SUBSTR(STR(?author), 32); separator=",")) AS ?authorsUrl)
+WITH {
+  # By standard GROUP_CONCAT does not sort, but BlazeGraph seems to sort.
+  SELECT
+    ?work ?author ?author_label
+  WHERE {
+    ?work wdt:P50 target: .
+    ?work p:P50 [ ps:P50 ?author ; pq:P1545 ?order ] .
+    BIND(xsd:integer(?order) AS ?n)
+    OPTIONAL {
+      ?author rdfs:label ?author_label_ . FILTER (LANG(?author_label_) = 'en')
+    }
+    BIND(COALESCE(?author_label_, SUBSTR(STR(?author), 32)) AS ?author_label)
+  }
+  ORDER BY ?n
+} AS %authors  
 WHERE {
   ?work wdt:P50 target: .
-  ?work wdt:P50 ?author .
-  OPTIONAL {
-    ?author rdfs:label ?author_label_ . FILTER (LANG(?author_label_) = 'en')
-  }
-  BIND(COALESCE(?author_label_, SUBSTR(STR(?author), 32)) AS ?author_label)
+  INCLUDE %authors 
+  
   OPTIONAL { ?work wdt:P31 ?type_ . ?type_ rdfs:label ?type_label . FILTER (LANG(?type_label) = 'en') }
   ?work wdt:P577 ?datetimes .
   BIND(xsd:date(?datetimes) AS ?dates)

--- a/scholia/app/templates/organization_recent-literature.sparql
+++ b/scholia/app/templates/organization_recent-literature.sparql
@@ -7,23 +7,49 @@ SELECT
   ?work ?workLabel
   ?researchers ?researchersUrl
 WITH {
-  SELECT 
-    (MIN(?publication_datetimes) AS ?publication_datetime) ?work 
-    (GROUP_CONCAT(DISTINCT ?researcher_label; separator=', ') AS ?researchers)
-    (CONCAT("../authors/", GROUP_CONCAT(DISTINCT SUBSTR(STR(?researcher), 32); separator=",")) AS ?researchersUrl)
-  WHERE {                                                         
+  SELECT DISTINCT
+    ?researcher
+  WHERE {
     ?researcher ( wdt:P108 | wdt:P463 | wdt:P1416 ) / wdt:P361* target: .
-    ?work wdt:P50 ?researcher .
-    ?researcher rdfs:label ?researcher_label . FILTER (LANG(?researcher_label) = 'en')
-    OPTIONAL {
-      ?work wdt:P577 ?publication_datetimes .
-    }
+  }
+} AS %researchers
+WITH {
+  SELECT
+    ?work
+    (MIN(?publication_datetime_) AS ?publication_datetime)
+  WHERE {
+    INCLUDE %researchers
+    ?work wdt:P50 ?researcher ;
+          wdt:P577 ?publication_datetime_ .
   }
   GROUP BY ?work
   ORDER BY DESC(?publication_datetime)
-  LIMIT 200  
+  LIMIT 200
+} AS %works
+WITH {
+  SELECT 
+    ?work 
+    (GROUP_CONCAT(?researcher_label; separator=', ') AS ?researchers)
+    (CONCAT("../authors/", GROUP_CONCAT(DISTINCT SUBSTR(STR(?researcher), 32); separator=",")) AS ?researchersUrl)
+  WHERE {
+    INCLUDE %researchers
+    INCLUDE %works
+    {
+      # GROUP_CONCAT cannot honor sorting, but this was an attempt
+      SELECT
+        ?work ?researcher ?researcher_label
+      WHERE {
+        ?work p:P50 [ ps:P50 ?researcher ; pq:P1545 ?order ] .
+        BIND(xsd:integer(?order) AS ?n)
+       ?researcher rdfs:label ?researcher_label . FILTER (LANG(?researcher_label) = 'en')
+      }
+      ORDER BY ?n
+    }
+  }
+  GROUP BY ?work 
 } AS %results
 WHERE {
+  INCLUDE %works
   INCLUDE %results
   BIND(xsd:date(?publication_datetime) AS ?publication_date)
   SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }

--- a/scholia/app/templates/work_data.sparql
+++ b/scholia/app/templates/work_data.sparql
@@ -27,11 +27,23 @@ WHERE {
       (CONCAT("../authors/", GROUP_CONCAT(?q; separator=",")) AS ?valueUrl)
     {
       BIND(1 AS ?dummy)
-      target: wdt:P50 ?iri .
-      BIND(SUBSTR(STR(?iri), 32) AS ?q) 
-      ?iri rdfs:label ?value_string . 
-      FILTER (LANG(?value_string) = 'en')
-      BIND(COALESCE(?value_string, ?q) AS ?value_)
+      {
+        # GROUP_CONCAT does not order by standard but BlazeGraph seems to order
+	# so we are hoping the sorting is correct here.
+        SELECT 
+          ?value_ ?q
+        WHERE {
+          target: p:P50 ?author_statement .
+          ?author_statement ps:P50 ?author .
+          BIND(SUBSTR(STR(?author), 32) AS ?q) 
+          ?author_statement pq:P1545 ?order .
+          BIND(xsd:integer(?order) AS ?n)
+          ?author rdfs:label ?value_string . 
+          FILTER (LANG(?value_string) = 'en')
+          BIND(COALESCE(?value_string, ?q) AS ?value_)
+        }
+        ORDER BY ?n
+      }
     }
     GROUP BY ?dummy
   }


### PR DESCRIPTION
GROUP_CONCAT does not sort, so author lists might be permuted. There seems very little to do about it other than attempt to sort the authors before concatenation and then "hope" that BlazeGraph does the correct sorting. This sometimes work, but at other times there seems to be no effect - at least in recent publication panel for organization the problem persist.

The problem has been noted, e.g., at
https://github.com/w3c/sparql-dev/issues/9

Fixes #2513

### Description
This is a partial "hopeful" solution
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* http://127.0.0.1:8100/work/Q132146963 (seems to work)
* http://127.0.0.1:8100/author/Q20980928 (seems to work)
* http://127.0.0.1:8100/organization/Q24283660 (does not work)

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
