### PR TITLE
Adds a panel to show CiTO annotations of citations to this retracted article

### DIFF
--- a/scholia/app/templates/ask_retraction_cito.sparql
+++ b/scholia/app/templates/ask_retraction_cito.sparql
@@ -1,0 +1,3 @@
+ASK {
+    [] pq:P3712 / wdt:P31 wd:Q96471816 ; ps:P2860 wd:{{q}} . BIND("work-cito" AS ?aspectsubpage)
+}

--- a/scholia/app/templates/retraction.html
+++ b/scholia/app/templates/retraction.html
@@ -11,6 +11,12 @@
 {{ sparql_to_iframe('citations-per-year') }}
 {{ sparql_to_table('statements-with-retracted-references') }}
 
+{% call ask_query_callback('cito') %}
+
+{{ sparql_to_iframe('cito-incoming-chart') }}
+
+{% endcall %}
+
 {% endblock %}
 
 
@@ -33,6 +39,14 @@ before and after the retraction.
 
 <div class="embed-responsive embed-responsive-16by9">
     <iframe class="embed-responsive-item" id="citations-per-year-iframe"></iframe>
+</div>
+
+<div id="cito" class="d-none">
+<h2 id="cito-incoming">Reasons why this retracted article is cited</h2>
+
+<div class="embed-responsive embed-responsive-16by9">
+  <iframe class="embed-responsive-item" id="cito-incoming-chart-iframe"></iframe>
+</div>
 </div>
 
 <h2 id="statements-with-retracted-references">Wikidata statements citing retracted references</h2>

--- a/scholia/app/templates/retraction_cito-incoming-chart.sparql
+++ b/scholia/app/templates/retraction_cito-incoming-chart.sparql
@@ -1,0 +1,37 @@
+#sparql_endpoint= https://query-scholarly.wikidata.org/sparql
+#sparql_endpoint_name= WDQS&nbsp;scholarly
+#sparql_editurl= https://query-scholarly.wikidata.org/#
+#sparql_embedurl= https://query-scholarly.wikidata.org/embed.html#
+#defaultView:BarChart
+PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
+
+SELECT
+  (STR(?year_) AS ?year)
+  (SUM(?count_) AS ?count)
+  ?intentionLabel
+WHERE {
+  {
+    SELECT
+      ?year_
+      ?intention ?intentionLabel
+      (COUNT(DISTINCT ?citing_work) AS ?count_)
+    WHERE {
+      ?citing_work p:P2860 ?citationStatement .
+      ?citationStatement pq:P3712 ?intention ;
+                         ps:P2860 target: .
+      SERVICE wdsubgraph:wikidata_main {
+        ?intention wdt:P31 wd:Q96471816 ;
+          rdfs:label ?intentionLabel .
+        FILTER (lang(?intentionLabel) = "en")
+      }
+  
+      # Year of citation
+      ?citing_work wdt:P577 ?date .
+      BIND(YEAR(?date) AS ?year_)
+      BIND(xsd:date(?date) AS ?pubDate_)
+    }
+    GROUP BY ?year_ ?intention ?intentionLabel
+  }
+}
+GROUP BY ?year_ ?intention ?intentionLabel
+ORDER BY DESC(?year_)


### PR DESCRIPTION
…if and only if there is such annotation, otherwise no panel is shown

IMPORTANT: depends on https://github.com/WDscholia/scholia/pull/2712 to be applied first.

### Description
This patch adds an extra panel to the `/retraction/Q...` aspect for retracted articles which have citations to them with CiTO annotation (via an `ask` first, such as original implemented by Carlin for `/work/`). For some articles this information is very rich, as for the Wakefield article (Q28264479).

Screenshot of the proposed extra panel (along with the existing citations by year above the new panel):

<img width="924" height="1169" alt="image" src="https://github.com/user-attachments/assets/3e7a4e9d-6916-4b9c-a013-aea330769d21" />

### Caveats

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

### Testing
Test this PR on two articles, one with CiTO annotation and one without. The first should show a screenshot like above, and the second to confirm no panel shows up when no CiTO annotation is available.

* With CiTO: http://127.0.0.1:8100/retraction/Q28264479
* No CiTO, no panel: http://127.0.0.1:8100/retraction/Q29030043

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
