### PR TITLE
Use shared requests.Session for connection pooling

### DIFF
--- a/scholia/api.py
+++ b/scholia/api.py
@@ -29,6 +29,7 @@ import time
 from typing import Optional
 
 import requests
+from requests.adapters import HTTPAdapter
 
 from .config import config
 
@@ -36,6 +37,15 @@ from .config import config
 USER_AGENT = config['requests'].get('user_agent')
 
 HEADERS = {'User-Agent': USER_AGENT}
+
+# Shared session for connection pooling.
+# Without this, every requests.get() opens a new TCP/SSL connection,
+# which exhausts file descriptors under load (OSError: [Errno 24]).
+_shared_session = requests.Session()
+_shared_session.headers.update(HEADERS)
+_adapter = HTTPAdapter(pool_connections=10, pool_maxsize=20)
+_shared_session.mount('https://', _adapter)
+_shared_session.mount('http://', _adapter)
 
 # Must be indexed from zero
 MONTH_NUMBER_TO_MONTH = {
@@ -199,7 +209,7 @@ def wb_get_entities(
     next_allowed_time = 0.0
 
     # Create/choose a session
-    sess = session or requests.Session()
+    sess = session or _shared_session
 
     def _sleep_until_allowed():
         nonlocal next_allowed_time
@@ -698,10 +708,10 @@ def search(query, page=0, limit=10):
     }
 
     # Query the Wikidata API
-    response = requests.get(
+    response = _shared_session.get(
         "https://www.wikidata.org/w/api.php",
         params=params,
-        headers=HEADERS)
+        timeout=10)
 
     # Convert the response
     response_data = response.json()

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -2268,7 +2268,13 @@ def show_search():
     prev_page = -1
 
     if query:
-        data = search(query, page)
+        try:
+            data = search(query, page)
+        except Exception:
+            raise ServiceUnavailable(
+                "Could not reach the Wikidata search API. "
+                "Please try again later."
+            )
         search_results = data["results"]
         next_page = data.get("next_page", -1)
         prev_page = data.get("prev_page", -1)


### PR DESCRIPTION
## Summary

Use a shared `requests.Session` with connection pooling to prevent file descriptor exhaustion (`OSError: [Errno 24] Too many open files`) that causes SSL errors and "no healthy upstream" failures under load.

Builds on #2787 which addressed timeouts and added a 503 error page for the author view. This PR targets the underlying cause: every `requests.get()` call opens a new TCP/SSL connection instead of reusing them.

Fixes #2785

## Changes

### `scholia/api.py`
- Add a module-level `_shared_session` backed by `HTTPAdapter(pool_connections=10, pool_maxsize=20)` for connection reuse
- `search()`: Replace bare `requests.get()` with `_shared_session.get()` and add a timeout
- `wb_get_entities()`: Default to `_shared_session` when no explicit session is provided (previously created a new `requests.Session()` per call)

### `scholia/app/views.py`
- `show_search()`: Wrap the `search()` call in `try/except` to raise `ServiceUnavailable` with a user-friendly message, leveraging the 503 error handler from #2787

## Why this matters

The traceback in #2785 shows `requests.get()` at `api.py:561` (now line 701) hitting `OSError: [Errno 24] Too many open files`. Each bare `requests.get()` creates a throwaway `Session` → new TCP socket → new SSL handshake. Under 588K requests/day, these pile up faster than the OS can reclaim them. A shared session pools and reuses connections via urllib3, keeping file descriptor usage bounded.

## Testing

- Verified the module imports and session initializes correctly
- No new dependencies (uses `requests.adapters.HTTPAdapter` already bundled with `requests`)
