### PR TITLE
Fix #2693 add 'mul' for title

### DIFF
--- a/scholia/app/templates/base.html
+++ b/scholia/app/templates/base.html
@@ -126,27 +126,31 @@ askQuery2("{{ sparql_endpoint }}", "{{ panel }}", `# tool: scholia
 <script type="text/javascript" src="{{ url_for('static', filename='bootstrap-autocomplete.min.js')}}"></script>
 
 <script type="text/javascript">
-    {% if q %}
-    var url = 'https://www.wikidata.org/w/api.php?action=wbgetentities&ids=' +
-	       '{{ q }}' + 
-	       '&format=json&callback=?';
-    
-    const currentAspect = window.location.pathname.split("/")[1];
-
-    $.getJSON(url, function (data) {
-	 var item = data.entities["{{ q }}"];
-	 if ('en' in item.labels) {
-	     var title = item.labels.en.value;
-	     var wdtitle = item.labels.en.value;
-	     $("#h1").text(title);
-	     $(".self").text(title);
-       $("title").text(title + " - Scholia");
-
-       var crossref_button = document.getElementById("check-crossref-button");
-       if (title && crossref_button) {
+  {% if q %}
+  var url = 'https://www.wikidata.org/w/api.php?action=wbgetentities&ids=' +
+	    '{{ q }}' + 
+	    '&format=json&callback=?';
+  
+  const currentAspect = window.location.pathname.split("/")[1];
+  
+  $.getJSON(url, function (data) {
+    var item = data.entities["{{ q }}"];
+    var title = '';
+    if ('en' in item.labels) {
+	    title = item.labels.en.value;
+    } else if ('mul' in item.labels) {
+	    title = item.labels.mul.value;
+    }
+    if (title) {
+      $("#h1").text(title);
+      $(".self").text(title);
+      $("title").text(title + " - Scholia");
+      
+	    var crossref_button = document.getElementById("check-crossref-button");
+	    if (title && crossref_button) {
         crossref_button.onclick = () => {get_dois_from_crossref(wdtitle)}
         crossref_button.innerHTML = "Check Crossref"
-       }
+	    }
 
 	     {% if request.path.endswith("curation") or request.path.endswith("curation/") %}
 	     $("#h1").text("Improve " + currentAspect + ": " + title);


### PR DESCRIPTION
Now uses 'en' or if not defined, 'mul' for the h1 title.

This code change change the indentation style around the changes to 2 spaces.

Fixes #2693

### Description
> Please include a summary of the change, relevant motivation and context. If possible and applicable, include before and after screenshots and a URL where the changes can be seen.
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* work/Q135315814


### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [ ] My changes generate no new warnings
* [ ] I have not used code from external sources without attribution
* [ ] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [ ] There are no remaining debug statements (print, console.log, ...)
