### PR TITLE
Fix co-author map query for QLever compatibility

### DIFF
--- a/scholia/app/templates/author_coauthor-map.sparql
+++ b/scholia/app/templates/author_coauthor-map.sparql
@@ -7,11 +7,11 @@ SELECT ?organization ?organizationLabel ?geo ?count ?layer WHERE {
     SELECT DISTINCT ?organization ?geo (COUNT(DISTINCT ?work) AS ?count) WHERE {
       ?work wdt:P50 target: ;
             wdt:P50 ?author .
-      FILTER (?author != target:)
+      FILTER (STR(?author) != STR(target:))
       ?author (wdt:P108 | wdt:P463 | wdt:P1416)/wdt:P361* ?organization .
       ?organization (wdt:P625 | ((wdt:P276 | wdt:P159)/wdt:P625)) ?geo .
     }
-    GROUP BY ?organization ?geo ?count
+    GROUP BY ?organization ?geo
     ORDER BY DESC(?count)
     LIMIT 2000
   }


### PR DESCRIPTION
## Summary

Fix the SPARQL query in `author_coauthor-map.sparql` that was returning no results on the QLever-backed Scholia instance.

Fixes #2780

## Changes

Two issues were identified and fixed:

### 1. IRI inequality filter incompatibility with QLever

`FILTER (?author != target:)` does not work correctly on QLever for IRI inequality comparison. QLever silently returns empty results instead of filtering properly.

**Fix:** Changed to `FILTER (STR(?author) != STR(target:))` which works correctly on both QLever and Wikidata SPARQL (Blazegraph).

### 2. Invalid GROUP BY clause

`GROUP BY ?organization ?geo ?count` included the aggregate variable `?count` (defined as `COUNT(DISTINCT ?work)`), which is technically invalid SPARQL. While Blazegraph tolerates this, QLever is stricter.

**Fix:** Removed `?count` from the `GROUP BY` clause, leaving `GROUP BY ?organization ?geo`.

## Testing

- Verified the fixed query returns results on QLever API (previously returned 0 results)
- - Verified the fixed query continues to work correctly on Wikidata SPARQL endpoint (Blazegraph)