### PR TITLE
[WIP] Basic retraction info pages

### DIFF
--- a/scholia/app/templates/retraction-index.html
+++ b/scholia/app/templates/retraction-index.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+
+{% set aspect = "retraction-index" %}
+{% block title %}Retractions - Scholia{% endblock %}
+
+{% block in_ready %}
+
+{{ sparql_to_table('most-cited-retracted-works') }}
+{{ sparql_to_table('authors_with_many_retractions') }}
+{{ sparql_to_table('venues_with_many_retractions') }}
+
+{% endblock %}
+
+
+
+{% block page_content %}
+
+<h1>Retractions</h1>
+
+<h2 id="most-cited-retracted-works">Most cited retracted works</h2>
+
+<table class="table table-hover" id="most-cited-retracted-works-table"></table>
+
+<h2 id="authors_with_many_retractions">Authors with the most retractions</h2>
+
+<table class="table table-hover" id="authors_with_many_retractions-table"></table>
+
+<h2 id="venues_with_many_retractions">Venues with the most retractions</h2>
+
+<table class="table table-hover" id="venues_with_many_retractions-table"></table>
+
+
+{% endblock %}
+

--- a/scholia/app/templates/retraction-index_authors_with_many_retractions.sparql
+++ b/scholia/app/templates/retraction-index_authors_with_many_retractions.sparql
@@ -1,0 +1,18 @@
+#sparql_endpoint = https://query.wikidata.org/sparql
+#sparql_endpoint_name= WDQS&nbsp;main
+#sparql_editurl = https://query.wikidata.org/#
+#sparql_embedurl = https://query.wikidata.org/embed.html#
+SELECT ?author ?authorLabel ?count WHERE {
+  hint:Query hint:optimizer "None" .
+  SERVICE wdsubgraph:scholarly_articles {
+    SELECT ?author (COUNT(DISTINCT ?work) AS ?count) WHERE {
+      { ?work wdt:P31 wd:Q45182324 . } UNION
+      { ?work wdt:P793 wd:Q7316896 . } UNION
+      { ?work wdt:P5824 [] . }
+      ?work wdt:P50 ?author .
+    } GROUP BY ?author ?authorLabel
+      ORDER BY DESC(?count)
+      LIMIT 100
+  }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
+} ORDER BY DESC(?count)

--- a/scholia/app/templates/retraction-index_most-cited-retracted-works.sparql
+++ b/scholia/app/templates/retraction-index_most-cited-retracted-works.sparql
@@ -1,0 +1,18 @@
+#sparql_endpoint = https://query-scholarly.wikidata.org/sparql
+#sparql_endpoint_name= WDQS&nbsp;scholarly
+#sparql_editurl = https://query-scholarly.wikidata.org/#
+#sparql_embedurl = https://query-scholarly.wikidata.org/embed.html#
+SELECT ?work ?workLabel (CONCAT("../retraction/", SUBSTR(STR(?work), 32)) AS ?workUrl)
+  ?count WITH {
+  SELECT ?work (COUNT(DISTINCT ?citation) AS ?count) WHERE {
+    hint:Query hint:optimizer "None" .
+    { ?work wdt:P31 wd:Q45182324 . } UNION
+    { ?work wdt:P793 wd:Q7316896 . } UNION
+    { ?work wdt:P5824 [] . }
+    { SERVICE wdsubgraph:wikidata_main { ?citation wdt:P2860 ?work . } } UNION
+    { ?citation wdt:P2860 ?work . }
+  } GROUP BY ?work ORDER BY DESC(?count) LIMIT 100
+} AS %RETRACTIONS WHERE {
+  INCLUDE %RETRACTIONS
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
+} ORDER BY DESC(?count)

--- a/scholia/app/templates/retraction-index_venues_with_many_retractions.sparql
+++ b/scholia/app/templates/retraction-index_venues_with_many_retractions.sparql
@@ -1,0 +1,27 @@
+#sparql_endpoint = https://query.wikidata.org/sparql
+#sparql_endpoint_name= WDQS&nbsp;main
+#sparql_editurl = https://query.wikidata.org/#
+#sparql_embedurl = https://query.wikidata.org/embed.html#
+SELECT 
+  ?works
+  ?venue ?venueLabel
+  (CONCAT("../venue/", SUBSTR(STR(?venue), 32)) AS ?venueUrl)
+  ?venueDescription
+WHERE {
+  SERVICE wdsubgraph:scholarly_articles {
+    {
+      SELECT
+        (COUNT(?work) AS ?works)
+        ?venue
+      WHERE {
+        ?work wdt:P31 wd:Q45182324 ;
+              wdt:P1433 ?venue .
+      }
+      GROUP BY ?venue
+      ORDER BY DESC(?works)
+      LIMIT 200
+    }
+  }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
+} 
+ORDER BY DESC(?works)

