### PR TITLE
Only count actually retracted articles

### DIFF
--- a/scholia/app/templates/retraction_list-of-authors.sparql
+++ b/scholia/app/templates/retraction_list-of-authors.sparql
@@ -24,7 +24,7 @@ WHERE {
         ?author_statement pq:P1545 ?order_ .
         BIND(xsd:integer(?order_) AS ?order)
       }
-      ?work wdt:P50 ?author_ .
+      ?work wdt:P50 ?author_ ; wdt:P31 wd:Q45182324 .
     }
     UNION
     {


### PR DESCRIPTION
It fixes the counting of retracted articles. I forgot to limit the count to retracted articles, so it was accidentally listing the number of articles for that author, including those that are not retracted.

### Description
This adds the limiting part of the SPARQL.
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing

* Go to your local https://scholia.toolforge.org/retraction/Q29617959 page
* look up Catherine Verfaillie and make sure it says 4 retracted articles, not 335

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
