### PR TITLE
Set pool_block=True to enforce connection limit

### DIFF
--- a/scholia/api.py
+++ b/scholia/api.py
@@ -43,7 +43,7 @@ HEADERS = {'User-Agent': USER_AGENT}
 # which exhausts file descriptors under load (OSError: [Errno 24]).
 _shared_session = requests.Session()
 _shared_session.headers.update(HEADERS)
-_adapter = HTTPAdapter(pool_connections=10, pool_maxsize=20)
+_adapter = HTTPAdapter(pool_connections=10, pool_maxsize=20, pool_block=True)
 _shared_session.mount('https://', _adapter)
 _shared_session.mount('http://', _adapter)
 


### PR DESCRIPTION
## Summary

Follow-up to #2788 as suggested by @fnielsen: add `pool_block=True` to the `HTTPAdapter` so that when all pooled connections are in use, new requests wait for a free slot instead of creating overflow connections beyond `pool_maxsize`.

Ref: #2785