--- a/scholia/app/templates/retraction.html
+++ b/scholia/app/templates/retraction.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+
+{% set aspect = "retraction" %}
+{% block title %}Retractions - Scholia{% endblock %}
+
+{% block in_ready %}
+
+{{ sparql_to_table('list-of-authors') }}
+{{ sparql_to_iframe('citations-per-year') }}
+
+{% endblock %}
+
+
+
+{% block page_content %}
+
+<h1 id="h1">Retraction</h1>
+
+<h2 id="list-of-authors">List of authors</h2>
+
+<table class="table table-hover" id="list-of-authors-table"></table>
+
+<h2 id="citations-per-year">Citations per year</h2>
+
+This plot shows the number of citations to the retracted article over time.
+If the date of retraction is known, it colors which citations have been made
+before and after the retraction.
+
+<div class="embed-responsive embed-responsive-16by9">
+    <iframe class="embed-responsive-item" id="citations-per-year-iframe"></iframe>
+</div>
+
+{% endblock %}
+

--- a/scholia/app/templates/retraction_citations-per-year.sparql
+++ b/scholia/app/templates/retraction_citations-per-year.sparql
@@ -1,0 +1,55 @@
+#sparql_endpoint = https://query-scholarly.wikidata.org/sparql
+#sparql_endpoint_name= WDQS&nbsp;main
+#sparql_editurl = https://query-scholarly.wikidata.org/#
+#sparql_embedurl = https://query-scholarly.wikidata.org/embed.html#
+#defaultView:BarChart
+PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
+
+SELECT
+  (STR(?year_) AS ?year)
+  (SUM(?count_) AS ?count)
+  ?kind
+WHERE {
+  {
+    SELECT
+      ?year_
+      (COUNT(DISTINCT ?citing_work) AS ?count_)
+      ?kind2
+    WHERE {
+      ?citing_work wdt:P2860 target: .
+  
+      # Year of citation
+      ?citing_work wdt:P577 ?date .
+      BIND(YEAR(?date) AS ?year_)
+      BIND(xsd:date(?date) AS ?pubDate_)
+
+      target: p:P31 ?isRetractedPaperStatement .
+      ?isRetractedPaperStatement ps:P31 wd:Q45182324 .
+      ?isRetractedPaperStatement pq:P580 ?retractionDate
+      BIND(xsd:date(?retractionDate) AS ?retractionDate_)
+      BIND (IF (?retractionDate_ > ?pubDate_,
+        "before retraction", "after retraction") AS ?kind2)
+    }
+    GROUP BY ?year_ ?kind2
+  }
+  UNION 
+  {
+    SELECT
+      ?year_
+      (COUNT(DISTINCT ?citing_work) AS ?count_)
+      ?kind2
+    WHERE {
+      ?citing_work wdt:P2860 target: .
+  
+      # Year of citation
+      ?citing_work wdt:P577 ?date .
+      BIND(YEAR(?date) AS ?year_)
+      BIND(xsd:date(?date) AS ?pubDate_)
+      MINUS { target: p:P31 / pq:P580 ?retractionDate }
+    }
+    GROUP BY ?year_ ?kind2
+  }
+  BIND(IF(BOUND(?kind2), ?kind2, "_") AS ?kind)
+}
+GROUP BY ?year_ ?kind
+ORDER BY DESC(?year_)

