### PR TITLE
Fix #2659 Fix arxiv scraper

### DIFF
--- a/scholia/arxiv.py
+++ b/scholia/arxiv.py
@@ -24,10 +24,13 @@ import sys
 import requests
 from feedparser import parse as parse_api
 
+from .config import config
 from .qs import paper_to_quickstatements
 
 
-USER_AGENT = 'Scholia'
+USER_AGENT = config['requests'].get('user_agent')
+
+HEADERS = {'User-Agent': USER_AGENT}
 
 ARXIV_URL = 'https://export.arxiv.org/'
 
@@ -74,7 +77,7 @@ def get_metadata(arxiv):
 
     url = ARXIV_URL + "api/query?id_list=" + arxiv
     try:
-        response = requests.get(url)
+        response = requests.get(url, headers=HEADERS)
 
         if response.status_code == 200:
             feed = parse_api(response.content)


### PR DESCRIPTION
The user-agent was added to the request

Fixes #2659 

### Description
API request to arxiv failed. Now the header is submitted with user agent information
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* tox -e py310

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
