### PR TITLE
patch that implements a column with citation intentions

### DIFF
--- a/scholia/app/templates/work_cited-works.sparql
+++ b/scholia/app/templates/work_cited-works.sparql
@@ -3,7 +3,8 @@
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
 # List of works that is cited by the specified work
-SELECT ?citations ?publication_date ?cited_work ?cited_workLabel 
+SELECT ?citations ?publication_date ?cited_work ?cited_workLabel
+  (GROUP_CONCAT(DISTINCT ?intentionLabel;separator=", ") AS ?intentions)
 WITH {
   SELECT (MIN(?date) AS ?publication_date) (COUNT(DISTINCT ?citing_cited_work) AS ?citations) ?cited_work 
   WHERE {
@@ -18,6 +19,12 @@ WITH {
 } AS %result
 WHERE {
   INCLUDE %result
+  OPTIONAL {
+    target: p:P2860 ?citationStatement .
+    ?citationStatement pq:P3712 ?intention ;
+                       ps:P2860 ?cited_work .
+    ?intention rdfs:label ?intentionLabel . FILTER (lang(?intentionLabel) = "en")
+  }
   SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . } 
-} 
+} GROUP BY ?citations ?publication_date ?cited_work ?cited_workLabel
 ORDER BY DESC(?citations) DESC(?date)


### PR DESCRIPTION
Implements #2618

### Description
This patch add an additional column to the table for the `Cited works` panel in the `work` aspect with citation intentions. If no intentionare given (far most common), it will be a small empty columne. The issue report #2618 has screenshots.
    
### Caveats

I cannot think of any particular. The column content is optional.

### Testing

To match the screenshots from issue #2618, and check the "Cited works" panels:

* Open a work with citation intention annotations, e.g. http://127.0.0.1:8100/work/Q133835656#cited-works
* Open a work without such annotations, e.g. http://127.0.0.1:8100/work/Q133848754#cited-works

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [ ] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [ ] There are no remaining debug statements (print, console.log, ...)
