### PR TITLE
Add endpoints for unchanged WDQS main queries

### DIFF
--- a/scholia/app/templates/software_data.sparql
+++ b/scholia/app/templates/software_data.sparql
@@ -1,3 +1,7 @@
+#sparql_endpoint = https://query.wikidata.org/sparql
+#sparql_endpoint_name= WDQS main
+#sparql_editurl = https://query.wikidata.org/#
+#sparql_embedurl = https://query.wikidata.org/embed.html#
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
 SELECT DISTINCT ?description ?value ?valueUrl

--- a/scholia/app/templates/software_dependent-software.sparql
+++ b/scholia/app/templates/software_dependent-software.sparql
@@ -1,3 +1,7 @@
+#sparql_endpoint = https://query.wikidata.org/sparql
+#sparql_endpoint_name= WDQS main
+#sparql_editurl = https://query.wikidata.org/#
+#sparql_embedurl = https://query.wikidata.org/embed.html#
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 
 SELECT 

--- a/scholia/app/templates/software_software-dependencies.sparql
+++ b/scholia/app/templates/software_software-dependencies.sparql
@@ -1,4 +1,8 @@
 #description: Show software library, programming language and developer dependencies
+#sparql_endpoint = https://query.wikidata.org/sparql
+#sparql_endpoint_name= WDQS main
+#sparql_editurl = https://query.wikidata.org/#
+#sparql_embedurl = https://query.wikidata.org/embed.html#
 
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 


### PR DESCRIPTION
Related to #2676 (issue number, if applicable) 

### Description
Checked three software queries queries and they can be run on WDQS main as far as I can tell. 
They don't touch scholarly publications as currently defined

    
 Local results, run on Main, are identical to legacy. Also, they do not seem to touch items in the `scholarly` graph: 
 
 #### Local
![image](https://github.com/user-attachments/assets/e31e6f80-2bd2-4dc4-84df-4c6498fa4641)
![image](https://github.com/user-attachments/assets/4d3aa5ff-724e-4e3b-9ed4-becb944a07bc)

#### Online
    
![image](https://github.com/user-attachments/assets/795f7e9c-5d2e-41a9-9e92-2ea8a68aefae)
![image](https://github.com/user-attachments/assets/b121a696-1e62-4de4-9d8f-e1ea7e35f5fb)

### Caveats
Like #2669, I assume this is affected by the bug #2668 
> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
* [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [x]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Only done manual testing, like #2669
### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [ ] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
