### PR TITLE
Fix #2652 query server URL read from configuration

### DIFF
--- a/tests/test_ask_query.py
+++ b/tests/test_ask_query.py
@@ -3,6 +3,8 @@
 import re
 import requests
 
+from scholia.config import config
+
 USER_AGENT = "Scholia"
 HEADERS = {"User-Agent": USER_AGENT}
 
@@ -44,7 +46,7 @@ def ask_query(file_name, q_number):
 
     query = re.sub(r"\{\{ ?q ?\}\}", q_number, query)
 
-    url = "https://query.wikidata.org/sparql"
+    url = config['query-server']['sparql_endpoint']
     params = {"query": query, "format": "json"}
     response = requests.get(url, params=params, headers=HEADERS)
 


### PR DESCRIPTION
Fixes #2652

### Description
Query Service URL now read from Scholia configuration
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* Test A
* Test B

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [ ] My changes generate no new warnings
* [ ] I have not used code from external sources without attribution
* [ ] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [ ] There are no remaining debug statements (print, console.log, ...)
