### PR TITLE
Deeplink to the #list-of-retracted-articles section of the /author/ aspect

### DIFF
--- a/scholia/app/templates/retraction_list-of-authors.sparql
+++ b/scholia/app/templates/retraction_list-of-authors.sparql
@@ -19,7 +19,7 @@ WHERE {
     {
       target: p:P50 ?author_statement .
       ?author_statement ps:P50 ?author_ .
-      BIND(CONCAT("../author/", SUBSTR(STR(?author_), 32)) AS ?authorUrl)
+      BIND(CONCAT("../author/", SUBSTR(STR(?author_), 32), "#list-of-retracted-articles") AS ?authorUrl)
       OPTIONAL {
         ?author_statement pq:P1545 ?order_ .
         BIND(xsd:integer(?order_) AS ?order)


### PR DESCRIPTION
Implements the first idea of https://github.com/WDscholia/scholia/issues/2709

### Description
Before this path, the author list on the `/retraction/` aspect links to the `/author/` aspect (only for `P50`), but it now links directly to the section on that aspect where the articles by that author that have been retracted are listed.
    
### Caveats
It assumes that that section always exist. The `/author/` aspect only shows that section when retractions are discovered, but both aspects should use the same logic. That said, there are several models (and both aspect support several aspects) and noting that one is predominant, this is not expected to give a lot of problems. If it does, it basically is a curation event in Wikidata. BTW, if the section does not exist, it will just default to the author page, so there is no impact on the user experience.

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

### Testing

* Go to https://scholia.toolforge.org/retraction/Q28264479
* Click on the first author (Wakefield) and notice the redirections to https://scholia.toolforge.org/author/Q508568#list-of-retracted-articles instead of https://scholia.toolforge.org/author/Q508568

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
