### PR TITLE
The 'retracted articles' panel in the Author aspect now links to the /retraction/ aspect

### DIFF
--- a/scholia/app/templates/author_list-of-retracted-articles.sparql
+++ b/scholia/app/templates/author_list-of-retracted-articles.sparql
@@ -4,6 +4,7 @@ PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 SELECT
   (MIN(?dates) AS ?date)
   ?work ?workLabel
+  (CONCAT("../retraction/", SUBSTR(STR(?work), 32)) AS ?workUrl)
   (GROUP_CONCAT(DISTINCT ?type_label; separator=", ") AS ?type)
   (SAMPLE(?pages_) AS ?pages)
   ?venue ?venueLabel
@@ -24,5 +25,5 @@ WHERE {
   OPTIONAL { ?work wdt:P1433 ?venue }
   SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }
-GROUP BY ?work ?workLabel ?venue ?venueLabel
+GROUP BY ?work ?workLabel ?workUrl ?venue ?venueLabel
 ORDER BY DESC(?date)


### PR DESCRIPTION
Implements item 2 of https://github.com/WDscholia/scholia/issues/2709

### Description
Before this patch, the  'retracted articles' panel in the Author aspect linked to the root Scholia folder, for many items in the list, forwarding via the default aspect typing to the /work/ aspect. This patch will update that table to always link to the /retraction/ aspect.

The idea here is that when people link from this table of retracted articles, they are more likely to want to know about why it was retracted. The regular work list (also on the /author/ aspect) continues to link to the regular /work/ aspect. Moreover, from the /retraction/ aspect, users can also go to the /work/ aspect.
    
### Caveats
Same as https://github.com/WDscholia/scholia/pull/2710: 

> It assumes that that section always exist. The /author/ aspect only shows that section when retractions are
> discovered, but both aspects should use the same logic. That said, there are several models (and both aspect
> support several aspects) and noting that one is predominant, this is not expected to give a lot of problems. If it
> does, it basically is a curation event in Wikidata. BTW, if the section does not exist, it will just default to the
> author page, so there is no impact on the user experience.

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

### Testing

* Go to https://scholia.toolforge.org/author/Q508568#list-of-retracted-articles
* Click one of the three retracted articles of that author
* check if you get linked to the /retraction/ aspect, e.g. https://scholia.toolforge.org/retraction/Q28264479

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [ ] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
