### PR TITLE
[WIP] Implements SPARQL-level config for ASK queries

### DIFF
--- a/scholia/app/static/scholia.js
+++ b/scholia/app/static/scholia.js
@@ -803,6 +803,10 @@ function askQuery2(endpointUrl, panel, askQuery, callback) {
        data: { query: askQuery },
      };
 
+     // overwrite the central URLs of SPARQL specific URLs are found
+     configFromSPARQL = extractConfig(askQuery);
+     if (configFromSPARQL["url"]) endpointUrl = configFromSPARQL["url"];
+
      $.ajax(endpointUrl, settings).then((data) => {
         if (data.boolean) {
             // unhide panels

--- a/scholia/app/templates/ask_work_cito.sparql
+++ b/scholia/app/templates/ask_work_cito.sparql
@@ -1,3 +1,6 @@
+#sparql_endpoint = https://query-scholarly.wikidata.org/sparql
 ASK {
-    [] pq:P3712 / wdt:P31 wd:Q96471816 ; ps:P2860 wd:{{q}} . BIND("work-cito" AS ?aspectsubpage)
+    [] pq:P3712 ?intent ; ps:P2860 wd:Q28264479 .
+    SERVICE wdsubgraph:wikidata_main { ?intent wdt:P31 wd:Q96471816 }
+    BIND("work-cito" AS ?aspectsubpage)
 }


### PR DESCRIPTION
### Description
So far, ASK queries were always run against the globally defined SPARQL endpoint. This patch added the option to configure this for each SPARQL query separately.
    
### Caveats
Non-trivial to test.

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

### Testing
For the example configured ASK query:

* Go to https://scholia.toolforge.org/work/Q30149558#cito-incoming
* Ensure that the "Reasons why this article is cited" shows up (compare with the live website):

<img width="961" height="928" alt="image" src="https://github.com/user-attachments/assets/529ca7fc-304e-49fa-b74a-66efadda3fab" />

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [ ] My changes generate no new warnings
* [ ] I have not used code from external sources without attribution
* [ ] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [ ] There are no remaining debug statements (print, console.log, ...)
