### PR TITLE
Update DOI error message

### DIFF
--- a/scholia/app/templates/404-doi.html
+++ b/scholia/app/templates/404-doi.html
@@ -24,7 +24,7 @@ try {
   crossrefLink.setAttribute('href', crossrefUrl)
   crossrefLink.textContent = crossrefUrl
   if (error.message.includes("status code 404")) {
-    $( '#qs' ).after( "No metadata found for DOI. Please check the DOI for mistakes. The metadata may be unvailable because the publisher has not (yet) submitted metadata to their DOI Registration Agency (e.g. Crossref or DataCite). If the DOI is newly minted, please check again in 1–4 weeks. You can check Crossref at ", crossrefLink )
+    $( '#qs' ).after( "No metadata found for DOI. Please check the DOI for mistakes. The metadata may be unvailable if the publisher has not (yet) submitted metadata to their DOI Registration Agency (e.g. Crossref or DataCite). If the DOI is newly minted, please check again in 1–4 weeks. You can check Crossref at ", crossrefLink )
   } else {
     console.error(error)
   }


### PR DESCRIPTION
Fixes #2719 

### Description
Update error message for DOIs where no metadata can be found.

<img width="1920" height="924" alt="127 0 0 1_8100_doi_10 1002_pssb 202600316" src="https://github.com/user-attachments/assets/f6def701-9760-4015-84d7-4aa8c618df21" />

### Testing

* E.g. this nonexistent DOI: http://127.0.0.1:8100/doi/10.1002/pssb.202600316

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
