### PR TITLE
Make chromosomes optional

### DIFF
--- a/scholia/app/templates/taxon_genome.sparql
+++ b/scholia/app/templates/taxon_genome.sparql
@@ -7,8 +7,12 @@ PREFIX wdt: <http://www.wikidata.org/prop/direct/>
 PREFIX wikibase: <http://wikiba.se/ontology#>
 SELECT ?gene ?geneLabel ?geneDescription ?chromosome ?chromosomeLabel ?chromosomeDescription {
   ?gene wdt:P31 wd:Q7187 ;
-        wdt:P703 target: ;
-        wdt:P1057 ?chromosome .
-  {{ sparql_helpers.labels(["?gene", "?chromosome"], languages) }}
-  {{ sparql_helpers.descriptions(["?gene", "?chromosome"], languages) }}
+        wdt:P703 target: .
+ OPTIONAL {
+    ?gene wdt:P1057 ?chromosome .
+    {{ sparql_helpers.labels(["?chromosome"], languages) }}
+    {{ sparql_helpers.descriptions(["?chromosome"], languages) }}
+  }
+  {{ sparql_helpers.labels(["?gene"], languages) }}
+  {{ sparql_helpers.descriptions(["?gene"], languages) }}
 }


### PR DESCRIPTION
Fixes #2796

### Description
The previous query requires genes to be always linked to chromosomes, but SARS-CoV-2 does not have a chromosome.
    
### Caveats

Check any of the following which apply:

* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
    * [ ]  I have made corresponding changes to the documentation
* [ ]  This change requires new dependencies (please list)

### Testing
Provide instructions, so we can reproduce. Please also list any relevant details for your test configuration.

* Test if genes show up in the `Genome` panel at https://qlever.scholia.wiki/taxon/Q82069695#genome

### Checklist
* [ ] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [ ] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
