### PR TITLE
Partial fix #2786 with "no healthy upstream"

### DIFF
--- a/scholia/api.py
+++ b/scholia/api.py
@@ -137,8 +137,8 @@ def wb_get_entities(
     *,
     batch_size: int = 50,
     rate_limit: float = 2.0,
-    max_retries: int = 5,
-    timeout: int = 30,
+    max_retries: int = 0,
+    timeout: int = 5,
     session: Optional[requests.Session] = None,
     **extra_params,
 ):

--- a/scholia/app/templates/503.html
+++ b/scholia/app/templates/503.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+
+{% block title %}Service Unavailable - Scholia{% endblock %}
+
+{% block page_content %}
+
+<h1>Service Unavailable</h1>
+
+<div class="text-center">
+  {% if not error %}
+  <a href="/search?q={{ request.path[1:] }}"
+    class="btn btn-primary">Search for "{{ request.path[1:] }}"</a>
+  {% else %}
+    <p>{{error}}</p>
+  {% endif %}
+</div>
+
+{% endblock %}

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -7,6 +7,7 @@ from flask import (Blueprint, current_app, jsonify, redirect,
                    render_template as render_template_base,
                    request, Response, url_for)
 from jinja2 import TemplateNotFound
+from werkzeug.exceptions import ServiceUnavailable
 from werkzeug.routing import BaseConverter
 
 from ..api import (entity_to_classes, entity_to_name, entity_to_smiles, search,
@@ -437,6 +438,19 @@ def inject_js_config():
     return dict(js_config=get_js_config())
 
 
+@main.errorhandler(ServiceUnavailable)
+def handle_service_unavailable(error):
+    """Serve error page for 503.
+
+    Returns
+    -------
+    html : str
+        Rederende HTML for index page.
+
+    """
+    return render_template("503.html", error=error), 503
+
+
 @main.route("/")
 def index():
     """Return rendered index page.
@@ -528,7 +542,7 @@ def redirect_q(q):
     """
     try:
         # Use the API to get entity information
-        entities = wb_get_entities([q])
+        entities = wb_get_entities([q], max_retries=0, timeout=2.0)
 
         # Extract 'instance of' information
         classes = entity_to_classes(entities[q])
@@ -809,7 +823,10 @@ def show_author(q):
     ep = config['query-server'].get('sparql_endpoint')
     editurl = config['query-server'].get('sparql_editurl')
     embedurl = config['query-server'].get('sparql_embedurl')
-    entities = wb_get_entities([q])
+    try:
+        entities = wb_get_entities([q])
+    except Exception as e:
+        raise ServiceUnavailable("Could not retrieve entity data") from e
     name = entity_to_name(entities[q])
     if name:
         first_initial, last_name = name[0], name.split()[-1]


### PR DESCRIPTION
Number of retries have been set to zero and the time out has been lowered for getting the the entity data from Wikidata.

For the author aspect an error handler has been added to the entity data requests. For other aspects there might be uncaught exceptions from the entity data download.

The Wikidata Query Service as in the meantime become responsive again so it has not been possible to test the error response

Fixes #2786

### Description
> Please include a summary of the change, relevant motivation and context. If possible and applicable, include before and after screenshots and a URL where the changes can be seen.
    
### Caveats

> Please list anything which has been left out of this PR or which should be considered before this PR is accepted
Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

*If you make changes to the Python code*
  
* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
Please describe the [tests](https://numpy.org/doc/stable/reference/testing.html) that you ran to verify your changes. Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

No test. 

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
