### PR TITLE
Checked two `chemical-class` queries and they can be run on WDQS main

### DIFF
--- a/scholia/app/templates/chemical-class_identifiers.sparql
+++ b/scholia/app/templates/chemical-class_identifiers.sparql
@@ -1,4 +1,8 @@
 # title: identifiers for this chemical class
+#sparql_endpoint = https://query.wikidata.org/sparql
+#sparql_endpoint_name= WDQS main
+#sparql_editurl = https://query.wikidata.org/#
+#sparql_embedurl = https://query.wikidata.org/embed.html#
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
 SELECT

--- a/scholia/app/templates/chemical-class_related-chemicals.sparql
+++ b/scholia/app/templates/chemical-class_related-chemicals.sparql
@@ -1,4 +1,8 @@
 # title: lists related chemicals for this class
+#sparql_endpoint = https://query.wikidata.org/sparql
+#sparql_endpoint_name= WDQS main
+#sparql_editurl = https://query.wikidata.org/#
+#sparql_embedurl = https://query.wikidata.org/embed.html#
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
 SELECT ?mol ?molLabel ?InChIKey ?CAS ?CASUrl ?ChemSpider ?ChemSpiderUrl ?PubChem_CID ?PubChem_CIDUrl WITH {


### PR DESCRIPTION
Fixes part of https://github.com/WDscholia/scholia/issues/2667

The two queries do not use scholarly information.

### Description
Comparison of the Legacy (right) versus Main (left):

![image](https://github.com/user-attachments/assets/8d3d4bc4-97c8-4ab8-8652-54d6b5281a29)

### Caveats
The pull request is affected by this bug: https://github.com/WDscholia/scholia/issues/2668

### Testing
Run the two queries on Legacy and Main. The test fail seems to be due to an unrelated tox test assertion.

For example, when locally testing `/chemical-class/Q41581`, check if you see the two panels use `query.wikidata.org` instead of `query-legacy-full.wikidata.org`:

![image](https://github.com/user-attachments/assets/de38ad45-af2b-45de-bd78-7b985524abb9)

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [ ] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