--- a/scholia/app/templates/retraction_list-of-authors.sparql
+++ b/scholia/app/templates/retraction_list-of-authors.sparql
@@ -1,0 +1,47 @@
+#sparql_endpoint = https://query.wikidata.org/sparql
+#sparql_endpoint_name= WDQS&nbsp;main
+#sparql_editurl = https://query.wikidata.org/#
+#sparql_embedurl = https://query.wikidata.org/embed.html#
+PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
+
+# List of authors for a work
+SELECT DISTINCT
+  # Author order
+  ?order
+
+  # Author item and label
+  ?author ?authorUrl
+
+  (COUNT(DISTINCT ?work) AS ?retractions)
+WHERE {
+  hint:Query hint:optimizer "None" .
+  SERVICE wdsubgraph:scholarly_articles {
+    {
+      target: p:P50 ?author_statement .
+      ?author_statement ps:P50 ?author_ .
+      BIND(CONCAT("../author/", SUBSTR(STR(?author_), 32)) AS ?authorUrl)
+      OPTIONAL {
+        ?author_statement pq:P1545 ?order_ .
+        BIND(xsd:integer(?order_) AS ?order)
+      }
+      ?work wdt:P50 ?author_ .
+    }
+    UNION
+    {
+      target: p:P2093 ?authorstring_statement .
+      ?authorstring_statement ps:P2093 ?author_
+      BIND(CONCAT(?author_, " ↗") AS ?author)
+      OPTIONAL {
+        ?authorstring_statement pq:P1545 ?order_ .
+        BIND(xsd:integer(?order_) AS ?order)
+      }
+      BIND(CONCAT("https://author-disambiguator.toolforge.org/names_oauth.php?doit=Look+for+author&name=", ENCODE_FOR_URI(?author_)) AS ?authorUrl)
+      BIND(target: AS ?work)
+    }
+  }
+  OPTIONAL {
+    ?author_ rdfs:label ?author .
+    FILTER (LANG(?author) = 'en')
+  }
+} GROUP BY ?order ?author ?authorUrl
+  ORDER BY ?order

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -3274,6 +3274,45 @@ def show_work_index():
     return render_template('work-index.html')
 
 
+@main.route('/retraction/' + q_pattern)
+def show_retraction(q):
+    """Return rendered HTML page for retracted work.
+
+    Parameters
+    ----------
+    q : str
+        Wikidata item identifier
+
+    Returns
+    -------
+    html : str
+        Rendered HTML page for retracted work.
+
+    """
+    ep = config['query-server'].get('sparql_endpoint')
+    editurl = config['query-server'].get('sparql_editurl')
+    embedurl = config['query-server'].get('sparql_embedurl')
+    return render_template('retraction.html', q=q, sparql_endpoint=ep,
+                           sparql_editURL=editurl, sparql_embedURL=embedurl)
+
+
+@main.route('/retraction/')
+def show_retraction_index():
+    """Return rendered index page for retractions.
+
+    Returns
+    -------
+    html : str
+        Rendered HTML page for retraction index page.
+
+    """
+    ep = config['query-server'].get('sparql_endpoint')
+    editurl = config['query-server'].get('sparql_editurl')
+    embedurl = config['query-server'].get('sparql_embedurl')
+    return render_template('retraction-index.html', sparql_endpoint=ep,
+                           sparql_editURL=editurl, sparql_embedURL=embedurl)
+
+
 @main.route('/works/' + qs_pattern)
 def show_works(qs):
     """Return HTML rendering for specific authors.


### PR DESCRIPTION
### Description
Uses information in Wikidata about retrations

This PR is "work in progress" (WIP) and this functionality is pending:

* link from /work/ to /retraction in the data table (if the article is retracted)
* on the landing page, list Wikidata items which use retracted articles as statement reference
* on the landing page, show the number of retractions per year
    
### Caveats
It depends on the following data model: articles are P31-ed as `retracted article`. It also becomes a lot more useful if that statement has a 'start time' qualifier (which 90% will have, pending a few QS batches).

Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
* A new landing: http://127.0.0.1:8100/retraction/
* A retracted article: http://127.0.0.1:8100/retraction/Q34377294

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [ ] My changes generate no new warnings
* [ ] I have not used code from external sources without attribution
* [ ] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [ ] There are no remaining debug statements (print, console.log, ...)

### Screenshots

<img width="893" height="1206" alt="image" src="https://github.com/user-attachments/assets/f2985aa2-06a5-414c-b9e2-97b49a331422" />

<img width="893" height="1206" alt="image" src="https://github.com/user-attachments/assets/4593769b-9609-4f12-87f3-3e26efd5a272" />


