### PR TITLE
Sync tox.ini with CI matrix and consolidate test envs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,54 +1,16 @@
 [tox]
-envlist = flake8, pydocstyle, py39, py310
+envlist = flake8, pydocstyle, py310, py311, py312, py313
 
 
 [gh-actions]
-python = 
-  3.9: py39
+python =
   3.10: py310
+  3.11: py311
+  3.12: py312
+  3.13: py313
 
 
-[testenv:py27]
-commands = 
-    python -m pytest --doctest-modules scholia
-    python -m pytest tests
-deps=
-    pytest
-    -rrequirements.txt
-
-[testenv:py35]
-commands = 
-    python -m pytest --doctest-modules scholia
-    python -m pytest tests
-deps=
-    pytest
-    -rrequirements.txt
-
-[testenv:py37]
-commands = 
-    python -m pytest --doctest-modules scholia
-    python -m pytest tests
-deps=
-    pytest
-    -rrequirements.txt
-
-[testenv:py38]
-commands = 
-    python -m pytest --doctest-modules scholia
-    python -m pytest tests
-deps=
-    pytest
-    -rrequirements.txt
-
-[testenv:py39]
-commands = 
-    python -m pytest --doctest-modules scholia
-    python -m pytest tests
-deps=
-    pytest
-    -rrequirements.txt
-
-[testenv:py310]
+[testenv]
 commands =
     python -m pytest --doctest-modules scholia
     python -m pytest tests
@@ -59,13 +21,13 @@ deps=
 
 [testenv:flake8]
 commands = flake8 scholia
-deps = 
+deps =
     flake8
     flake8-docstrings
 
 [testenv:pydocstyle]
 commands = pydocstyle --convention=numpy scholia
-deps = 
+deps =
     pydocstyle
 
 [testenv:docs]


### PR DESCRIPTION
## Summary

The `[gh-actions]` mapping in `tox.ini` was out of sync with the Python matrix in `main.yml` since e276f2d1 (Feb 2026). Only Python 3.10 had a valid mapping; **3.11, 3.12, and 3.13 were silently skipped** by `tox-gh-actions` — no tests ran, but CI reported green.

## Root cause

`main.yml` matrix was updated from `["3.9", "3.10"]` → `["3.10", "3.11", "3.12", "3.13"]` but `tox.ini` was not updated to match.

## Changes

- Add 3.11, 3.12, 3.13 to `[gh-actions]` mapping and `envlist`
- Replace six identical per-version `[testenv:pyXX]` sections with a single `[testenv]` base
- Remove dead py27, py35, py37, py38 sections

Fixes #2790, fixes #2791
