### PR TITLE
Accept venues with mul label too

### DIFF
--- a/scholia/app/templates/cito-index_articles-by-year.sparql
+++ b/scholia/app/templates/cito-index_articles-by-year.sparql
@@ -1,5 +1,5 @@
 #defaultView:BarChart
-select ?year (count(?work) as ?number_of_publications) ?role where {
+select DISTINCT ?year (count(?work) as ?number_of_publications) ?role where {
   {
     select ?work (min(?years) as ?year) ?type_ ?venue where {
       ?work wdt:P577 ?dates ;
@@ -8,7 +8,7 @@ select ?year (count(?work) as ?number_of_publications) ?role where {
       bind(str(year(?dates)) as ?years) .
       OPTIONAL {
         ?work wdt:P31 wd:Q109229154 . bind("explicit" as ?type_)
-        ?work wdt:P1433 ?venue_ . ?venue_ rdfs:label ?venue . FILTER (LANG(?venue) = "en")
+        ?work wdt:P1433 ?venue_ . ?venue_ rdfs:label ?venue . FILTER (LANG(?venue) = "en" || LANG(?venue) = "mul")
         MINUS { ?venue_ wdt:P31 wd:Q1143604 }
       }
       OPTIONAL {


### PR DESCRIPTION
Fixes the problem that BioHackrXiv preprints are [not showing up](https://scholia.toolforge.org/cito/#articles-by-year):

<img width="1071" height="615" alt="image" src="https://github.com/user-attachments/assets/41b42ef6-3249-444e-aa5e-691f04b62db5" />

### Description
Because venues can have their label as `mul` too now, filtering on `LANG() = 'en'` should now also include allow it to have the value `mul`.

This probably applies to more SPARQL queries.
    
### Caveats
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

### Testing
Check the "Number of articles with CiTO-annotated citations by year" section at

* https://scholia.toolforge.org/cito/#articles-by-year

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [ ] My changes generate no new warnings
* [ ] I have not used code from external sources without attribution
* [ ] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [ ] There are no remaining debug statements (print, console.log, ...)
