### PR TITLE
Fix #2656 404 handler fix

### DIFF
--- a/scholia/app/templates/base.html
+++ b/scholia/app/templates/base.html
@@ -117,7 +117,7 @@ askQuery2("{{ sparql_endpoint }}", "{{ panel }}", `# tool: scholia
 {% block scripts %}
 {{super()}}
 
-<script type="text/javascript">window.jsConfig = {{ js_config | tojson }};</script>
+<script type="text/javascript">window.jsConfig = {{ js_config | default({}) | tojson | safe }};</script>
 <script type="text/javascript" src="{{ url_for('static', filename='d3.v5.min.js') }}"></script>
 <script type="text/javascript" src="{{ url_for('static', filename='d3-scale-chromatic.v1.min.js') }}"></script>
 <script type="text/javascript" src="{{ url_for('static', filename='jquery.dataTables.min.js') }}"></script>

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -369,9 +369,8 @@ def classes_to_aspect(classes):
     return aspect
 
 
-@main.context_processor
-def inject_js_config():
-    """Return configuration for Javascript.
+def get_js_config():
+    """Return dictionary with Javascript configuration.
 
     Returns
     -------
@@ -379,10 +378,23 @@ def inject_js_config():
         Configuration to Javascript as a dict.
 
     """
-    return dict(js_config={
+    return {
         "sparqlEndpointName":
         config['query-server'].get('sparql_endpoint_name'),
-    })
+    }
+
+
+@main.context_processor
+def inject_js_config():
+    """Return configuration for Javascript for injection.
+
+    Returns
+    -------
+    js_config : dict
+        Configuration to Javascript as a dict.
+
+    """
+    return dict(js_config=get_js_config())
 
 
 @main.route("/")
@@ -3385,7 +3397,8 @@ def page_not_found(e):
     This function can be used as 404 error handler.
 
     """
-    return render_template("404.html", error=""), 404
+    return (render_template("404.html", js_config=get_js_config(), error=""),
+            404)
 
 
 def could_not_find(name):


### PR DESCRIPTION
Internal Server Error happened for 404 pages. This was due to missing handling of Javascript configuration injection in the 404 error handler.

Fixes #2656

### Description
Fix 404 handling
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* Tested with non-existing pages.

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [ ] My changes generate no new warnings
* [ ] I have not used code from external sources without attribution
* [ ] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [ ] There are no remaining debug statements (print, console.log, ...)
